### PR TITLE
feat(graph): assign atomic integer ID to each node

### DIFF
--- a/dt_model/engine/atomic/__init__.py
+++ b/dt_model/engine/atomic/__init__.py
@@ -1,0 +1,50 @@
+"""
+Atomic Operations
+=================
+
+This module provides thread-safe atomic operations for integer values.
+It implements an atomic integer counter class similar to Go's atomic.Int64.
+"""
+
+import threading
+
+
+class Int:
+    """
+    A thread-safe integer class supporting atomic operations.
+
+    This class provides atomic operations on integer values by using
+    a lock to ensure thread-safety. It allows incrementing, adding,
+    and reading values without race conditions in multithreaded environments.
+    """
+
+    def __init__(self):
+        """
+        Initialize an atomic integer with a value of 0.
+        """
+        self.__value = 0
+        self.__lock = threading.Lock()
+
+    def add(self, value: int) -> int:
+        """
+        Atomically add a value to the current value.
+
+        Args:
+            value (int): The value to add.
+
+        Returns:
+            int: The new value after addition.
+        """
+        with self.__lock:
+            self.__value += value
+            return self.__value
+
+    def load(self) -> int:
+        """
+        Atomically load and return the current value.
+
+        Returns:
+            int: The current value.
+        """
+        with self.__lock:
+            return self.__value

--- a/dt_model/engine/frontend/graph.py
+++ b/dt_model/engine/frontend/graph.py
@@ -89,6 +89,8 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from .. import atomic
+
 
 Axis = int | tuple[int, ...]
 """Type alias for axis specifications in shape operations."""
@@ -102,6 +104,10 @@ NODE_FLAG_TRACE = 1 << 0
 
 NODE_FLAG_BREAK = 1 << 1
 """Inserts a breakpoint at the corresponding graph node."""
+
+
+_id_generator = atomic.Int()
+"""Atomic integer generator for unique node IDs."""
 
 
 class Node:
@@ -125,6 +131,7 @@ class Node:
     def __init__(self, name: str = "") -> None:
         self.name = name
         self.flags = 0
+        self.id = _id_generator.add(1)
 
     def __hash__(self) -> int:
         # Note: introducing hashing by identity in the class inheritance

--- a/tests/engine/atomic/test_int.py
+++ b/tests/engine/atomic/test_int.py
@@ -1,4 +1,4 @@
-"""Tests for the dt_model.atomic.Int type."""
+"""Tests for the dt_model.engine.atomic.Int type."""
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/engine/atomic/test_int.py
+++ b/tests/engine/atomic/test_int.py
@@ -1,0 +1,48 @@
+"""Tests for the dt_model.atomic.Int type."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+import pytest
+
+from dt_model.engine.atomic import Int
+
+
+def test_atomic_int_basic():
+    """Test basic operations of atomic Int."""
+    counter = Int()
+    assert counter.load() == 0  # Initial value
+
+    # Test add operation
+    assert counter.add(1) == 1  # Returns new value
+    assert counter.load() == 1  # Verify current value
+
+    # Test larger increments
+    assert counter.add(10) == 11
+    assert counter.load() == 11
+
+
+def test_atomic_int_thread_safety():
+    """Test thread safety of atomic Int."""
+    counter = Int()
+    iterations = 1000
+    threads = 10
+
+    def increment_counter():
+        for _ in range(iterations):
+            counter.add(1)
+
+    # Create and start threads
+    thread_list = []
+    for _ in range(threads):
+        thread = threading.Thread(target=increment_counter)
+        thread_list.append(thread)
+        thread.start()
+
+    # Wait for all threads to complete
+    for thread in thread_list:
+        thread.join()
+
+    # Check final counter value
+    # If counter is thread-safe, value should be threads * iterations
+    assert counter.load() == threads * iterations

--- a/tests/engine/frontend/test_graph.py
+++ b/tests/engine/frontend/test_graph.py
@@ -1,8 +1,9 @@
-"""Tests for the dt_model.engine.frontend.graph module."""
+"""Tests for the dt_model.frontend.graph module."""
 
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+
 from dt_model.engine.frontend import graph
 
 
@@ -167,3 +168,50 @@ def test_where_operation():
     assert result.condition is condition
     assert result.then is then
     assert result.otherwise is otherwise
+
+
+def test_node_id_generation():
+    """Test that nodes receive unique, incrementing IDs."""
+    # Create multiple nodes of different types
+    nodes = [
+        graph.Node(),
+        graph.constant(1.0),
+        graph.placeholder("x"),
+        graph.Node(),
+    ]
+
+    # Check that IDs exist and are unique
+    ids = [node.id for node in nodes]
+    assert len(set(ids)) == len(ids)  # All IDs should be unique
+
+    # Verify IDs are increasing
+    for i in range(1, len(ids)):
+        assert ids[i] > ids[i - 1]
+
+
+def test_node_id_persistence():
+    """Test that node IDs remain stable across operations."""
+    a = graph.placeholder("a")
+    id_a = a.id
+
+    # Perform operations that use the node
+    traced_a = graph.tracepoint(a)
+
+    # Verify node identity is preserved and ID remains the same
+    assert traced_a is a
+    assert traced_a.id == id_a
+
+
+def test_binary_op_node_ids():
+    """Test that binary operation nodes get unique IDs."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+
+    op1 = graph.add(a, b)
+    op2 = graph.subtract(a, b)
+
+    assert hasattr(op1, "id")
+    assert hasattr(op2, "id")
+    assert op1.id != op2.id
+    assert op1.id != a.id
+    assert op1.id != b.id

--- a/tests/engine/frontend/test_graph.py
+++ b/tests/engine/frontend/test_graph.py
@@ -1,4 +1,4 @@
-"""Tests for the dt_model.frontend.graph module."""
+"""Tests for the dt_model.engine.frontend.graph module."""
 
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
This diff extends the graph representation to assign an atomic integer ID to each node. In the tn-aixpa/overtourism demo we are using UUID4 in a similar fashion, however, using incremental atomic integers has more advantages, including that it allows us to sort nodes by their order of insertion. In turn, this sortability property allows us to flatten the graph tree to the insertion order easily. And, by doing this, we are able to evaluate the graph in its natural order without keeping track of the correct evaluation order on the side. Note that we are using an atomic integer here instead of using just an integer because Streamlit uses multiple threads. Also, note that we are targeting Python 3.11, while subsequent versions seem to have better support for atomic integers. We'll update our code when we'll get there.