### PR TITLE
fix(tests): add __init__.py to each directory

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the dt_model package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/engine/__init__.py
+++ b/tests/engine/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the dt_model.engine package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/engine/atomic/__init__.py
+++ b/tests/engine/atomic/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the dt_model.engine.atomic package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/engine/frontend/__init__.py
+++ b/tests/engine/frontend/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the dt_model.engine.frontend package."""
+
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
I originally thought this was not needed with `pytest` because of its auto-discover feature. However, it seems not having an `__init__.py` prevents us from having equally named test files in different directories. Conversely, with an `__init__.py`, each testing module lives in a package, thus equally named files are not a problem anymore.