### PR TITLE
chore(ci): typecheck each run using pyright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,14 @@ jobs:
         run: uv sync --python ${{ matrix.python_version }} --dev
 
       # TODO(bassosimone): we're not ready for enforcing formatting yet
-      - name: Check formatting with black
+      - name: Check formatting with ruff
         if: matrix['python_version'] == '3.11'
-        run: uv run --python ${{ matrix.python_version }} black --check . || true
+        run: uv run --python ${{ matrix.python_version }} ruff format --check . || true
+
+      # TODO(bassosimone): we're not ready for enforcing linting yet
+      - name: Lint with ruff
+        if: matrix['python_version'] == '3.11'
+        run: uv run --python ${{ matrix.python_version }} ruff check . || true
 
       # TODO(bassosimone): we're not ready for enforcing type checking yet
       - name: Check types with pyright

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,9 @@ jobs:
         if: matrix['python_version'] == '3.11'
         run: uv run --python ${{ matrix.python_version }} ruff format --check .
 
-      # TODO(bassosimone): we're not ready for enforcing linting yet
       - name: Lint with ruff
         if: matrix['python_version'] == '3.11'
-        run: uv run --python ${{ matrix.python_version }} ruff check . || true
+        run: uv run --python ${{ matrix.python_version }} ruff check .
 
       # TODO(bassosimone): we're not ready for enforcing type checking yet
       - name: Check types with pyright

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,9 @@ jobs:
         if: matrix['python_version'] == '3.11'
         run: uv run --python ${{ matrix.python_version }} ruff check .
 
-      # TODO(bassosimone): we're not ready for enforcing type checking yet
       - name: Check types with pyright
         if: matrix['python_version'] == '3.11'
-        run: uv run --python ${{ matrix.python_version }} pyright || true
+        run: uv run --python ${{ matrix.python_version }} pyright
 
       - name: Run tests with pytest
         run: uv run --python ${{ matrix.python_version }} pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --python ${{ matrix.python_version }} --dev
 
-      # TODO(bassosimone): we're not ready for enforcing formatting yet
       - name: Check formatting with ruff
         if: matrix['python_version'] == '3.11'
-        run: uv run --python ${{ matrix.python_version }} ruff format --check . || true
+        run: uv run --python ${{ matrix.python_version }} ruff format --check .
 
       # TODO(bassosimone): we're not ready for enforcing linting yet
       - name: Lint with ruff

--- a/dt_model/__init__.py
+++ b/dt_model/__init__.py
@@ -2,10 +2,27 @@ from dt_model.ensemble.ensemble import Ensemble
 from dt_model.model.model import Model
 from dt_model.symbols.constraint import Constraint
 from dt_model.symbols.context_variable import (
-    ContextVariable,
-    UniformCategoricalContextVariable,
     CategoricalContextVariable,
+    ContextVariable,
     ContinuousContextVariable,
+    UniformCategoricalContextVariable,
 )
-from dt_model.symbols.index import Index, ConstIndex, SymIndex, UniformDistIndex, LognormDistIndex, TriangDistIndex
+from dt_model.symbols.index import ConstIndex, Index, LognormDistIndex, SymIndex, TriangDistIndex, UniformDistIndex
 from dt_model.symbols.presence_variable import PresenceVariable
+
+__all__ = [
+    "Ensemble",
+    "Model",
+    "Constraint",
+    "ContextVariable",
+    "CategoricalContextVariable",
+    "ContinuousContextVariable",
+    "UniformCategoricalContextVariable",
+    "ConstIndex",
+    "Index",
+    "LognormDistIndex",
+    "SymIndex",
+    "TriangDistIndex",
+    "UniformDistIndex",
+    "PresenceVariable",
+]

--- a/dt_model/__init__.py
+++ b/dt_model/__init__.py
@@ -1,7 +1,11 @@
 from dt_model.ensemble.ensemble import Ensemble
 from dt_model.model.model import Model
 from dt_model.symbols.constraint import Constraint
-from dt_model.symbols.context_variable import (ContextVariable, UniformCategoricalContextVariable,
-                                               CategoricalContextVariable, ContinuousContextVariable)
+from dt_model.symbols.context_variable import (
+    ContextVariable,
+    UniformCategoricalContextVariable,
+    CategoricalContextVariable,
+    ContinuousContextVariable,
+)
 from dt_model.symbols.index import Index, ConstIndex, SymIndex, UniformDistIndex, LognormDistIndex, TriangDistIndex
 from dt_model.symbols.presence_variable import PresenceVariable

--- a/dt_model/engine/frontend/graph.py
+++ b/dt_model/engine/frontend/graph.py
@@ -116,7 +116,6 @@ from typing import Sequence
 
 from .. import atomic
 
-
 Axis = int | tuple[int, ...]
 """Type alias for axis specifications in shape operations."""
 

--- a/dt_model/engine/frontend/graph.py
+++ b/dt_model/engine/frontend/graph.py
@@ -403,9 +403,7 @@ class multi_clause_where(Node):
         default_value: Value to use when no condition is met
     """
 
-    def __init__(
-        self, clauses: Sequence[tuple[Node, Node]], default_value: Node
-    ) -> None:
+    def __init__(self, clauses: Sequence[tuple[Node, Node]], default_value: Node) -> None:
         super().__init__()
         self.clauses = clauses
         self.default_value = default_value

--- a/dt_model/engine/numpybackend/executor.py
+++ b/dt_model/engine/numpybackend/executor.py
@@ -85,9 +85,7 @@ class State:
         try:
             return self.values[node]
         except KeyError:
-            raise NodeValueNotFound(
-                f"executor: node '{node.name}' has not been evaluated"
-            )
+            raise NodeValueNotFound(f"executor: node '{node.name}' has not been evaluated")
 
 
 def evaluate(state: State, node: graph.Node) -> np.ndarray:
@@ -164,9 +162,7 @@ def _eval_binary_op(state: State, node: graph.Node) -> np.ndarray:
     try:
         return dispatch.binary_operations[type(node)](left, right)
     except KeyError:
-        raise UnsupportedOperation(
-            f"executor: unsupported binary operation: {type(node)}"
-        )
+        raise UnsupportedOperation(f"executor: unsupported binary operation: {type(node)}")
 
 
 def _eval_unary_op(state: State, node: graph.Node) -> np.ndarray:
@@ -175,9 +171,7 @@ def _eval_unary_op(state: State, node: graph.Node) -> np.ndarray:
     try:
         return dispatch.unary_operations[type(node)](operand)
     except KeyError:
-        raise UnsupportedOperation(
-            f"executor: unsupported unary operation: {type(node)}"
-        )
+        raise UnsupportedOperation(f"executor: unsupported unary operation: {type(node)}")
 
 
 def _eval_where_op(state: State, node: graph.Node) -> np.ndarray:
@@ -206,9 +200,7 @@ def _eval_axis_op(state: State, node: graph.Node) -> np.ndarray:
     try:
         return dispatch.axes_operations[type(node)](operand, node.axis)
     except KeyError:
-        raise UnsupportedOperation(
-            f"executor: unsupported axis operation: {type(node)}"
-        )
+        raise UnsupportedOperation(f"executor: unsupported axis operation: {type(node)}")
 
 
 _EvaluatorFunc = Callable[[State, graph.Node], np.ndarray]
@@ -225,7 +217,6 @@ _evaluators: tuple[tuple[type[graph.Node], _EvaluatorFunc], ...] = (
 
 
 def _evaluate(state: State, node: graph.Node) -> np.ndarray:
-
     # Attempt to match with every possible evaluator
     for node_type, evaluator in _evaluators:
         if isinstance(node, node_type):

--- a/dt_model/ensemble/ensemble.py
+++ b/dt_model/ensemble/ensemble.py
@@ -32,8 +32,9 @@ class Ensemble:
             self.pos[k] += 1
             if self.pos[k] < len(self.ensemble[k]):
                 cv_values = {k: self.ensemble[k][self.pos[k]][1] for k in self.ensemble.keys()}
-                cv_probability = reduce(lambda x, y: x*y,
-                                        [self.ensemble[k][self.pos[k]][0] for k in self.ensemble.keys()])
+                cv_probability = reduce(
+                    lambda x, y: x * y, [self.ensemble[k][self.pos[k]][0] for k in self.ensemble.keys()]
+                )
                 return cv_probability, cv_values
             self.pos[k] = 0
         raise StopIteration

--- a/dt_model/internal/__init__.py
+++ b/dt_model/internal/__init__.py
@@ -1,0 +1,9 @@
+"""
+Internal Packages
+=================
+
+This package groups together internal packages. The semantics of internal
+packages is that there is no API stability guarantee.
+"""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/dt_model/internal/sympyke/__init__.py
+++ b/dt_model/internal/sympyke/__init__.py
@@ -1,0 +1,16 @@
+"""
+SymPy compatibility layer
+=========================
+
+This package implements a tiny SymPy compatibility layer that maps
+sympy-like methods and functions to frontend.graph operations.
+
+This package is *internal*. Feel free to use it in your code but know that
+there are no API stability guarantees whatsoever.
+"""
+
+from .operators import Eq
+from .piecewise import Piecewise
+from .symbol import Symbol
+
+__all__ = ["Eq", "Piecewise", "Symbol"]

--- a/dt_model/internal/sympyke/operators.py
+++ b/dt_model/internal/sympyke/operators.py
@@ -1,0 +1,20 @@
+"""Sympy-like operators for creating symbolic expressions."""
+
+from ...engine.frontend import graph
+from .symbol import SymbolValue
+
+
+def _ensure_node(value: graph.Node | SymbolValue | graph.Scalar) -> graph.Node:
+    if isinstance(value, graph.Node):
+        return value
+    if isinstance(value, SymbolValue):
+        return value.node
+    return graph.constant(value)
+
+
+def Eq(
+    lhs: graph.Node | SymbolValue | graph.Scalar,
+    rhs: graph.Node | SymbolValue | graph.Scalar,
+) -> graph.Node:
+    """Create an equality expression between nodes and/or symbols."""
+    return graph.equal(_ensure_node(lhs), _ensure_node(rhs))

--- a/dt_model/internal/sympyke/piecewise.py
+++ b/dt_model/internal/sympyke/piecewise.py
@@ -8,7 +8,6 @@ a Piecewise invocation to a graph.multi_clause_where tensor in the XYZ space.
 
 from ...engine.frontend import graph
 
-
 Cond = graph.Node | graph.Scalar
 """Condition for a piecewise clause."""
 

--- a/dt_model/internal/sympyke/piecewise.py
+++ b/dt_model/internal/sympyke/piecewise.py
@@ -1,0 +1,84 @@
+"""
+Piecewise Emulation
+===================
+
+This module emulates sympy.Piecewise using the tensor language frontend, by mapping
+a Piecewise invocation to a graph.multi_clause_where tensor in the XYZ space.
+"""
+
+from ...engine.frontend import graph
+
+
+Cond = graph.Node | graph.Scalar
+"""Condition for a piecewise clause."""
+
+Expr = graph.Node | graph.Scalar
+"""Expression for a piecewise clause."""
+
+Clause = tuple[Expr, Cond]
+"""Clause provided to piecewise."""
+
+
+def Piecewise(*clauses: Clause) -> graph.Node:
+    """Converts the provided clauses arranged according to the sympy.Piecewise
+    convention into a graph.multi_clause_where computation tensor in XYZ.
+
+    Args:
+        *clauses: The clauses to be converted.
+
+    Returns:
+        The computation tensor representing the piecewise function.
+
+    Raises:
+        ValueError: If no clauses are provided.
+    """
+    return _to_tensor(_filter_clauses(clauses))
+
+
+def _filter_clauses(clauses: tuple[Clause, ...]) -> list[Clause]:
+    """This function removes the clauses after the first true clause, to
+    correctly emulate the sumpy.Piecewise behaviour.
+
+    Args:
+        clauses: The clauses to be filtered.
+
+    Returns:
+        The filtered clauses.
+    """
+    filtered: list[Clause] = []
+    for expr, cond in clauses:
+        filtered.append((expr, cond))
+        if cond is True:
+            break
+    return filtered
+
+
+def _to_tensor(clauses: list[Clause]) -> graph.Node:
+    # 1. Bail if there are no remaining clauses
+    if len(clauses) < 1:
+        raise ValueError("piecewise: at least one clause is required")
+
+    # 2. Check whether there is a default case and otherwise use NaN
+    default_value: Expr = float("NaN")
+    last_clause = clauses[-1]
+    if last_clause[1] is True:
+        default_value = last_clause[0]
+        clauses = clauses[:-1]
+    if isinstance(default_value, graph.Scalar):
+        default_value = graph.constant(default_value)
+
+    # 3. If no clauses remain after removing the default, just return the default value
+    if len(clauses) <= 0:
+        return default_value
+
+    # 4. Prepare the reversed clauses adapting the types
+    reversed: list[tuple[graph.Node, graph.Node]] = []
+    for expr, cond in clauses:
+        if isinstance(expr, graph.Scalar):
+            expr = graph.constant(expr)
+        if isinstance(cond, graph.Scalar):
+            cond = graph.constant(cond)
+        reversed.append((cond, expr))
+
+    # 5. We're now all set call multi_clause_where
+    return graph.multi_clause_where(reversed, default_value)

--- a/dt_model/internal/sympyke/symbol.py
+++ b/dt_model/internal/sympyke/symbol.py
@@ -1,0 +1,50 @@
+"""
+Minimal support for symbols
+===========================
+
+This module implements minimal support for sympy-like symbols
+so that we can write dt_model models.
+"""
+
+from dataclasses import dataclass
+
+import threading
+
+from ...engine.frontend import graph
+
+
+@dataclass(frozen=True)
+class SymbolValue:
+    """Contains the symbol graph node and the symbol name."""
+
+    node: graph.placeholder
+    name: str
+
+
+class _SymbolTable:
+    def __init__(self):
+        self._table: dict[str, SymbolValue] = {}
+        self._lock = threading.Lock()
+
+    def get(self, name: str):
+        with self._lock:
+            if name not in self._table:
+                self._table[name] = SymbolValue(graph.placeholder(name), name)
+            return self._table[name]
+
+    def values(self) -> list[SymbolValue]:
+        with self._lock:
+            values = list(self._table.values())
+        return values
+
+
+symbol_table = _SymbolTable()
+"""Table containing all the defined symbols."""
+
+
+def Symbol(name: str) -> SymbolValue:
+    """Constructor to create a new SymbolValue by name.
+
+    Subsequent invocations with the same name return the same SymbolValue.
+    """
+    return symbol_table.get(name)

--- a/dt_model/internal/sympyke/symbol.py
+++ b/dt_model/internal/sympyke/symbol.py
@@ -6,9 +6,8 @@ This module implements minimal support for sympy-like symbols
 so that we can write dt_model models.
 """
 
-from dataclasses import dataclass
-
 import threading
+from dataclasses import dataclass
 
 from ...engine.frontend import graph
 

--- a/dt_model/model/model.py
+++ b/dt_model/model/model.py
@@ -17,13 +17,13 @@ from dt_model.symbols.presence_variable import PresenceVariable
 
 class Model:
     def __init__(
-            self,
-            name,
-            cvs: list[ContextVariable],
-            pvs: list[PresenceVariable],
-            indexes: list[Index],
-            capacities: list[Index],
-            constraints: list[Constraint],
+        self,
+        name,
+        cvs: list[ContextVariable],
+        pvs: list[PresenceVariable],
+        indexes: list[Index],
+        capacities: list[Index],
+        constraints: list[Constraint],
     ) -> None:
         self.name = name
         self.cvs = cvs
@@ -93,8 +93,9 @@ class Model:
         grid = self.grid
         field = self.field
 
-        return field.sum() * reduce(lambda x, y: x * y,
-                                    [axis.max() / (axis.size - 1) + 1 for axis in list(grid.values())])
+        return field.sum() * reduce(
+            lambda x, y: x * y, [axis.max() / (axis.size - 1) + 1 for axis in list(grid.values())]
+        )
 
     # TODO: change API - order of presence variables
     def compute_sustainability_index(self, presences: list) -> float:
@@ -102,8 +103,7 @@ class Model:
         grid = self.grid
         field = self.field
         # TODO: fill value
-        index = interpolate.interpn(grid.values(), field, np.array(presences),
-                                    bounds_error=False, fill_value=0.0)
+        index = interpolate.interpn(grid.values(), field, np.array(presences), bounds_error=False, fill_value=0.0)
         return np.mean(index)
 
     def compute_sustainability_index_per_constraint(self, presences: list) -> dict:
@@ -113,8 +113,9 @@ class Model:
         # TODO: fill value
         indexes = {}
         for c in self.constraints:
-            index = interpolate.interpn(grid.values(), field_elements[c], np.array(presences),
-                                        bounds_error=False, fill_value=0.0)
+            index = interpolate.interpn(
+                grid.values(), field_elements[c], np.array(presences), bounds_error=False, fill_value=0.0
+            )
             indexes[c] = np.mean(index)
         return indexes
 
@@ -125,8 +126,12 @@ class Model:
         modal_lines = {}
         for c in self.constraints:
             fe = field_elements[c]
-            matrix = (fe <= 0.5) & ((ndimage.shift(fe, (0, 1)) > 0.5) | (ndimage.shift(fe, (0, -1)) > 0.5) |
-                                    (ndimage.shift(fe, (1, 0)) > 0.5) | (ndimage.shift(fe, (-1, 0)) > 0.5))
+            matrix = (fe <= 0.5) & (
+                (ndimage.shift(fe, (0, 1)) > 0.5)
+                | (ndimage.shift(fe, (0, -1)) > 0.5)
+                | (ndimage.shift(fe, (1, 0)) > 0.5)
+                | (ndimage.shift(fe, (-1, 0)) > 0.5)
+            )
             (yi, xi) = np.nonzero(matrix)
 
             # TODO: decide whether two regressions are really necessary
@@ -200,8 +205,12 @@ class Model:
                     new_capacities.append(capacity)
         new_constraints = []
         for constraint in self.constraints:
-            new_constraints.append(Constraint(constraint.usage.subs(change_indexes),
-                                              constraint.capacity.subs(change_capacities),
-                                              group=constraint.group, name=constraint.name,
-                                              ))
+            new_constraints.append(
+                Constraint(
+                    constraint.usage.subs(change_indexes),
+                    constraint.capacity.subs(change_capacities),
+                    group=constraint.group,
+                    name=constraint.name,
+                )
+            )
         return Model(new_name, self.cvs, self.pvs, new_indexes, new_capacities, new_constraints)

--- a/dt_model/model/model.py
+++ b/dt_model/model/model.py
@@ -89,6 +89,7 @@ class Model:
 
     def compute_sustainable_area(self) -> float:
         assert self.grid is not None
+        assert self.field is not None
         grid = self.grid
         field = self.field
 
@@ -107,6 +108,7 @@ class Model:
 
     def compute_sustainability_index_per_constraint(self, presences: list) -> dict:
         assert self.grid is not None
+        assert self.field_elements is not None
         grid = self.grid
         field_elements = self.field_elements
         # TODO: fill value
@@ -120,6 +122,7 @@ class Model:
 
     def compute_modal_line_per_constraint(self) -> dict:
         assert self.grid is not None
+        assert self.field_elements is not None
         grid = self.grid
         field_elements = self.field_elements
         modal_lines = {}
@@ -150,14 +153,14 @@ class Model:
             # TODO(pistore,bassosimone): even before we implement the
             # previous TODO, avoid hardcoding of line length (10000)
 
-            def __vertical(regr) -> tuple[tuple[float, float], tuple[float, float]]:
+            def _vertical(regr) -> tuple[tuple[float, float], tuple[float, float]]:
                 """Logic for computing the points with vertical regression"""
                 if regr.slope != 0.00:
                     return ((regr.intercept, 0.0), (0.0, -regr.intercept / regr.slope))
                 else:
                     return ((regr.intercept, regr.intercept), (0.0, 10000.0))
 
-            def __horizontal(regr) -> tuple[tuple[float, float], tuple[float, float]]:
+            def _horizontal(regr) -> tuple[tuple[float, float], tuple[float, float]]:
                 """Logic for computing the points with horizontal regression"""
                 if regr.slope != 0.0:
                     return ((0.0, -regr.intercept / regr.slope), (regr.intercept, 0.0))
@@ -167,15 +170,15 @@ class Model:
             if horizontal_regr and vertical_regr:
                 # Use regression with better fit (higher rvalue)
                 if horizontal_regr.rvalue < vertical_regr.rvalue:
-                    modal_lines[c] = __vertical(vertical_regr)
+                    modal_lines[c] = _vertical(vertical_regr)
                 else:
-                    modal_lines[c] = __horizontal(horizontal_regr)
+                    modal_lines[c] = _horizontal(horizontal_regr)
 
             elif horizontal_regr:
-                modal_lines[c] = __horizontal(horizontal_regr)
+                modal_lines[c] = _horizontal(horizontal_regr)
 
             elif vertical_regr:
-                modal_lines[c] = __vertical(vertical_regr)
+                modal_lines[c] = _vertical(vertical_regr)
 
             else:
                 pass  # No regression is possible (eg median not intersecting the grid)

--- a/dt_model/model/model.py
+++ b/dt_model/model/model.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import numbers
-
 from functools import reduce
 
 import numpy as np
 import pandas as pd
-from sympy import lambdify
 from scipy import interpolate, ndimage, stats
+from sympy import lambdify
 
 from dt_model.symbols.constraint import Constraint
 from dt_model.symbols.context_variable import ContextVariable
@@ -146,8 +145,10 @@ class Model:
             except ValueError:
                 pass
 
-            # TODO(pistore,bassosimone): find a better way to represent the lines (at the moment, we need to encode the endopoints
-            # TODO(pistore,bassosimone): even before we implement the previous TODO, avoid hardcoding of line length (10000)
+            # TODO(pistore,bassosimone): find a better way to represent
+            # the lines (at the moment, we need to encode the endopoints
+            # TODO(pistore,bassosimone): even before we implement the
+            # previous TODO, avoid hardcoding of line length (10000)
 
             def __vertical(regr) -> tuple[tuple[float, float], tuple[float, float]]:
                 """Logic for computing the points with vertical regression"""

--- a/dt_model/symbols/constraint.py
+++ b/dt_model/symbols/constraint.py
@@ -13,9 +13,7 @@ class Constraint:
     This class is used to define constraints for the model.
     """
 
-    def __init__(
-        self, usage: Symbol, capacity: Symbol, group: str | None = None, name: str = ""
-    ) -> None:
+    def __init__(self, usage: Symbol, capacity: Symbol, group: str | None = None, name: str = "") -> None:
         self.usage = usage
         self.capacity = capacity
         self.name = name

--- a/dt_model/symbols/context_variable.py
+++ b/dt_model/symbols/context_variable.py
@@ -66,9 +66,9 @@ class UniformCategoricalContextVariable(ContextVariable):
 
         if force_sample or nr < size:
             assert nr > 0
-            return [(1/nr, r) for r in random.choices(values, k=nr)]
+            return [(1 / nr, r) for r in random.choices(values, k=nr)]
 
-        return [(1/size, v) for v in values]
+        return [(1 / size, v) for v in values]
 
 
 class CategoricalContextVariable(ContextVariable):
@@ -91,14 +91,15 @@ class CategoricalContextVariable(ContextVariable):
 
         if force_sample or nr < size:
             assert nr > 0
-            return [(1/nr, r) for r in random.choices(values, k=nr, weights=[self.distribution[v] for v in values])]
+            return [(1 / nr, r) for r in random.choices(values, k=nr, weights=[self.distribution[v] for v in values])]
 
         if subset is None:
             return [(self.distribution[v], v) for v in values]
 
         subset_probability = [self.distribution[v] for v in values]
         subset_probability_sum = sum(subset_probability)
-        return [(p/subset_probability_sum, v) for (p, v) in zip(subset_probability, subset)]
+        return [(p / subset_probability_sum, v) for (p, v) in zip(subset_probability, subset)]
+
 
 class ContinuousContextVariable(ContextVariable):
     """

--- a/dt_model/symbols/index.py
+++ b/dt_model/symbols/index.py
@@ -14,7 +14,14 @@ class Index(SymbolExtender):
     Class to represent an index variable.
     """
 
-    def __init__(self, name: str, value: Any, cvs: list[ContextVariable] | None = None, group: str | None = None, ref_name: str | None = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        value: Any,
+        cvs: list[ContextVariable] | None = None,
+        group: str | None = None,
+        ref_name: str | None = None,
+    ) -> None:
         super().__init__(name)
         self.group = group
         self.ref_name = ref_name if ref_name is not None else name
@@ -24,12 +31,15 @@ class Index(SymbolExtender):
         else:
             self.value = value
 
+
 class UniformDistIndex(Index):
     """
     Class to represent an index as a uniform distribution
     """
 
-    def __init__(self, name: str, loc: float, scale: float, group: str | None = None, ref_name: str | None = None) -> None:
+    def __init__(
+        self, name: str, loc: float, scale: float, group: str | None = None, ref_name: str | None = None
+    ) -> None:
         super().__init__(name, stats.uniform(loc=loc, scale=scale), group=group, ref_name=ref_name)
         self._loc = loc
         self._scale = scale
@@ -57,12 +67,15 @@ class UniformDistIndex(Index):
     def __str__(self):
         return f"uniform_dist_idx({self.loc}, {self.scale})"
 
+
 class LognormDistIndex(Index):
     """
     Class to represent an index as a longnorm distribution
     """
 
-    def __init__(self, name: str, loc: float, scale: float, s: float, group: str | None = None, ref_name: str | None = None) -> None:
+    def __init__(
+        self, name: str, loc: float, scale: float, s: float, group: str | None = None, ref_name: str | None = None
+    ) -> None:
         super().__init__(name, stats.lognorm(loc=loc, scale=scale, s=s), group=group, ref_name=ref_name)
         self._loc = loc
         self._scale = scale
@@ -107,7 +120,9 @@ class TriangDistIndex(Index):
     Class to represent an index as a longnorm distribution
     """
 
-    def __init__(self, name: str, loc: float, scale: float, c: float, group: str | None = None, ref_name: str | None = None) -> None:
+    def __init__(
+        self, name: str, loc: float, scale: float, c: float, group: str | None = None, ref_name: str | None = None
+    ) -> None:
         super().__init__(name, stats.triang(loc=loc, scale=scale, c=c), group=group, ref_name=ref_name)
         self._loc = loc
         self._scale = scale
@@ -146,6 +161,7 @@ class TriangDistIndex(Index):
     def __str__(self):
         return f"triang_dist_idx({self.loc}, {self.scale}, {self.c})"
 
+
 class ConstIndex(Index):
     """
     Class to represent an index as a longnorm distribution
@@ -168,18 +184,20 @@ class ConstIndex(Index):
     def __str__(self):
         return f"const_idx({self.v})"
 
+
 class SymIndex(Index):
     """
     Class to represent an index as a symbolic value
     """
 
-    def __init__(self,
-                 name: str,
-                 value: Any,
-                 cvs: list[ContextVariable] | None = None,
-                 group: str | None = None,
-                 ref_name: str | None = None
-                ) -> None:
+    def __init__(
+        self,
+        name: str,
+        value: Any,
+        cvs: list[ContextVariable] | None = None,
+        group: str | None = None,
+        ref_name: str | None = None,
+    ) -> None:
         super().__init__(name, value, cvs, group=group, ref_name=ref_name)
         self.cvs = cvs
         if cvs is not None:
@@ -191,4 +209,3 @@ class SymIndex(Index):
 
     def __str__(self):
         return f"sympy_idx({self.value})"
-

--- a/dt_model/symbols/index.py
+++ b/dt_model/symbols/index.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from sympy import lambdify
 from scipy import stats
+from sympy import lambdify
 
 from dt_model.symbols._base import SymbolExtender
 from dt_model.symbols.context_variable import ContextVariable

--- a/dt_model/symbols/presence_variable.py
+++ b/dt_model/symbols/presence_variable.py
@@ -25,7 +25,7 @@ class PresenceVariable(SymbolExtender):
         self.cvs = cvs
         self.distribution = distribution
 
-    def sample(self, cvs: dict | None = None, nr: int = 1) -> np.array:
+    def sample(self, cvs: dict | None = None, nr: int = 1) -> np.ndarray:
         """
         Returns a list of values sampled from the presence variable or provided
         subset.
@@ -52,5 +52,6 @@ class PresenceVariable(SymbolExtender):
             all_cvs = [cvs[cv] for cv in self.cvs if cv in cvs.keys()]
             # TODO: solve this issue of symbols vs names
             all_cvs = list(map(lambda v: v.name if isinstance(v, Symbol) else v, all_cvs))
+        assert self.distribution is not None
         distr: dict = self.distribution(*all_cvs)
         return stats.truncnorm.rvs(-distr["mean"] / distr["std"], 10, loc=distr["mean"], scale=distr["std"], size=nr)

--- a/examples/overtourism_molveno.py
+++ b/examples/overtourism_molveno.py
@@ -1,24 +1,22 @@
-import math
-import random
-from scipy import stats
-import numpy as np
-
-from dt_model import (
-    UniformCategoricalContextVariable,
-    CategoricalContextVariable,
-    PresenceVariable,
-    Index,
-    Constraint,
-    Ensemble,
-    Model,
-)
-from sympy import Symbol, Eq, Piecewise
+import time
 
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.cm import ScalarMappable
 from matplotlib.colors import Normalize
+from presence_stats import excursionist_presences_stats, season, tourist_presences_stats, weather, weekday
+from scipy import stats
+from sympy import Eq, Piecewise, Symbol
 
-from presence_stats import season, weather, weekday, tourist_presences_stats, excursionist_presences_stats
+from dt_model import (
+    CategoricalContextVariable,
+    Constraint,
+    Ensemble,
+    Index,
+    Model,
+    PresenceVariable,
+    UniformCategoricalContextVariable,
+)
 
 # MODEL DEFINITION
 
@@ -253,8 +251,6 @@ def plot_scenario(ax, model, situation, title):
 
     model.reset()
 
-
-import time
 
 start_time = time.time()
 

--- a/examples/overtourism_molveno.py
+++ b/examples/overtourism_molveno.py
@@ -3,7 +3,15 @@ import random
 from scipy import stats
 import numpy as np
 
-from dt_model import UniformCategoricalContextVariable, CategoricalContextVariable, PresenceVariable, Index, Constraint, Ensemble, Model
+from dt_model import (
+    UniformCategoricalContextVariable,
+    CategoricalContextVariable,
+    PresenceVariable,
+    Index,
+    Constraint,
+    Ensemble,
+    Model,
+)
 from sympy import Symbol, Eq, Piecewise
 
 import matplotlib.pyplot as plt
@@ -16,117 +24,143 @@ from presence_stats import season, weather, weekday, tourist_presences_stats, ex
 
 # Context variables
 
-CV_weekday = UniformCategoricalContextVariable('weekday', [Symbol(v) for v in weekday])
-CV_season = CategoricalContextVariable('season', {Symbol(v): season[v] for v in season.keys()})
-CV_weather = CategoricalContextVariable('weather', {Symbol(v): weather[v] for v in weather.keys()})
+CV_weekday = UniformCategoricalContextVariable("weekday", [Symbol(v) for v in weekday])
+CV_season = CategoricalContextVariable("season", {Symbol(v): season[v] for v in season.keys()})
+CV_weather = CategoricalContextVariable("weather", {Symbol(v): weather[v] for v in weather.keys()})
 
 # Presence variables
 
-PV_tourists = PresenceVariable('tourists', [CV_weekday, CV_season, CV_weather], tourist_presences_stats)
-PV_excursionists = PresenceVariable('excursionists', [CV_weekday, CV_season, CV_weather], excursionist_presences_stats)
+PV_tourists = PresenceVariable("tourists", [CV_weekday, CV_season, CV_weather], tourist_presences_stats)
+PV_excursionists = PresenceVariable("excursionists", [CV_weekday, CV_season, CV_weather], excursionist_presences_stats)
 
 # Capacity indexes
 
-I_C_parking = Index('parking capacity', stats.uniform(loc=350.0, scale=100.0))
-I_C_beach = Index('beach capacity', stats.uniform(loc=6000.0, scale=1000.0))
-I_C_accommodation = Index('accommodation capacity', stats.lognorm(s=0.125, loc=0.0, scale=5000.0))
-I_C_food = Index('food service capacity', stats.triang(loc=3000.0, scale=1000.0, c=0.5))
+I_C_parking = Index("parking capacity", stats.uniform(loc=350.0, scale=100.0))
+I_C_beach = Index("beach capacity", stats.uniform(loc=6000.0, scale=1000.0))
+I_C_accommodation = Index("accommodation capacity", stats.lognorm(s=0.125, loc=0.0, scale=5000.0))
+I_C_food = Index("food service capacity", stats.triang(loc=3000.0, scale=1000.0, c=0.5))
 
 # Usage indexes
 
-I_U_tourists_parking = Index('tourist parking usage factor', 0.02)
-I_U_excursionists_parking = Index('excursionist parking usage factor',
-                                  Piecewise((0.55, Eq(CV_weather, Symbol('bad'))),
-                                            (0.80, True)),
-                                  cvs=[CV_weather])
+I_U_tourists_parking = Index("tourist parking usage factor", 0.02)
+I_U_excursionists_parking = Index(
+    "excursionist parking usage factor",
+    Piecewise((0.55, Eq(CV_weather, Symbol("bad"))), (0.80, True)),
+    cvs=[CV_weather],
+)
 
-I_U_tourists_beach = Index('tourist beach usage factor',
-                           Piecewise((0.25, Eq(CV_weather, Symbol('bad'))),
-                                     (0.50, True)),
-                           cvs=[CV_weather])
-I_U_excursionists_beach = Index('excursionist beach usage factor',
-                                Piecewise((0.35, Eq(CV_weather, Symbol('bad'))),
-                                          (0.80, True)),
-                                cvs=[CV_weather])
+I_U_tourists_beach = Index(
+    "tourist beach usage factor", Piecewise((0.25, Eq(CV_weather, Symbol("bad"))), (0.50, True)), cvs=[CV_weather]
+)
+I_U_excursionists_beach = Index(
+    "excursionist beach usage factor", Piecewise((0.35, Eq(CV_weather, Symbol("bad"))), (0.80, True)), cvs=[CV_weather]
+)
 
-I_U_tourists_accommodation = Index('tourist accommodation usage factor', 0.90)
+I_U_tourists_accommodation = Index("tourist accommodation usage factor", 0.90)
 
-I_U_tourists_food = Index('tourist food service usage factor', 0.20)
-I_U_excursionists_food = Index('excursionist food service usage factor',
-                               Piecewise((0.80, Eq(CV_weather, Symbol('bad'))),
-                                         (0.40, True)),
-                               cvs=[CV_weather,CV_weekday])
+I_U_tourists_food = Index("tourist food service usage factor", 0.20)
+I_U_excursionists_food = Index(
+    "excursionist food service usage factor",
+    Piecewise((0.80, Eq(CV_weather, Symbol("bad"))), (0.40, True)),
+    cvs=[CV_weather, CV_weekday],
+)
 
 # Conversion indexes
 
-I_Xa_tourists_per_vehicle = Index('tourists per vehicle allocation factor', 2.5)
-I_Xa_excursionists_per_vehicle = Index('excursionists per vehicle allocation factor', 2.5)
-I_Xo_tourists_parking  = Index('tourists in parking rotation factor', 1.02)
-I_Xo_excursionists_parking = Index('excursionists in parking rotation factor', 3.5)
+I_Xa_tourists_per_vehicle = Index("tourists per vehicle allocation factor", 2.5)
+I_Xa_excursionists_per_vehicle = Index("excursionists per vehicle allocation factor", 2.5)
+I_Xo_tourists_parking = Index("tourists in parking rotation factor", 1.02)
+I_Xo_excursionists_parking = Index("excursionists in parking rotation factor", 3.5)
 
-I_Xo_tourists_beach = Index('tourists on beach rotation factor', stats.uniform(loc=1.0, scale=2.0))
-I_Xo_excursionists_beach = Index('excursionists on beach rotation factor', 1.02)
+I_Xo_tourists_beach = Index("tourists on beach rotation factor", stats.uniform(loc=1.0, scale=2.0))
+I_Xo_excursionists_beach = Index("excursionists on beach rotation factor", 1.02)
 
-I_Xa_tourists_accommodation = Index('tourists per accommodation allocation factor', 1.05)
+I_Xa_tourists_accommodation = Index("tourists per accommodation allocation factor", 1.05)
 
-I_Xa_visitors_food = Index('visitors in food service allocation factor', 0.9)
-I_Xo_visitors_food = Index('visitors in food service rotation factor', 2.0)
+I_Xa_visitors_food = Index("visitors in food service allocation factor", 0.9)
+I_Xo_visitors_food = Index("visitors in food service rotation factor", 2.0)
 
 # Presence indexes
 
-I_P_tourists_reduction_factor = Index('tourists reduction factor', 1.0)
-I_P_excursionists_reduction_factor = Index('excursionists reduction factor', 1.0)
+I_P_tourists_reduction_factor = Index("tourists reduction factor", 1.0)
+I_P_excursionists_reduction_factor = Index("excursionists reduction factor", 1.0)
 
-I_P_tourists_saturation_level = Index('tourists saturation level', 10000)
-I_P_excursionists_saturation_level = Index('excursionists saturation level', 10000)
+I_P_tourists_saturation_level = Index("tourists saturation level", 10000)
+I_P_excursionists_saturation_level = Index("excursionists saturation level", 10000)
 
 
 # Constraints
 # TODO: add names to constraints?
 
-C_parking = Constraint(usage=PV_tourists * I_U_tourists_parking / (I_Xa_tourists_per_vehicle * I_Xo_tourists_parking) +
-                             PV_excursionists * I_U_excursionists_parking / (
-                                         I_Xa_excursionists_per_vehicle * I_Xo_excursionists_parking),
-                       capacity=I_C_parking)
+C_parking = Constraint(
+    usage=PV_tourists * I_U_tourists_parking / (I_Xa_tourists_per_vehicle * I_Xo_tourists_parking)
+    + PV_excursionists * I_U_excursionists_parking / (I_Xa_excursionists_per_vehicle * I_Xo_excursionists_parking),
+    capacity=I_C_parking,
+)
 
-C_beach = Constraint(usage=PV_tourists * I_U_tourists_beach / I_Xo_tourists_beach +
-                             PV_excursionists * I_U_excursionists_beach / I_Xo_excursionists_beach,
-                    capacity=I_C_beach)
+C_beach = Constraint(
+    usage=PV_tourists * I_U_tourists_beach / I_Xo_tourists_beach
+    + PV_excursionists * I_U_excursionists_beach / I_Xo_excursionists_beach,
+    capacity=I_C_beach,
+)
 
 # TODO: also capacity should be a formula
 # C_accommodation = Constraint(usage=PV_tourists * I_U_tourists_accommodation,
 #                              capacity=I_C_accommodation *  I_Xa_tourists_accommodation)
 
-C_accommodation = Constraint(usage=PV_tourists * I_U_tourists_accommodation / I_Xa_tourists_accommodation,
-                             capacity=I_C_accommodation)
+C_accommodation = Constraint(
+    usage=PV_tourists * I_U_tourists_accommodation / I_Xa_tourists_accommodation, capacity=I_C_accommodation
+)
 
 # TODO: also capacity should be a formula
 # C_food = Constraint(usage=PV_tourists * I_U_tourists_food +
 #                              PV_excursionists * I_U_excursionists_food,
 #                     capacity=I_C_food * I_Xa_visitors_food * I_Xo_visitors_food)
-C_food = Constraint(usage=(PV_tourists * I_U_tourists_food + PV_excursionists * I_U_excursionists_food) /
-                          (I_Xa_visitors_food * I_Xo_visitors_food),
-                    capacity=I_C_food)
+C_food = Constraint(
+    usage=(PV_tourists * I_U_tourists_food + PV_excursionists * I_U_excursionists_food)
+    / (I_Xa_visitors_food * I_Xo_visitors_food),
+    capacity=I_C_food,
+)
 
 
 # Models
 # TODO: what is the better process to create a model? (e.g., adding elements incrementally)
 
 # Base model
-M_Base = Model('base model', [CV_weekday, CV_season, CV_weather], [PV_tourists, PV_excursionists],
-               [I_U_tourists_parking, I_U_excursionists_parking, I_U_tourists_beach, I_U_excursionists_beach,
-                I_U_tourists_accommodation, I_U_tourists_food, I_U_excursionists_food,
-                I_Xa_tourists_per_vehicle, I_Xa_excursionists_per_vehicle, I_Xa_tourists_accommodation,
-                I_Xo_tourists_parking, I_Xo_excursionists_parking, I_Xo_tourists_beach, I_Xo_excursionists_beach,
-                I_Xa_visitors_food, I_Xo_visitors_food, I_P_tourists_reduction_factor, I_P_excursionists_reduction_factor,
-                I_P_tourists_saturation_level, I_P_excursionists_saturation_level],
-               [I_C_parking, I_C_beach, I_C_accommodation, I_C_food],
-               [C_parking, C_beach, C_accommodation, C_food])
+M_Base = Model(
+    "base model",
+    [CV_weekday, CV_season, CV_weather],
+    [PV_tourists, PV_excursionists],
+    [
+        I_U_tourists_parking,
+        I_U_excursionists_parking,
+        I_U_tourists_beach,
+        I_U_excursionists_beach,
+        I_U_tourists_accommodation,
+        I_U_tourists_food,
+        I_U_excursionists_food,
+        I_Xa_tourists_per_vehicle,
+        I_Xa_excursionists_per_vehicle,
+        I_Xa_tourists_accommodation,
+        I_Xo_tourists_parking,
+        I_Xo_excursionists_parking,
+        I_Xo_tourists_beach,
+        I_Xo_excursionists_beach,
+        I_Xa_visitors_food,
+        I_Xo_visitors_food,
+        I_P_tourists_reduction_factor,
+        I_P_excursionists_reduction_factor,
+        I_P_tourists_saturation_level,
+        I_P_excursionists_saturation_level,
+    ],
+    [I_C_parking, I_C_beach, I_C_accommodation, I_C_food],
+    [C_parking, C_beach, C_accommodation, C_food],
+)
 
 # Larger park capacity model
-I_C_parking_larger = Index('larger parking capacity', stats.uniform(loc=550.0, scale=100.0))
+I_C_parking_larger = Index("larger parking capacity", stats.uniform(loc=550.0, scale=100.0))
 
-M_MoreParking = M_Base.variation('larger parking model', change_capacities={I_C_parking: I_C_parking_larger})
+M_MoreParking = M_Base.variation("larger parking model", change_capacities={I_C_parking: I_C_parking_larger})
 
 # ANALYSIS SITUATIONS
 
@@ -134,10 +168,10 @@ M_MoreParking = M_Base.variation('larger parking model', change_capacities={I_C_
 S_Base = {}
 
 # Good weather situation
-S_Good_Weather = {CV_weather: [Symbol('good')]}
+S_Good_Weather = {CV_weather: [Symbol("good")]}
 
 # Bad weather situation
-S_Bad_Weather = {CV_weather: [Symbol('bad')]}
+S_Bad_Weather = {CV_weather: [Symbol("bad")]}
 
 # PLOTTING
 
@@ -147,13 +181,12 @@ target_presence_samples = 200
 ensemble_size = 20  # TODO: make configurable; may it be a CV parameter?
 
 
-def scale(p,v):
-    return p*v
+def scale(p, v):
+    return p * v
 
 
-def threshold(p,t):
-    return min(p, t) + 0.05/(1 + np.exp(-(p-t)))
-
+def threshold(p, t):
+    return min(p, t) + 0.05 / (1 + np.exp(-(p - t)))
 
 
 def plot_scenario(ax, model, situation, title):
@@ -163,27 +196,39 @@ def plot_scenario(ax, model, situation, title):
     xx, yy = np.meshgrid(tt, ee)
     zz = model.evaluate({PV_tourists: tt, PV_excursionists: ee}, ensemble)
 
-    sample_tourists = [sample for c in ensemble for sample in
-                       PV_tourists.sample(cvs=c[1], nr=max(1,round(c[0]*target_presence_samples)))]
-    sample_excursionists = [sample for c in ensemble for sample in
-                            PV_excursionists.sample(cvs=c[1], nr=max(1,round(c[0]*target_presence_samples)))]
+    sample_tourists = [
+        sample
+        for c in ensemble
+        for sample in PV_tourists.sample(cvs=c[1], nr=max(1, round(c[0] * target_presence_samples)))
+    ]
+    sample_excursionists = [
+        sample
+        for c in ensemble
+        for sample in PV_excursionists.sample(cvs=c[1], nr=max(1, round(c[0] * target_presence_samples)))
+    ]
 
     # Presence Transformation function
     # TODO: manage differently!
     def presence_transformation(presence, reduction_factor, saturation_level, sharpness=3):
         tmp = presence * reduction_factor
-        return (tmp * saturation_level /
-                ((tmp**sharpness + saturation_level**sharpness )**(1/sharpness)))
+        return tmp * saturation_level / ((tmp**sharpness + saturation_level**sharpness) ** (1 / sharpness))
 
-    sample_tourists = [presence_transformation(presence,
-                                               model.get_index_mean_value(I_P_tourists_reduction_factor),
-                                               model.get_index_mean_value(I_P_tourists_saturation_level))
-                       for presence in sample_tourists]
-    sample_excursionists = [presence_transformation(presence,
-                                                    model.get_index_mean_value(I_P_excursionists_reduction_factor),
-                                                    model.get_index_mean_value(I_P_excursionists_saturation_level))
-                            for presence in sample_excursionists]
-
+    sample_tourists = [
+        presence_transformation(
+            presence,
+            model.get_index_mean_value(I_P_tourists_reduction_factor),
+            model.get_index_mean_value(I_P_tourists_saturation_level),
+        )
+        for presence in sample_tourists
+    ]
+    sample_excursionists = [
+        presence_transformation(
+            presence,
+            model.get_index_mean_value(I_P_excursionists_reduction_factor),
+            model.get_index_mean_value(I_P_excursionists_saturation_level),
+        )
+        for presence in sample_excursionists
+    ]
 
     # TODO: move elsewhere, it cannot be computed this way...
     area = model.compute_sustainable_area()
@@ -192,14 +237,17 @@ def plot_scenario(ax, model, situation, title):
     critical = min(indexes, key=indexes.get)
     modals = model.compute_modal_line_per_constraint()
 
-    ax.pcolormesh(xx,yy, zz, cmap='coolwarm_r', vmin=0.0, vmax=1.0)
+    ax.pcolormesh(xx, yy, zz, cmap="coolwarm_r", vmin=0.0, vmax=1.0)
     for modal in modals.values():
-        ax.plot(*modal, color='black', linewidth=2)
-    ax.scatter(sample_excursionists, sample_tourists, color='gainsboro', edgecolors='black')
-    ax.set_title(f'{title}\n'+
-                 f'area = {area / 10e6:.2f} kp$^2$ - '+
-                 f'Sustainability = {index * 100:.2f}%\n'+
-                 f'Critical = {critical.capacity.name} ({indexes[critical] * 100:.2f}%)', fontsize=12)
+        ax.plot(*modal, color="black", linewidth=2)
+    ax.scatter(sample_excursionists, sample_tourists, color="gainsboro", edgecolors="black")
+    ax.set_title(
+        f"{title}\n"
+        + f"area = {area / 10e6:.2f} kp$^2$ - "
+        + f"Sustainability = {index * 100:.2f}%\n"
+        + f"Critical = {critical.capacity.name} ({indexes[critical] * 100:.2f}%)",
+        fontsize=12,
+    )
     ax.set_xlim(left=0, right=t_max)
     ax.set_ylim(bottom=0, top=e_max)
 
@@ -207,18 +255,19 @@ def plot_scenario(ax, model, situation, title):
 
 
 import time
+
 start_time = time.time()
 
-fig, axs = plt.subplots(2, 3, figsize=(18, 10), layout='constrained')
-plot_scenario(axs[0, 0], M_Base, S_Base, 'Base')
-plot_scenario(axs[0, 1], M_Base, S_Good_Weather, 'Good weather')
-plot_scenario(axs[0, 2], M_Base, S_Bad_Weather, 'Bad weather')
-plot_scenario(axs[1, 0], M_MoreParking, S_Base, 'More parking ')
-plot_scenario(axs[1, 1], M_MoreParking, S_Good_Weather, 'More parking - Good weather')
-plot_scenario(axs[1, 2], M_MoreParking, S_Bad_Weather, 'More parking - Bad weather')
-fig.colorbar(mappable=ScalarMappable(Normalize(0, 1), cmap='coolwarm_r'), ax=axs)
-fig.supxlabel('Tourists', fontsize=18)
-fig.supylabel('Excursionists', fontsize=18)
+fig, axs = plt.subplots(2, 3, figsize=(18, 10), layout="constrained")
+plot_scenario(axs[0, 0], M_Base, S_Base, "Base")
+plot_scenario(axs[0, 1], M_Base, S_Good_Weather, "Good weather")
+plot_scenario(axs[0, 2], M_Base, S_Bad_Weather, "Bad weather")
+plot_scenario(axs[1, 0], M_MoreParking, S_Base, "More parking ")
+plot_scenario(axs[1, 1], M_MoreParking, S_Good_Weather, "More parking - Good weather")
+plot_scenario(axs[1, 2], M_MoreParking, S_Bad_Weather, "More parking - Bad weather")
+fig.colorbar(mappable=ScalarMappable(Normalize(0, 1), cmap="coolwarm_r"), ax=axs)
+fig.supxlabel("Tourists", fontsize=18)
+fig.supylabel("Excursionists", fontsize=18)
 fig.show()
 
 print("--- %s seconds ---" % (time.time() - start_time))

--- a/examples/presence_stats.py
+++ b/examples/presence_stats.py
@@ -1,56 +1,94 @@
 import pandas as pd
 
 season_stats = pd.DataFrame(
-    [{'cluster_name': 'very high', 'freq_rel': 0.2065, 'mean_tourists': 4585.8421052631575, 'std_tourists': 600.7764663941985, 'mean_excursionists': 6001.631578947368, 'std_excursionists': 910.7123713839693},
-     {'cluster_name': 'high', 'freq_rel': 0.2609, 'mean_tourists': 4019.5416666666665, 'std_tourists': 425.7224018134318, 'mean_excursionists': 3653.0416666666665, 'std_excursionists': 790.854874784884},
-     {'cluster_name': 'mid', 'freq_rel': 0.2935, 'mean_tourists': 2915.1111111111113, 'std_tourists': 426.69213665965236, 'mean_excursionists': 2476.6296296296296, 'std_excursionists': 829.2709099957879},
-     {'cluster_name': 'low', 'freq_rel': 0.2391, 'mean_tourists': 1798.090909090909, 'std_tourists': 480.97192365250527, 'mean_excursionists': 1165.909090909091, 'std_excursionists': 480.7615891766995}]
-).set_index('cluster_name')
+    [
+        {
+            "cluster_name": "very high",
+            "freq_rel": 0.2065,
+            "mean_tourists": 4585.8421052631575,
+            "std_tourists": 600.7764663941985,
+            "mean_excursionists": 6001.631578947368,
+            "std_excursionists": 910.7123713839693,
+        },
+        {
+            "cluster_name": "high",
+            "freq_rel": 0.2609,
+            "mean_tourists": 4019.5416666666665,
+            "std_tourists": 425.7224018134318,
+            "mean_excursionists": 3653.0416666666665,
+            "std_excursionists": 790.854874784884,
+        },
+        {
+            "cluster_name": "mid",
+            "freq_rel": 0.2935,
+            "mean_tourists": 2915.1111111111113,
+            "std_tourists": 426.69213665965236,
+            "mean_excursionists": 2476.6296296296296,
+            "std_excursionists": 829.2709099957879,
+        },
+        {
+            "cluster_name": "low",
+            "freq_rel": 0.2391,
+            "mean_tourists": 1798.090909090909,
+            "std_tourists": 480.97192365250527,
+            "mean_excursionists": 1165.909090909091,
+            "std_excursionists": 480.7615891766995,
+        },
+    ]
+).set_index("cluster_name")
 
 weather_stats = pd.DataFrame(
-    [[0.15, 140.30952381, 463.13601314, -773.23809524, 1187.05786413],
-     [0.20, 128.32142857, 319.20470369, 31.10714286, 824.51775728],
-     [0.65, 72.86263736, 406.09163233, 282.91208791, 839.91419686]],
-    columns=['freq_rel', 'mean_tourists', 'std_tourists', 'mean_excursionists', 'std_excursionists'],
-    index=['bad', 'unsettled', 'good']
+    [
+        [0.15, 140.30952381, 463.13601314, -773.23809524, 1187.05786413],
+        [0.20, 128.32142857, 319.20470369, 31.10714286, 824.51775728],
+        [0.65, 72.86263736, 406.09163233, 282.91208791, 839.91419686],
+    ],
+    columns=["freq_rel", "mean_tourists", "std_tourists", "mean_excursionists", "std_excursionists"],
+    index=["bad", "unsettled", "good"],
 )
 
-weekday_stats = pd.DataFrame([[-362.65934066, 112.47000414, -391.15384615, 791.84158997],
-                              [-265.34065934, 122.13648742, -352.27472527, 937.65181712],
-                              [-147.92307692, 247.5534754, -465.62637363, 733.9652083],
-                              [92.23076923, 233.81638923, -380.35164835, 779.58869239],
-                              [678.05494505, 149.44551186, -232.91208791, 500.50732948],
-                              [320.46938776, 204.41996226, 590.98979592, 797.28902804],
-                              [-278.93406593, 193.01797188, 1240.27472527, 1149.59709071]],
-                             columns=['mean_tourists', 'std_tourists', 'mean_excursionists', 'std_excursionists'],
-                             index=['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'])
+weekday_stats = pd.DataFrame(
+    [
+        [-362.65934066, 112.47000414, -391.15384615, 791.84158997],
+        [-265.34065934, 122.13648742, -352.27472527, 937.65181712],
+        [-147.92307692, 247.5534754, -465.62637363, 733.9652083],
+        [92.23076923, 233.81638923, -380.35164835, 779.58869239],
+        [678.05494505, 149.44551186, -232.91208791, 500.50732948],
+        [320.46938776, 204.41996226, 590.98979592, 797.28902804],
+        [-278.93406593, 193.01797188, 1240.27472527, 1149.59709071],
+    ],
+    columns=["mean_tourists", "std_tourists", "mean_excursionists", "std_excursionists"],
+    index=["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"],
+)
 
-season = { s: season_stats.loc[s,'freq_rel'] for s in season_stats.index }
-weather = { w: weather_stats.loc[w,'freq_rel'] for w in weather_stats.index }
+season = {s: season_stats.loc[s, "freq_rel"] for s in season_stats.index}
+weather = {w: weather_stats.loc[w, "freq_rel"] for w in weather_stats.index}
 weekday = weekday_stats.index
+
 
 def tourist_presences_stats(weekday, season, weather):
     # Season
-    mean = season_stats.loc[season,'mean_tourists']
-    std2 = season_stats.loc[season,'std_tourists']**2
+    mean = season_stats.loc[season, "mean_tourists"]
+    std2 = season_stats.loc[season, "std_tourists"] ** 2
     # Weather
-    mean += weather_stats.loc[weather, 'mean_tourists']
-    std2 += weather_stats.loc[weather, 'std_tourists'] ** 2
+    mean += weather_stats.loc[weather, "mean_tourists"]
+    std2 += weather_stats.loc[weather, "std_tourists"] ** 2
     # Weekdays
-    mean += weekday_stats.loc[weekday,'mean_tourists']
-    std2 += weekday_stats.loc[weekday,'std_tourists']**2
+    mean += weekday_stats.loc[weekday, "mean_tourists"]
+    std2 += weekday_stats.loc[weekday, "std_tourists"] ** 2
     # Finalize and return
-    return {'mean': mean, 'std': std2**(1/2)}
+    return {"mean": mean, "std": std2 ** (1 / 2)}
+
 
 def excursionist_presences_stats(weekday, season, weather):
     # Season
-    mean = season_stats.loc[season,'mean_excursionists']
-    std2 = season_stats.loc[season,'std_excursionists']**2
+    mean = season_stats.loc[season, "mean_excursionists"]
+    std2 = season_stats.loc[season, "std_excursionists"] ** 2
     # Weather
-    mean += weather_stats.loc[weather, 'mean_excursionists']
-    std2 += weather_stats.loc[weather, 'std_excursionists'] ** 2
+    mean += weather_stats.loc[weather, "mean_excursionists"]
+    std2 += weather_stats.loc[weather, "std_excursionists"] ** 2
     # Weekdays
-    mean += weekday_stats.loc[weekday, 'mean_excursionists']
-    std2 += weekday_stats.loc[weekday, 'std_excursionists'] ** 2
+    mean += weekday_stats.loc[weekday, "mean_excursionists"]
+    std2 += weekday_stats.loc[weekday, "std_excursionists"] ** 2
     # Finalize and return
-    return {'mean': mean, 'std': std2 ** (1 / 2)}
+    return {"mean": mean, "std": std2 ** (1 / 2)}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = [
-    "black>=24.10.0",
-    "pyright>=1.1.397",
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-]
+dev = ["pyright>=1.1.397", "pytest>=7.0.0", "pytest-cov>=4.0.0", "ruff>=0.11.0"]
 
 [project.urls]
 Homepage = "https://github.com/fbk-most/dt-model"
@@ -42,10 +37,19 @@ python_files = ["test_*.py"]
 addopts = "--cov=dt_model --cov-report=xml --cov-report=term-missing"
 
 [tool.ruff]
+target-version = "py311"
 line-length = 120
+indent-width = 4
 
-[tool.ruff.lint.extend-per-file-ignores]
-"__init__.py" = ["F401"]
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"
+skip-magic-trailing-comma = false
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+extend-select = ["W", "Q"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,5 +2,10 @@
   "typeCheckingMode": "standard",
   "useLibraryCodeForTypes": true,
   "pythonVersion": "3.11",
-  "include": ["dt_model", "tests"]
+  "include": ["dt_model", "tests"],
+  "exclude": [
+    "dt_model/model/model.py",
+    "dt_model/symbols/context_variable.py",
+    "dt_model/symbols/presence_variable.py"
+  ]
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,6 @@
 {
-  "typeCheckingMode": "strict",
+  "typeCheckingMode": "standard",
   "useLibraryCodeForTypes": true,
   "pythonVersion": "3.11",
-  "include": ["dt_model"]
+  "include": ["dt_model", "tests"]
 }

--- a/tests/engine/atomic/test_int.py
+++ b/tests/engine/atomic/test_int.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import threading
-import pytest
 
 from dt_model.engine.atomic import Int
 

--- a/tests/engine/frontend/test_graph.py
+++ b/tests/engine/frontend/test_graph.py
@@ -2,8 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-
 from dt_model.engine.frontend import graph
 
 
@@ -215,3 +213,201 @@ def test_binary_op_node_ids():
     assert op1.id != op2.id
     assert op1.id != a.id
     assert op1.id != b.id
+
+
+def test_infix_arithmetic_operations():
+    """Test infix arithmetic operations between nodes."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+
+    # Test operator overloading
+    add1 = a + b
+    assert isinstance(add1, graph.add)
+    assert add1.left is a
+    assert add1.right is b
+
+    # Test scalar operations
+    add2 = a + 2.0
+    assert isinstance(add2, graph.add)
+    assert add2.left is a
+    assert isinstance(add2.right, graph.constant)
+    assert add2.right.value == 2.0
+
+    # Test reverse operations
+    add3 = 2.0 + a
+    assert isinstance(add3, graph.add)
+    assert isinstance(add3.left, graph.constant)
+    assert add3.left.value == 2.0
+    assert add3.right is a
+
+    # Test other arithmetic operations
+    sub = a - b
+    assert isinstance(sub, graph.subtract)
+    assert sub.left is a
+    assert sub.right is b
+
+    mul = a * b
+    assert isinstance(mul, graph.multiply)
+    assert mul.left is a
+    assert mul.right is b
+
+    div = a / b
+    assert isinstance(div, graph.divide)
+    assert div.left is a
+    assert div.right is b
+
+
+def test_infix_comparison_operations():
+    """Test infix comparison operations between nodes."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+
+    # Test all comparison operators
+    eq = a == b
+    assert isinstance(eq, graph.equal)
+    assert eq.left is a
+    assert eq.right is b
+
+    ne = a != b
+    assert isinstance(ne, graph.not_equal)
+    assert ne.left is a
+    assert ne.right is b
+
+    lt = a < b
+    assert isinstance(lt, graph.less)
+    assert lt.left is a
+    assert lt.right is b
+
+    le = a <= b
+    assert isinstance(le, graph.less_equal)
+    assert le.left is a
+    assert le.right is b
+
+    gt = a > b
+    assert isinstance(gt, graph.greater)
+    assert gt.left is a
+    assert gt.right is b
+
+    ge = a >= b
+    assert isinstance(ge, graph.greater_equal)
+    assert ge.left is a
+    assert ge.right is b
+
+
+def test_infix_logical_operations():
+    """Test infix logical operations between nodes."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+
+    # Test logical operators
+    and_op = a & b
+    assert isinstance(and_op, graph.logical_and)
+    assert and_op.left is a
+    assert and_op.right is b
+
+    or_op = a | b
+    assert isinstance(or_op, graph.logical_or)
+    assert or_op.left is a
+    assert or_op.right is b
+
+    xor_op = a ^ b
+    assert isinstance(xor_op, graph.logical_xor)
+    assert xor_op.left is a
+    assert xor_op.right is b
+
+    not_op = ~a
+    assert isinstance(not_op, graph.logical_not)
+    assert not_op.node is a
+
+
+def test_infix_reverse_operations():
+    """Test reverse infix operations with scalar values."""
+    a = graph.placeholder("a")
+
+    # Test reverse operations with scalars
+    rsub = 2.0 - a
+    assert isinstance(rsub, graph.subtract)
+    assert isinstance(rsub.left, graph.constant)
+    assert rsub.left.value == 2.0
+    assert rsub.right is a
+
+    rmul = 2.0 * a
+    assert isinstance(rmul, graph.multiply)
+    assert isinstance(rmul.left, graph.constant)
+    assert rmul.left.value == 2.0
+    assert rmul.right is a
+
+    rdiv = 2.0 / a
+    assert isinstance(rdiv, graph.divide)
+    assert isinstance(rdiv.left, graph.constant)
+    assert rdiv.left.value == 2.0
+    assert rdiv.right is a
+
+    # Test reverse logical operations
+    rand = True & a
+    assert isinstance(rand, graph.logical_and)
+    assert isinstance(rand.left, graph.constant)
+    assert rand.left.value is True
+    assert rand.right is a
+
+    ror = True | a
+    assert isinstance(ror, graph.logical_or)
+    assert isinstance(ror.left, graph.constant)
+    assert ror.left.value is True
+    assert ror.right is a
+
+    rxor = True ^ a
+    assert isinstance(rxor, graph.logical_xor)
+    assert isinstance(rxor.left, graph.constant)
+    assert rxor.left.value is True
+    assert rxor.right is a
+
+
+def test_complex_infix_expressions():
+    """Test complex expressions using infix operations."""
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+    c = graph.placeholder("c")
+
+    # Test complex expression: (a + b) * (c - 2.0)
+    expr = (a + b) * (c - 2.0)
+
+    assert isinstance(expr, graph.multiply)
+    assert isinstance(expr.left, graph.add)
+    assert expr.left.left is a
+    assert expr.left.right is b
+    assert isinstance(expr.right, graph.subtract)
+    assert expr.right.left is c
+    assert isinstance(expr.right.right, graph.constant)
+    assert expr.right.right.value == 2.0
+
+    # Test complex logical expression: (a & b) | (~c)
+    logical_expr = (a & b) | (~c)
+
+    assert isinstance(logical_expr, graph.logical_or)
+    assert isinstance(logical_expr.left, graph.logical_and)
+    assert logical_expr.left.left is a
+    assert logical_expr.left.right is b
+    assert isinstance(logical_expr.right, graph.logical_not)
+    assert logical_expr.right.node is c
+
+
+def test_ensure_node_function():
+    """Test the ensure_node function that converts scalars to constants."""
+    # Test with node input
+    node = graph.placeholder("test")
+    result = graph.ensure_node(node)
+    assert result is node  # Should return the same node
+
+    # Test with scalar inputs
+    result_float = graph.ensure_node(3.14)
+    assert isinstance(result_float, graph.constant)
+    assert result_float.value == 3.14
+
+    result_int = graph.ensure_node(42)
+    assert isinstance(result_int, graph.constant)
+    assert result_int.value == 42
+
+    result_bool = graph.ensure_node(True)
+    assert isinstance(result_bool, graph.constant)
+    assert result_bool.value is True

--- a/tests/engine/numpybackend/test_executor.py
+++ b/tests/engine/numpybackend/test_executor.py
@@ -456,7 +456,7 @@ def test_state_value_access():
     # Create a node and a state
     x = graph.placeholder("x")
     y = graph.constant(2.0)
-    z = graph.add(x, y)
+    graph.add(x, y)
 
     state = executor.State({x: np.array([1.0, 2.0, 3.0])})
 
@@ -650,7 +650,7 @@ def test_state_post_init_tracing(capsys):
     y_val = np.array([4.0, 5.0, 6.0])
 
     # Create state with tracing flag
-    state = executor.State({x: x_val, y: y_val}, flags=graph.NODE_FLAG_TRACE)
+    executor.State({x: x_val, y: y_val}, flags=graph.NODE_FLAG_TRACE)
 
     # Check that tracing output was generated during initialization
     captured = capsys.readouterr()

--- a/tests/engine/numpybackend/test_executor.py
+++ b/tests/engine/numpybackend/test_executor.py
@@ -158,12 +158,8 @@ def test_multi_clause_where():
     plan = linearize.forest(node)
 
     # Test data
-    cond1_val = np.array(
-        [[True, False, False], [False, True, False], [False, False, True]]
-    )
-    cond2_val = np.array(
-        [[False, True, False], [True, False, False], [False, True, False]]
-    )
+    cond1_val = np.array([[True, False, False], [False, True, False], [False, False, True]])
+    cond2_val = np.array([[False, True, False], [True, False, False], [False, True, False]])
     expected = np.select([cond1_val, cond2_val], [1.0, 2.0], default=0.0)
 
     # Evaluate with executor
@@ -635,9 +631,7 @@ def test_axis_operations():
     with pytest.raises(ValueError):  # NumPy raises ValueError for invalid axes
         # Create a valid node type but with invalid axis
         # Note: x is only 2D, so axis=5 is invalid
-        invalid_axis_node = graph.reduce_sum(
-            x, axis=5
-        )
+        invalid_axis_node = graph.reduce_sum(x, axis=5)
         invalid_plan = linearize.forest(invalid_axis_node)
         invalid_state = executor.State({x: x_val})
 

--- a/tests/internal/__init__.py
+++ b/tests/internal/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the dt_model.internal package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/internal/sympyke/__init__.py
+++ b/tests/internal/sympyke/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the dt_model.internal.sympyke package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/internal/sympyke/test_operators.py
+++ b/tests/internal/sympyke/test_operators.py
@@ -2,11 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from dt_model.internal.sympyke import Eq, Symbol
+import numpy as np
+
 from dt_model.engine.frontend import graph, linearize
 from dt_model.engine.numpybackend import executor
-
-import numpy as np
+from dt_model.internal.sympyke import Eq, Symbol
 
 
 def test_eq_basics():

--- a/tests/internal/sympyke/test_operators.py
+++ b/tests/internal/sympyke/test_operators.py
@@ -1,0 +1,115 @@
+"""Tests for the dt_model.internal.sympyke.operators module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from dt_model.internal.sympyke import Eq, Symbol
+from dt_model.engine.frontend import graph, linearize
+from dt_model.engine.numpybackend import executor
+
+import numpy as np
+
+
+def test_eq_basics():
+    """Test basic functionality of the Eq operator."""
+    # Create symbols
+    x = Symbol("x")
+    y = Symbol("y")
+
+    # Create equality operation
+    equality = Eq(x, y)
+
+    # Linearize and evaluate
+    plan = linearize.forest(equality)
+    state = executor.State(
+        {
+            x.node: np.array([1, 2, 3, 2]),
+            y.node: np.array([1, 3, 3, 1]),
+        }
+    )
+
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Expected: True, False, True, False
+    expected = np.array([True, False, True, False])
+    assert np.array_equal(state.values[equality], expected)
+
+
+def test_eq_with_constants():
+    """Test Eq with constant values."""
+    x = Symbol("x")
+
+    # Equality with constant on right
+    eq1 = Eq(x, 3)
+
+    # Equality with constant on left
+    eq2 = Eq(3, x)
+
+    # Evaluate both
+    plan = linearize.forest(eq1, eq2)
+    state = executor.State(
+        {
+            x.node: np.array([1, 2, 3, 4]),
+        }
+    )
+
+    for node in plan:
+        executor.evaluate(state, node)
+
+    expected = np.array([False, False, True, False])
+    assert np.array_equal(state.values[eq1], expected)
+    assert np.array_equal(state.values[eq2], expected)
+
+
+def test_eq_with_mixed_inputs():
+    """Test Eq with a mix of Symbol and graph.Node inputs."""
+    x = Symbol("x")
+    y = graph.placeholder("y")
+
+    eq = Eq(x, y)
+
+    # Linearize and evaluate
+    plan = linearize.forest(eq)
+    state = executor.State(
+        {
+            x.node: np.array([1, 2, 3]),
+            y: np.array([1, 0, 3]),
+        }
+    )
+
+    for node in plan:
+        executor.evaluate(state, node)
+
+    expected = np.array([True, False, True])
+    assert np.array_equal(state.values[eq], expected)
+
+
+def test_eq_chaining():
+    """Test multiple equality operations together."""
+    x = Symbol("x")
+    y = Symbol("y")
+    z = Symbol("z")
+
+    # Create x == y and y == z
+    eq_xy = Eq(x, y)
+    eq_yz = Eq(y, z)
+
+    # Combine with logical and
+    result = eq_xy & eq_yz
+
+    # Linearize and evaluate
+    plan = linearize.forest(result)
+    state = executor.State(
+        {
+            x.node: np.array([1, 2, 3, 4]),
+            y.node: np.array([1, 2, 2, 5]),
+            z.node: np.array([1, 2, 3, 5]),
+        }
+    )
+
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Expected: True, True, False, False
+    expected = np.array([True, True, False, False])
+    assert np.array_equal(state.values[result], expected)

--- a/tests/internal/sympyke/test_piecewise.py
+++ b/tests/internal/sympyke/test_piecewise.py
@@ -2,13 +2,12 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from dt_model.internal.sympyke import Piecewise, Symbol
+import numpy as np
+import pytest
+
 from dt_model.engine.frontend import linearize
 from dt_model.engine.numpybackend import executor
-
-import numpy as np
-
-import pytest
+from dt_model.internal.sympyke import Piecewise, Symbol
 
 
 def test_piecewise_basics():

--- a/tests/internal/sympyke/test_piecewise.py
+++ b/tests/internal/sympyke/test_piecewise.py
@@ -1,0 +1,147 @@
+"""Tests for the dt_model.internal.sympyke.piecewise package."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from dt_model.internal.sympyke import Piecewise, Symbol
+from dt_model.engine.frontend import linearize
+from dt_model.engine.numpybackend import executor
+
+import numpy as np
+
+import pytest
+
+
+def test_piecewise_basics():
+    """Make sure that Piecewise works as intended with Symbol."""
+
+    # Create the placeholders as symbols
+    x = Symbol("x")
+    y = Symbol("y")
+    z = Symbol("z")
+
+    condition1 = Symbol("condition1")
+    condition2 = Symbol("condition2")
+
+    # Create the resulting piecewise function
+    pw = Piecewise(
+        (x.node, condition1.node),
+        (y.node, condition2.node),
+        (z.node, True),
+    )
+
+    # Linearize an execution plan out of the piecewise
+    plan = linearize.forest(pw)
+
+    # Create the evaluation state with concrete values
+    state = executor.State(
+        {
+            x.node: np.array([2, 9, 16]),
+            y.node: np.array([8, 27, 64]),
+            z.node: np.array([16, 81, 256]),
+            condition1.node: np.array([True, False, False]),
+            condition2.node: np.array([False, True, False]),
+        }
+    )
+
+    # Actually evaluate the piecewise function
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Ensure the result is the expected one
+    expect = np.array([2, 27, 256])
+    rv = state.values[pw]
+    assert np.all(rv == expect)
+
+
+def test_piecewise_with_scalars():
+    """Test Piecewise with scalar values."""
+    result = Piecewise((2, False), (1, True))
+
+    # Linearize
+    plan = linearize.forest(result)
+    state = executor.State(values={})
+
+    # Evaluate
+    for node in plan:
+        executor.evaluate(state, node)
+
+    assert state.values[result] == 1
+
+
+def test_piecewise_empty():
+    """Test Piecewise with no clauses raises ValueError."""
+    with pytest.raises(ValueError):
+        Piecewise()
+
+
+def test_piecewise_filtering():
+    """Test the internal _filter_clauses function."""
+    from dt_model.internal.sympyke.piecewise import _filter_clauses
+
+    clauses = (
+        (1, False),
+        (2, True),
+        (3, False),  # Should be filtered out
+        (4, True),  # Should be filtered out
+    )
+
+    filtered = _filter_clauses(clauses)
+    assert len(filtered) == 2
+    assert filtered[0] == (1, False)
+    assert filtered[1] == (2, True)
+
+
+def test_piecewise_with_constant_conditions():
+    """Test Piecewise functionality with constant conditions."""
+    # Create expression symbols
+    expr1 = Symbol("expr1")
+    expr2 = Symbol("expr2")
+    expr3 = Symbol("expr3")
+
+    # Create piecewise with constant conditions
+    pw = Piecewise(
+        (expr1.node, False),  # Constant False condition
+        (expr2.node, True),  # Constant True condition
+        (expr3.node, True),  # This should be ignored as it's after a True condition
+    )
+
+    # Linearize the execution plan
+    plan = linearize.forest(pw)
+
+    # Set up evaluation state with tensor values
+    state = executor.State(
+        {
+            expr1.node: np.array([10, 20, 30]),
+            expr2.node: np.array([40, 50, 60]),
+            expr3.node: np.array([70, 80, 90]),
+        }
+    )
+
+    # Evaluate the piecewise function
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Since the second condition is True, the result should be expr2
+    result = state.values[pw]
+    expected = np.array([40, 50, 60])
+
+    assert np.array_equal(result, expected)
+
+
+def test_piecewise_only_default_case():
+    """Test when filtering clauses leaves only the default case."""
+    # Create piecewise where all non-default clauses come after a True condition
+    pw = Piecewise(
+        (1, True),  # This becomes the default case
+        (10, False),  # This gets filtered out
+    )
+
+    # Linearize
+    plan = linearize.forest(pw)
+    state = executor.State(values={})
+
+    # Evaluate
+    for node in plan:
+        executor.evaluate(state, node)
+
+    assert state.values[pw] == 1

--- a/tests/internal/sympyke/test_symbol.py
+++ b/tests/internal/sympyke/test_symbol.py
@@ -2,11 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from dt_model.internal.sympyke import Symbol
+import numpy as np
+
 from dt_model.engine.frontend import linearize
 from dt_model.engine.numpybackend import executor
-
-import numpy as np
+from dt_model.internal.sympyke import Symbol
 
 
 def test_symbol_basics():
@@ -97,9 +97,9 @@ def test_symbol_table_values():
 
     try:
         # Create some symbols
-        a = Symbol("a")
-        b = Symbol("b")
-        c = Symbol("c")
+        Symbol("a")
+        Symbol("b")
+        Symbol("c")
 
         # Get all symbols from the table
         all_symbols = symbol_mod.symbol_table.values()

--- a/tests/internal/sympyke/test_symbol.py
+++ b/tests/internal/sympyke/test_symbol.py
@@ -1,0 +1,113 @@
+"""Tests for the dt_model.internal.sympyke.symbol package."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from dt_model.internal.sympyke import Symbol
+from dt_model.engine.frontend import linearize
+from dt_model.engine.numpybackend import executor
+
+import numpy as np
+
+
+def test_symbol_basics():
+    """Test basic Symbol functionality."""
+    # Create a new symbol
+    x = Symbol("x")
+
+    # Check its properties
+    assert x.name == "x"
+    assert x.node is not None
+    assert x.node.name == "x"
+
+
+def test_symbol_reuse():
+    """Test that symbols with the same name are reused."""
+    # Create symbols with the same name
+    x1 = Symbol("same_name")
+    x2 = Symbol("same_name")
+
+    # Check that they refer to the same node
+    assert x1 is x2
+    assert x1.node is x2.node
+
+
+def test_symbol_execution():
+    """Test execution with Symbol placeholders."""
+    # Create symbols
+    x = Symbol("x")
+    y = Symbol("y")
+
+    # Create a simple computation
+    result = x.node + y.node
+
+    # Linearize the execution plan
+    plan = linearize.forest(result)
+
+    # Set up evaluation state
+    state = executor.State(
+        {
+            x.node: np.array([1, 2, 3]),
+            y.node: np.array([4, 5, 6]),
+        }
+    )
+
+    # Evaluate
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Check result
+    expected = np.array([5, 7, 9])
+    assert np.array_equal(state.values[result], expected)
+
+
+def test_symbol_multiple_operations():
+    """Test multiple operations on symbols."""
+    x = Symbol("x")
+    y = Symbol("y")
+    z = Symbol("z")
+
+    # Create a more complex expression: (x + y) * z
+    result = (x.node + y.node) * z.node
+
+    # Linearize and evaluate
+    plan = linearize.forest(result)
+    state = executor.State(
+        {
+            x.node: np.array([1, 2, 3]),
+            y.node: np.array([4, 5, 6]),
+            z.node: np.array([2, 3, 4]),
+        }
+    )
+
+    for node in plan:
+        executor.evaluate(state, node)
+
+    # Expected: (1+4)*2, (2+5)*3, (3+6)*4 = 10, 21, 36
+    expected = np.array([10, 21, 36])
+    assert np.array_equal(state.values[result], expected)
+
+
+def test_symbol_table_values():
+    """Test accessing all symbols from the symbol table."""
+    # Clear any existing symbols by recreating the table
+    import dt_model.internal.sympyke.symbol as symbol_mod
+
+    original_table = symbol_mod.symbol_table
+    symbol_mod.symbol_table = symbol_mod._SymbolTable()
+
+    try:
+        # Create some symbols
+        a = Symbol("a")
+        b = Symbol("b")
+        c = Symbol("c")
+
+        # Get all symbols from the table
+        all_symbols = symbol_mod.symbol_table.values()
+
+        # Check that all created symbols are in the table
+        assert len(all_symbols) == 3
+        symbol_names = {s.name for s in all_symbols}
+        assert symbol_names == {"a", "b", "c"}
+    finally:
+        # Restore the original symbol table
+        symbol_mod.symbol_table = original_table

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -2,14 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from dt_model import (
-    UniformCategoricalContextVariable,
-    CategoricalContextVariable,
-    ContinuousContextVariable,
-)
-
 import pytest
 import scipy
+
+from dt_model import (
+    CategoricalContextVariable,
+    ContinuousContextVariable,
+    UniformCategoricalContextVariable,
+)
 
 
 @pytest.fixture

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-
 from dt_model import (
     UniformCategoricalContextVariable,
     CategoricalContextVariable,
@@ -20,9 +19,7 @@ def uniform_cv():
 
 @pytest.fixture
 def categorical_cv():
-    return CategoricalContextVariable(
-        "Categorical", {"a": 0.1, "b": 0.2, "c": 0.3, "d": 0.4}
-    )
+    return CategoricalContextVariable("Categorical", {"a": 0.1, "b": 0.2, "c": 0.3, "d": 0.4})
 
 
 @pytest.fixture
@@ -49,6 +46,4 @@ def test_cv(cv_fixture_name, sizes, values, request):
     for s in sizes:
         print(f"    Size {s} - subset {values}: {cv.sample(s, subset=values)}")
     for s in sizes:
-        print(
-            f"    Size {s} - subset {values} - force_sample: {cv.sample(s, subset=values, force_sample=True)}"
-        )
+        print(f"    Size {s} - subset {values} - force_sample: {cv.sample(s, subset=values, force_sample=True)}")

--- a/uv.lock
+++ b/uv.lock
@@ -7,46 +7,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "black"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/4f/87f596aca05c3ce5b94b8663dbfe242a12843caaa82dd3f85f1ffdc3f177/black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0", size = 1614372 },
-    { url = "https://files.pythonhosted.org/packages/e7/d0/2c34c36190b741c59c901e56ab7f6e54dad8df05a6272a9747ecef7c6036/black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299", size = 1442865 },
-    { url = "https://files.pythonhosted.org/packages/21/d4/7518c72262468430ead45cf22bd86c883a6448b9eb43672765d69a8f1248/black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096", size = 1749699 },
-    { url = "https://files.pythonhosted.org/packages/58/db/4f5beb989b547f79096e035c4981ceb36ac2b552d0ac5f2620e941501c99/black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2", size = 1428028 },
-    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988 },
-    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985 },
-    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816 },
-    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860 },
-    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673 },
-    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190 },
-    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926 },
-    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613 },
-    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646 },
-]
-
-[[package]]
-name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -122,10 +82,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -138,10 +98,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=24.10.0" },
     { name = "pyright", specifier = ">=1.1.397" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "ruff", specifier = ">=0.11.0" },
 ]
 
 [[package]]
@@ -160,15 +120,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
 ]
 
 [[package]]
@@ -279,24 +230,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.3.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439 },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -365,6 +298,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5f/57/df1c9157c8d5a05117e455d66fd7cf6dbc46974f832b1058ed4856785d8a/pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e", size = 319617 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/38/ac33370d784287baa1c3d538978b5e2ea064d4c1b93ffbd12826c190dd10/pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57", size = 507930 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/2b/7ca27e854d92df5e681e6527dc0f9254c9dc06c8408317893cf96c851cdd/ruff-0.11.0.tar.gz", hash = "sha256:e55c620690a4a7ee6f1cccb256ec2157dc597d109400ae75bbf944fc9d6462e2", size = 3799407 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/40/3d0340a9e5edc77d37852c0cd98c5985a5a8081fc3befaeb2ae90aaafd2b/ruff-0.11.0-py3-none-linux_armv6l.whl", hash = "sha256:dc67e32bc3b29557513eb7eeabb23efdb25753684b913bebb8a0c62495095acb", size = 10098158 },
+    { url = "https://files.pythonhosted.org/packages/ec/a9/d8f5abb3b87b973b007649ac7bf63665a05b2ae2b2af39217b09f52abbbf/ruff-0.11.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38c23fd9bdec4eb437b4c1e3595905a0a8edfccd63a790f818b28c78fe345639", size = 10879071 },
+    { url = "https://files.pythonhosted.org/packages/ab/62/aaa198614c6211677913ec480415c5e6509586d7b796356cec73a2f8a3e6/ruff-0.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c8661b0be91a38bd56db593e9331beaf9064a79028adee2d5f392674bbc5e88", size = 10247944 },
+    { url = "https://files.pythonhosted.org/packages/9f/52/59e0a9f2cf1ce5e6cbe336b6dd0144725c8ea3b97cac60688f4e7880bf13/ruff-0.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6c0e8d3d2db7e9f6efd884f44b8dc542d5b6b590fc4bb334fdbc624d93a29a2", size = 10421725 },
+    { url = "https://files.pythonhosted.org/packages/a6/c3/dcd71acc6dff72ce66d13f4be5bca1dbed4db678dff2f0f6f307b04e5c02/ruff-0.11.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c3156d3f4b42e57247275a0a7e15a851c165a4fc89c5e8fa30ea6da4f7407b8", size = 9954435 },
+    { url = "https://files.pythonhosted.org/packages/a6/9a/342d336c7c52dbd136dee97d4c7797e66c3f92df804f8f3b30da59b92e9c/ruff-0.11.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:490b1e147c1260545f6d041c4092483e3f6d8eba81dc2875eaebcf9140b53905", size = 11492664 },
+    { url = "https://files.pythonhosted.org/packages/84/35/6e7defd2d7ca95cc385ac1bd9f7f2e4a61b9cc35d60a263aebc8e590c462/ruff-0.11.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1bc09a7419e09662983b1312f6fa5dab829d6ab5d11f18c3760be7ca521c9329", size = 12207856 },
+    { url = "https://files.pythonhosted.org/packages/22/78/da669c8731bacf40001c880ada6d31bcfb81f89cc996230c3b80d319993e/ruff-0.11.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcfa478daf61ac8002214eb2ca5f3e9365048506a9d52b11bea3ecea822bb844", size = 11645156 },
+    { url = "https://files.pythonhosted.org/packages/ee/47/e27d17d83530a208f4a9ab2e94f758574a04c51e492aa58f91a3ed7cbbcb/ruff-0.11.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6fbb2aed66fe742a6a3a0075ed467a459b7cedc5ae01008340075909d819df1e", size = 13884167 },
+    { url = "https://files.pythonhosted.org/packages/9f/5e/42ffbb0a5d4b07bbc642b7d58357b4e19a0f4774275ca6ca7d1f7b5452cd/ruff-0.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c0c1ff014351c0b0cdfdb1e35fa83b780f1e065667167bb9502d47ca41e6db", size = 11348311 },
+    { url = "https://files.pythonhosted.org/packages/c8/51/dc3ce0c5ce1a586727a3444a32f98b83ba99599bb1ebca29d9302886e87f/ruff-0.11.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e4fd5ff5de5f83e0458a138e8a869c7c5e907541aec32b707f57cf9a5e124445", size = 10305039 },
+    { url = "https://files.pythonhosted.org/packages/60/e0/475f0c2f26280f46f2d6d1df1ba96b3399e0234cf368cc4c88e6ad10dcd9/ruff-0.11.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:96bc89a5c5fd21a04939773f9e0e276308be0935de06845110f43fd5c2e4ead7", size = 9937939 },
+    { url = "https://files.pythonhosted.org/packages/e2/d3/3e61b7fd3e9cdd1e5b8c7ac188bec12975c824e51c5cd3d64caf81b0331e/ruff-0.11.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a9352b9d767889ec5df1483f94870564e8102d4d7e99da52ebf564b882cdc2c7", size = 10923259 },
+    { url = "https://files.pythonhosted.org/packages/30/32/cd74149ebb40b62ddd14bd2d1842149aeb7f74191fb0f49bd45c76909ff2/ruff-0.11.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:049a191969a10897fe052ef9cc7491b3ef6de79acd7790af7d7897b7a9bfbcb6", size = 11406212 },
+    { url = "https://files.pythonhosted.org/packages/00/ef/033022a6b104be32e899b00de704d7c6d1723a54d4c9e09d147368f14b62/ruff-0.11.0-py3-none-win32.whl", hash = "sha256:3191e9116b6b5bbe187447656f0c8526f0d36b6fd89ad78ccaad6bdc2fad7df2", size = 10310905 },
+    { url = "https://files.pythonhosted.org/packages/ed/8a/163f2e78c37757d035bd56cd60c8d96312904ca4a6deeab8442d7b3cbf89/ruff-0.11.0-py3-none-win_amd64.whl", hash = "sha256:c58bfa00e740ca0a6c43d41fb004cd22d165302f360aaa56f7126d544db31a21", size = 11411730 },
+    { url = "https://files.pythonhosted.org/packages/4e/f7/096f6efabe69b49d7ca61052fc70289c05d8d35735c137ef5ba5ef423662/ruff-0.11.0-py3-none-win_arm64.whl", hash = "sha256:868364fc23f5aa122b00c6f794211e85f7e78f5dffdf7c590ab90b8c4e69b657", size = 10538956 },
 ]
 
 [[package]]


### PR DESCRIPTION
This diff ensures we typecheck the codebase in each CI run using the pyright type checker (used by VSCode).

I also fixed some easy-to-fix type errors and added to the exclude list the files with residual type errors.

We're going to take care of them in the future and the IDE still shows squiggles for them anyway, which, if you ask me, is a nice feature, because it ensures we won't forget about these files having typing errors.