### PR TITLE
chore: prepare for the 0.1.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,18 +3,21 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dt-model"
-version = "0.0.1"
+name = "civic-digital-twins"
+version = "0.1.0"
 description = "DigitalTwins Model"
 readme = "README.md"
-authors = [{ name = "Fondazione Bruno Kessler", email = "dslab@fbk.eu" }]
+authors = [
+    { name = "Fondazione Bruno Kessler", email = "most@fbk.eu" },
+    { name = "Marco Pistore", email = "pistore@fbk.eu" },
+    { name = "Simone Basso", email = "sibasso@fbk.eu" },
+]
 license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 keywords = []
 requires-python = ">=3.11.0"

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,41 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "civic-digital-twins"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "sympy" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.2.0" },
+    { name = "pandas", specifier = ">=2.2.0" },
+    { name = "scipy", specifier = ">=1.15.0" },
+    { name = "sympy", specifier = ">=1.13.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.397" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "ruff", specifier = ">=0.11.0" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -67,41 +102,6 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
-]
-
-[[package]]
-name = "dt-model"
-version = "0.0.1"
-source = { editable = "." }
-dependencies = [
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "scipy" },
-    { name = "sympy" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "numpy", specifier = ">=2.2.0" },
-    { name = "pandas", specifier = ">=2.2.0" },
-    { name = "scipy", specifier = ">=1.15.0" },
-    { name = "sympy", specifier = ">=1.13.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pyright", specifier = ">=1.1.397" },
-    { name = "pytest", specifier = ">=7.0.0" },
-    { name = "pytest-cov", specifier = ">=4.0.0" },
-    { name = "ruff", specifier = ">=0.11.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
1. make sure the version number is set to 0.1.0

2. make sure the responsible email is the research unit email

3. make sure we correctly specify the supported versions
of Python, zapping unsupported ones and adding 3.13

4. rename the package name to `civic-digital-twins` otherwise
we cannot publish it: the `dt-model` name is too similar to the
name used by other already existing packages.

With these changes applied, we look good for tagging.
