### PR TITLE
cleanup(legacy_model): zap unused variation method

### DIFF
--- a/dt_model/model/legacy_model.py
+++ b/dt_model/model/legacy_model.py
@@ -186,37 +186,3 @@ class LegacyModel:
                 pass  # No regression is possible (eg median not intersecting the grid)
 
         return modal_lines
-
-    def variation(self, new_name, *, change_indexes=None, change_capacities=None):
-        # TODO: check if changes are valid (ie they change elements present in the model)
-        if change_indexes is None:
-            new_indexes = self.indexes
-            change_indexes = {}
-        else:
-            new_indexes = []
-            for index in self.indexes:
-                if index in change_indexes:
-                    new_indexes.append(change_indexes[index])
-                else:
-                    new_indexes.append(index)
-        if change_capacities is None:
-            new_capacities = self.capacities
-            change_capacities = {}
-        else:
-            new_capacities = []
-            for capacity in self.capacities:
-                if capacity in change_capacities:
-                    new_capacities.append(change_capacities[capacity])
-                else:
-                    new_capacities.append(capacity)
-        new_constraints = []
-        for constraint in self.constraints:
-            new_constraints.append(
-                Constraint(
-                    constraint.usage.subs(change_indexes),
-                    constraint.capacity.subs(change_capacities),
-                    group=constraint.group,
-                    name=constraint.name,
-                )
-            )
-        return LegacyModel(new_name, self.cvs, self.pvs, new_indexes, new_capacities, new_constraints)

--- a/dt_model/symbols/constraint.py
+++ b/dt_model/symbols/constraint.py
@@ -11,10 +11,7 @@ resource and the usage of that resource. We model two types of constraints:
 
 from __future__ import annotations
 
-import typing
-
-if typing.TYPE_CHECKING:
-    from sympy import Symbol
+from sympy import Symbol
 
 
 class Constraint:
@@ -24,7 +21,13 @@ class Constraint:
     This class is used to define constraints for the model.
     """
 
-    def __init__(self, usage: Symbol, capacity: Symbol, group: str | None = None, name: str = "") -> None:
+    def __init__(
+        self,
+        usage: Symbol,
+        capacity: Symbol,
+        group: str | None = None,
+        name: str = "",
+    ) -> None:
         self.usage = usage
         self.capacity = capacity
         self.name = name

--- a/dt_model/symbols/presence_variable.py
+++ b/dt_model/symbols/presence_variable.py
@@ -50,7 +50,6 @@ class PresenceVariable(SymbolExtender):
             List of sampled values.
         """
         assert nr > 0
-        assert self.distribution is not None
 
         all_cvs = []
         # TODO: check this functionality

--- a/dt_model/symbols/presence_variable.py
+++ b/dt_model/symbols/presence_variable.py
@@ -1,3 +1,8 @@
+"""
+This module defines presence variables. A presence variable is a model variable that
+represents the presence of a certain entity in the modeled system.
+"""
+
 from __future__ import annotations
 
 from typing import Callable
@@ -45,6 +50,7 @@ class PresenceVariable(SymbolExtender):
             List of sampled values.
         """
         assert nr > 0
+        assert self.distribution is not None
 
         all_cvs = []
         # TODO: check this functionality
@@ -54,4 +60,6 @@ class PresenceVariable(SymbolExtender):
             all_cvs = list(map(lambda v: v.name if isinstance(v, Symbol) else v, all_cvs))
         assert self.distribution is not None
         distr: dict = self.distribution(*all_cvs)
-        return stats.truncnorm.rvs(-distr["mean"] / distr["std"], 10, loc=distr["mean"], scale=distr["std"], size=nr)
+        return np.asarray(
+            stats.truncnorm.rvs(-distr["mean"] / distr["std"], 10, loc=distr["mean"], scale=distr["std"], size=nr),
+        )


### PR DESCRIPTION
This diff removes the unused variation method from the legacy model module and class. The method is unused because:

1. existing code uses the `Model` instead

2. the `LegacyModel` is an implementation detail

Also, the `Model.variation` method does not invoke the `LegacyModel.variation` method to do its job.

While there, add more docstrings and modernize the import pattern used inside the codebase.

While there, avoid error squiggle by explicitly casting using `np.asarray`.