### PR TITLE
feat(engine): support replacing subgraph nodes

### DIFF
--- a/dt_model/engine/frontend/graph.py
+++ b/dt_model/engine/frontend/graph.py
@@ -17,7 +17,7 @@ This module provides:
 7. Reduction operations (sum, mean)
 8. Built-in debug operations (tracepoint, breakpoint)
 9. Support for infix and unary operators (e.g., `a + b`, `~a`)
-10. Node copying to support graph transformations (e.g., copy with new children)
+10. Node copying to support graph transformations (e.g., copy_with with new children)
 
 The nodes form a directed acyclic graph (DAG) that represents computations
 to be performed. Each node implements a specific operation and stores its
@@ -71,13 +71,13 @@ capturing the arguments it has been provided on construction.
 
 Node Copying
 -----------
-Several node types implement a `copy` method that creates a new node with the
+Several node types implement a `copy_with` method that creates a new node with the
 same type and attributes but with different children. This is useful for
 graph transformations that need to replace nodes while preserving the overall
 structure of the computation graph. For example:
 
     >>> original = a + b
-    >>> replacement = original.copy(left=c, right=d)  # Creates a new add node with c and d
+    >>> replacement = original.copy_with(left=c, right=d)  # Creates a new add node with c and d
 
 Design Decisions
 ----------------
@@ -285,7 +285,7 @@ class BinaryOp(Node):
         self.left = left
         self.right = right
 
-    def copy(self, left: Node, right: Node) -> BinaryOp:
+    def copy_with(self, left: Node, right: Node) -> BinaryOp:
         """Create a copy of this binary operation with new children.
 
         This method creates a new node of the same type with the provided
@@ -376,7 +376,7 @@ class UnaryOp(Node):
         super().__init__()
         self.node = node
 
-    def copy(self, node: Node) -> UnaryOp:
+    def copy_with(self, node: Node) -> UnaryOp:
         """Create a copy of this unary operation with a new child.
 
         This method creates a new node of the same type with the provided
@@ -439,7 +439,7 @@ class where(Node):
         self.then = then
         self.otherwise = otherwise
 
-    def copy(self, condition: Node, then: Node, otherwise: Node) -> where:
+    def copy_with(self, condition: Node, then: Node, otherwise: Node) -> where:
         """Create a copy of this where operation with new children.
 
         This method creates a new node with the provided children,
@@ -472,7 +472,7 @@ class multi_clause_where(Node):
         self.clauses = clauses
         self.default_value = default_value
 
-    def copy(self, clauses: Sequence[tuple[Node, Node]], default_value: Node) -> multi_clause_where:
+    def copy_with(self, clauses: Sequence[tuple[Node, Node]], default_value: Node) -> multi_clause_where:
         """Create a copy of this multi-clause where operation with new children.
 
         This method creates a new node with the provided clauses and default value,
@@ -511,7 +511,7 @@ class AxisOp(Node):
         self.node = node
         self.axis = axis
 
-    def copy(self, node: Node) -> AxisOp:
+    def copy_with(self, node: Node) -> AxisOp:
         """Create a copy of this axis operation with a new child.
 
         This method creates a new node of the same type with the provided

--- a/dt_model/engine/frontend/graph.py
+++ b/dt_model/engine/frontend/graph.py
@@ -17,6 +17,7 @@ This module provides:
 7. Reduction operations (sum, mean)
 8. Built-in debug operations (tracepoint, breakpoint)
 9. Support for infix and unary operators (e.g., `a + b`, `~a`)
+10. Node copying to support graph transformations (e.g., copy with new children)
 
 The nodes form a directed acyclic graph (DAG) that represents computations
 to be performed. Each node implements a specific operation and stores its
@@ -67,6 +68,16 @@ choice: violating PEP8 to produce code that reads like TensorFlow.
 The main type in this module is the `Node`, representing a node in the
 computation graph. Each operation (e.g., `add`) is a subclass of the `Node`
 capturing the arguments it has been provided on construction.
+
+Node Copying
+-----------
+Several node types implement a `copy` method that creates a new node with the
+same type and attributes but with different children. This is useful for
+graph transformations that need to replace nodes while preserving the overall
+structure of the computation graph. For example:
+
+    >>> original = a + b
+    >>> replacement = original.copy(left=c, right=d)  # Creates a new add node with c and d
 
 Design Decisions
 ----------------
@@ -274,6 +285,24 @@ class BinaryOp(Node):
         self.left = left
         self.right = right
 
+    def copy(self, left: Node, right: Node) -> BinaryOp:
+        """Create a copy of this binary operation with new children.
+
+        This method creates a new node of the same type with the provided
+        children, preserving the original node's attributes like name and flags.
+
+        Args:
+            left: New left child node
+            right: New right child node
+
+        Returns:
+            A new node of the same type with copied attributes
+        """
+        new_node = type(self)(left, right)
+        new_node.name = self.name
+        new_node.flags = self.flags
+        return new_node
+
 
 # Arithmetic operations
 
@@ -347,6 +376,23 @@ class UnaryOp(Node):
         super().__init__()
         self.node = node
 
+    def copy(self, node: Node) -> UnaryOp:
+        """Create a copy of this unary operation with a new child.
+
+        This method creates a new node of the same type with the provided
+        child, preserving the original node's attributes like name and flags.
+
+        Args:
+            node: New child node
+
+        Returns:
+            A new node of the same type with copied attributes
+        """
+        new_node = type(self)(node)
+        new_node.name = self.name
+        new_node.flags = self.flags
+        return new_node
+
 
 class logical_not(UnaryOp):
     """Element-wise logical NOT of a boolean tensor."""
@@ -393,6 +439,25 @@ class where(Node):
         self.then = then
         self.otherwise = otherwise
 
+    def copy(self, condition: Node, then: Node, otherwise: Node) -> where:
+        """Create a copy of this where operation with new children.
+
+        This method creates a new node with the provided children,
+        preserving the original node's attributes like name and flags.
+
+        Args:
+            condition: New condition node
+            then: New then node
+            otherwise: New otherwise node
+
+        Returns:
+            A new where node with copied attributes
+        """
+        new_node = where(condition, then, otherwise)
+        new_node.name = self.name
+        new_node.flags = self.flags
+        return new_node
+
 
 class multi_clause_where(Node):
     """Selects elements from tensors based on multiple conditions.
@@ -406,6 +471,24 @@ class multi_clause_where(Node):
         super().__init__()
         self.clauses = clauses
         self.default_value = default_value
+
+    def copy(self, clauses: Sequence[tuple[Node, Node]], default_value: Node) -> multi_clause_where:
+        """Create a copy of this multi-clause where operation with new children.
+
+        This method creates a new node with the provided clauses and default value,
+        preserving the original node's attributes like name and flags.
+
+        Args:
+            clauses: New sequence of (condition, value) pairs
+            default_value: New default value node
+
+        Returns:
+            A new multi_clause_where node with copied attributes
+        """
+        new_node = multi_clause_where(clauses, default_value)
+        new_node.name = self.name
+        new_node.flags = self.flags
+        return new_node
 
 
 # Shape-changing operations
@@ -427,6 +510,24 @@ class AxisOp(Node):
         super().__init__()
         self.node = node
         self.axis = axis
+
+    def copy(self, node: Node) -> AxisOp:
+        """Create a copy of this axis operation with a new child.
+
+        This method creates a new node of the same type with the provided
+        child and the same axis, preserving the original node's attributes
+        like name and flags.
+
+        Args:
+            node: New child node
+
+        Returns:
+            A new node of the same type with copied attributes
+        """
+        new_node = type(self)(node, self.axis)
+        new_node.name = self.name
+        new_node.flags = self.flags
+        return new_node
 
 
 class expand_dims(AxisOp):

--- a/dt_model/engine/frontend/replace.py
+++ b/dt_model/engine/frontend/replace.py
@@ -15,6 +15,7 @@ should be replaced, then recursively processes its children.
 
 from . import graph
 
+
 def nodes(
     target: graph.Node,
     replacements: dict[graph.Node, graph.Node],
@@ -107,9 +108,7 @@ def nodes(
         rotherwise = nodes(target.otherwise, replacements)
 
         # Handle the no-replacement case
-        if (rcondition is target.condition and
-            rthen is target.then and
-            rotherwise is target.otherwise):
+        if rcondition is target.condition and rthen is target.then and rotherwise is target.otherwise:
             return target
 
         # Use copy method to create a new node with the replaced children

--- a/dt_model/engine/frontend/replace.py
+++ b/dt_model/engine/frontend/replace.py
@@ -1,0 +1,142 @@
+"""
+Node Replacement for Computation Graphs
+=======================================
+
+This module provides facilities for transforming a computation graph
+by replacing a set of nodes with another set of nodes. The transformation
+creates a new graph without modifying the original nodes, preserving the
+immutability of the computation graph.
+
+The replacement process works recursively, traversing the entire graph
+starting from the target node and applying replacements to matching nodes
+and their descendants. For each node, it first checks if the node itself
+should be replaced, then recursively processes its children.
+"""
+
+from . import graph
+
+def nodes(
+    target: graph.Node,
+    replacements: dict[graph.Node, graph.Node],
+) -> graph.Node:
+    """Replace nodes in a computation graph with their specified replacements.
+
+    This function creates a new graph by recursively traversing the original graph
+    starting from the target node and replacing nodes according to the provided
+    replacements dictionary. The function preserves the structure of the original
+    graph for parts that don't need replacement.
+
+    The replacement is performed using identity (is) comparison, not equality (==).
+    If the target node is in the replacements dictionary, it is directly replaced.
+    Otherwise, the function recursively processes its children, and if any child
+    is replaced, a new node of the same type is created with the replaced children.
+
+    Args:
+        target: The root node of the graph or subgraph to transform.
+        replacements: A dictionary mapping original nodes to their replacement nodes.
+                     The keys are the nodes to be replaced, and the values are their
+                     replacements.
+
+    Returns:
+        A new graph node representing the transformed graph. If no replacements
+        were applied, the original target node is returned.
+
+    Raises:
+        TypeError: If an unsupported node type is encountered during traversal.
+
+    Examples:
+        >>> x = graph.placeholder("x")
+        >>> y = graph.placeholder("y")
+        >>> z = x + y * 2
+        >>> # Replace y with a constant 5
+        >>> new_z = nodes(z, {y: graph.constant(5)})
+        >>> # Now new_z represents x + 5 * 2
+    """
+
+    # Direct replacement of the target node
+    if target in replacements:
+        return replacements[target]
+
+    # Replacement for placeholders and constants
+    if isinstance(target, graph.constant):
+        return target
+    if isinstance(target, graph.placeholder):
+        return target
+
+    # Replacement for binary operators
+    if isinstance(target, graph.BinaryOp):
+        # Attempt to replace the left and right children
+        rleft, rright = nodes(target.left, replacements), nodes(target.right, replacements)
+
+        # Handle the no-replacement case
+        if rleft is target.left and rright is target.right:
+            return target
+
+        # Use copy method to create a new node with the replaced children
+        return target.copy(rleft, rright)
+
+    # Replacement for unary operators
+    if isinstance(target, graph.UnaryOp):
+        # Attempt to replace the child
+        rnode = nodes(target.node, replacements)
+
+        # Handle the no-replacement case
+        if rnode is target.node:
+            return target
+
+        # Use copy method to create a new node with the replaced child
+        return target.copy(rnode)
+
+    # Replacement for axis operators
+    if isinstance(target, graph.AxisOp):
+        # Attempt to replace the child node
+        rnode = nodes(target.node, replacements)
+
+        # Handle the no-replacement case
+        if rnode is target.node:
+            return target
+
+        # Use copy method to create a new node with the replaced child
+        return target.copy(rnode)
+
+    # Replacement for where operations
+    if isinstance(target, graph.where):
+        # Attempt to replace all three children
+        rcondition = nodes(target.condition, replacements)
+        rthen = nodes(target.then, replacements)
+        rotherwise = nodes(target.otherwise, replacements)
+
+        # Handle the no-replacement case
+        if (rcondition is target.condition and
+            rthen is target.then and
+            rotherwise is target.otherwise):
+            return target
+
+        # Use copy method to create a new node with the replaced children
+        return target.copy(rcondition, rthen, rotherwise)
+
+    # Replacement for multi_clause_where operations
+    if isinstance(target, graph.multi_clause_where):
+        # Attempt to replace each clause and the default value
+        new_clauses = []
+        clauses_changed = False
+
+        for cond, value in target.clauses:
+            rcond = nodes(cond, replacements)
+            rvalue = nodes(value, replacements)
+            new_clauses.append((rcond, rvalue))
+
+            if rcond is not cond or rvalue is not value:
+                clauses_changed = True
+
+        rdefault = nodes(target.default_value, replacements)
+
+        # Handle the no-replacement case
+        if not clauses_changed and rdefault is target.default_value:
+            return target
+
+        # Use copy method to create a new node with the replaced children
+        return target.copy(new_clauses, rdefault)
+
+    # Handle the case of an unsupported node type
+    raise TypeError(f"Unsupported node type for replacement: {type(target)}")

--- a/dt_model/engine/frontend/replace.py
+++ b/dt_model/engine/frontend/replace.py
@@ -73,8 +73,8 @@ def nodes(
         if rleft is target.left and rright is target.right:
             return target
 
-        # Use copy method to create a new node with the replaced children
-        return target.copy(rleft, rright)
+        # Use copy_with method to create a new node with the replaced children
+        return target.copy_with(rleft, rright)
 
     # Replacement for unary operators
     if isinstance(target, graph.UnaryOp):
@@ -85,8 +85,8 @@ def nodes(
         if rnode is target.node:
             return target
 
-        # Use copy method to create a new node with the replaced child
-        return target.copy(rnode)
+        # Use copy_with method to create a new node with the replaced child
+        return target.copy_with(rnode)
 
     # Replacement for axis operators
     if isinstance(target, graph.AxisOp):
@@ -97,8 +97,8 @@ def nodes(
         if rnode is target.node:
             return target
 
-        # Use copy method to create a new node with the replaced child
-        return target.copy(rnode)
+        # Use copy_with method to create a new node with the replaced child
+        return target.copy_with(rnode)
 
     # Replacement for where operations
     if isinstance(target, graph.where):
@@ -111,8 +111,8 @@ def nodes(
         if rcondition is target.condition and rthen is target.then and rotherwise is target.otherwise:
             return target
 
-        # Use copy method to create a new node with the replaced children
-        return target.copy(rcondition, rthen, rotherwise)
+        # Use copy_with method to create a new node with the replaced children
+        return target.copy_with(rcondition, rthen, rotherwise)
 
     # Replacement for multi_clause_where operations
     if isinstance(target, graph.multi_clause_where):
@@ -134,8 +134,8 @@ def nodes(
         if not clauses_changed and rdefault is target.default_value:
             return target
 
-        # Use copy method to create a new node with the replaced children
-        return target.copy(new_clauses, rdefault)
+        # Use copy_with method to create a new node with the replaced children
+        return target.copy_with(new_clauses, rdefault)
 
     # Handle the case of an unsupported node type
     raise TypeError(f"Unsupported node type for replacement: {type(target)}")

--- a/dt_model/engine/numpybackend/executor.py
+++ b/dt_model/engine/numpybackend/executor.py
@@ -66,7 +66,6 @@ class State:
     def __post_init__(self):
         if self.flags & graph.NODE_FLAG_TRACE != 0:
             nodes = sorted(self.values.keys(), key=lambda n: n.id)
-            # TODO(bassosimone): make it clear that those nodes are cached
             for node in nodes:
                 debug.print_graph_node(node)
                 debug.print_evaluated_node(self.values[node], cached=True)

--- a/dt_model/engine/numpybackend/executor.py
+++ b/dt_model/engine/numpybackend/executor.py
@@ -66,6 +66,7 @@ class State:
     def __post_init__(self):
         if self.flags & graph.NODE_FLAG_TRACE != 0:
             nodes = sorted(self.values.keys(), key=lambda n: n.id)
+            # TODO(bassosimone): make it clear that those nodes are cached
             for node in nodes:
                 debug.print_graph_node(node)
                 debug.print_evaluated_node(self.values[node], cached=True)

--- a/tests/engine/frontend/test_graph.py
+++ b/tests/engine/frontend/test_graph.py
@@ -77,7 +77,7 @@ def test_complex_arithmetic_graph():
     assert add_ab.right is b
 
 
-def test_binary_op_copy():
+def test_binary_op_copy_with():
     """Test that binary operations can be correctly copied with new children."""
     # Create some nodes
     a = graph.placeholder("a")
@@ -91,7 +91,7 @@ def test_binary_op_copy():
     add_op.flags = graph.NODE_FLAG_TRACE
 
     # Copy the operation with new children
-    new_add = add_op.copy(left=c, right=d)
+    new_add = add_op.copy_with(left=c, right=d)
 
     # Verify the copy has correct structure
     assert isinstance(new_add, graph.add)
@@ -109,13 +109,13 @@ def test_binary_op_copy():
     # Test more binary operations
     sub_op = graph.subtract(a, b)
     sub_op.name = "subtract_operation"
-    new_sub = sub_op.copy(left=c, right=d)
+    new_sub = sub_op.copy_with(left=c, right=d)
     assert isinstance(new_sub, graph.subtract)
     assert new_sub.name == "subtract_operation"
     assert new_sub.id != sub_op.id
 
     mul_op = graph.multiply(a, b)
-    new_mul = mul_op.copy(left=c, right=d)
+    new_mul = mul_op.copy_with(left=c, right=d)
     assert isinstance(new_mul, graph.multiply)
     assert new_mul.id != mul_op.id
 
@@ -144,7 +144,7 @@ def test_complex_conditional_graph():
     assert result.default_value is default
 
 
-def test_where_op_copy():
+def test_where_op_copy_with():
     """Test that where operations can be correctly copied with new children."""
     # Create some nodes
     a = graph.placeholder("a")
@@ -160,7 +160,7 @@ def test_where_op_copy():
     where_op.flags = graph.NODE_FLAG_TRACE
 
     # Copy the operation with new children
-    new_where = where_op.copy(condition=d, then=e, otherwise=f)
+    new_where = where_op.copy_with(condition=d, then=e, otherwise=f)
 
     # Verify the copy has correct structure
     assert isinstance(new_where, graph.where)
@@ -177,7 +177,7 @@ def test_where_op_copy():
     assert new_where.id != where_op.id
 
 
-def test_multi_clause_where_op_copy():
+def test_multi_clause_where_op_copy_with():
     """Test that multi-clause where operations can be correctly copied with new children."""
     # Create some nodes
     a = graph.placeholder("a")
@@ -201,7 +201,7 @@ def test_multi_clause_where_op_copy():
     new_clauses = [(e, f), (g, h)]
 
     # Copy the operation with new children
-    new_mcw = mcw_op.copy(clauses=new_clauses, default_value=new_default)
+    new_mcw = mcw_op.copy_with(clauses=new_clauses, default_value=new_default)
 
     # Verify the copy has correct structure
     assert isinstance(new_mcw, graph.multi_clause_where)
@@ -240,7 +240,7 @@ def test_reduction_graph():
     assert prod.right is y
 
 
-def test_unary_op_copy():
+def test_unary_op_copy_with():
     """Test that unary operations can be correctly copied with new children."""
     # Create some nodes
     a = graph.placeholder("a")
@@ -252,7 +252,7 @@ def test_unary_op_copy():
     exp_op.flags = graph.NODE_FLAG_BREAK
 
     # Copy the operation with a new child
-    new_exp = exp_op.copy(node=b)
+    new_exp = exp_op.copy_with(node=b)
 
     # Verify the copy has correct structure
     assert isinstance(new_exp, graph.exp)
@@ -269,14 +269,14 @@ def test_unary_op_copy():
     # Test logical not
     not_op = graph.logical_not(a)
     not_op.name = "not_operation"
-    new_not = not_op.copy(node=b)
+    new_not = not_op.copy_with(node=b)
     assert isinstance(new_not, graph.logical_not)
     assert new_not.name == "not_operation"
     assert new_not.node is b
     assert new_not.id != not_op.id
 
 
-def test_axis_op_copy():
+def test_axis_op_copy_with():
     """Test that axis operations can be correctly copied with new children."""
     # Create some nodes
     a = graph.placeholder("a")
@@ -288,7 +288,7 @@ def test_axis_op_copy():
     sum_op.flags = graph.NODE_FLAG_TRACE
 
     # Copy the operation with a new child
-    new_sum = sum_op.copy(node=b)
+    new_sum = sum_op.copy_with(node=b)
 
     # Verify the copy has correct structure
     assert isinstance(new_sum, graph.reduce_sum)
@@ -305,13 +305,13 @@ def test_axis_op_copy():
 
     # Test other axis operations
     mean_op = graph.reduce_mean(a, axis=1)
-    new_mean = mean_op.copy(node=b)
+    new_mean = mean_op.copy_with(node=b)
     assert isinstance(new_mean, graph.reduce_mean)
     assert new_mean.axis == 1
     assert new_mean.id != mean_op.id
 
     expand_op = graph.expand_dims(a, axis=2)
-    new_expand = expand_op.copy(node=b)
+    new_expand = expand_op.copy_with(node=b)
     assert isinstance(new_expand, graph.expand_dims)
     assert new_expand.axis == 2
     assert new_expand.id != expand_op.id

--- a/tests/engine/frontend/test_replace.py
+++ b/tests/engine/frontend/test_replace.py
@@ -1,0 +1,243 @@
+"""Tests for the dt_model.engine.frontend.replace module."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from dt_model.engine.frontend import graph, replace, linearize
+from dt_model.engine.numpybackend import executor
+
+
+def test_basic_node_replacements():
+    """Test basic node replacement functionality for different node types."""
+    # Direct replacement tests
+    a = graph.placeholder("a")
+    b = graph.constant(5.0)
+    c = graph.placeholder("c")
+
+    # Direct replacement
+    assert replace.nodes(a, {a: c}) is c
+    assert replace.nodes(b, {b: c}) is c
+
+    # Binary operator replacement
+    add_node = graph.add(a, b)
+    d = graph.placeholder("d")
+
+    # Replace one operand
+    result = replace.nodes(add_node, {a: d})
+    assert isinstance(result, graph.add)
+    assert result.left is d
+    assert result.right is b
+    assert result is not add_node
+
+    # Replace both operands
+    e = graph.placeholder("e")
+    result = replace.nodes(add_node, {a: d, b: e})
+    assert isinstance(result, graph.add)
+    assert result.left is d
+    assert result.right is e
+
+    # Unary operator replacement
+    exp_node = graph.exp(a)
+    result = replace.nodes(exp_node, {a: c})
+    assert isinstance(result, graph.exp)
+    assert result.node is c
+
+    # Axis operator replacement
+    sum_node = graph.reduce_sum(a, axis=0)
+    result = replace.nodes(sum_node, {a: c})
+    assert isinstance(result, graph.reduce_sum)
+    assert result.node is c
+    assert result.axis == 0
+
+
+def test_complex_node_replacements():
+    """Test replacement in more complex node structures."""
+    # Where operation
+    cond = graph.placeholder("cond")
+    then_branch = graph.placeholder("then")
+    else_branch = graph.placeholder("else")
+    where_op = graph.where(cond, then_branch, else_branch)
+
+    new_cond = graph.placeholder("new_cond")
+    new_then = graph.placeholder("new_then")
+
+    result = replace.nodes(where_op, {cond: new_cond, then_branch: new_then})
+    assert isinstance(result, graph.where)
+    assert result.condition is new_cond
+    assert result.then is new_then
+    assert result.otherwise is else_branch
+
+    # Multi-clause where operation
+    cond1 = graph.placeholder("cond1")
+    val1 = graph.placeholder("val1")
+    cond2 = graph.placeholder("cond2")
+    val2 = graph.placeholder("val2")
+    default = graph.placeholder("default")
+
+    mcw = graph.multi_clause_where([(cond1, val1), (cond2, val2)], default)
+
+    new_cond1 = graph.placeholder("new_cond1")
+    new_val2 = graph.placeholder("new_val2")
+    new_default = graph.placeholder("new_default")
+
+    result = replace.nodes(mcw, {cond1: new_cond1, val2: new_val2, default: new_default})
+    assert isinstance(result, graph.multi_clause_where)
+    assert result.clauses[0][0] is new_cond1
+    assert result.clauses[0][1] is val1
+    assert result.clauses[1][0] is cond2
+    assert result.clauses[1][1] is new_val2
+    assert result.default_value is new_default
+
+    # Default-only replacement in multi-clause where
+    only_default_mcw = graph.multi_clause_where([(cond1, val1)], default)
+    only_default_result = replace.nodes(only_default_mcw, {default: new_default})
+    assert isinstance(only_default_result, graph.multi_clause_where)
+    assert only_default_result.clauses[0][0] is cond1
+    assert only_default_result.clauses[0][1] is val1
+    assert only_default_result.default_value is new_default
+
+
+def test_recursive_graph_replacement():
+    """Test replacement in deeply nested graph structures."""
+    # Create a complex graph
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+    c = graph.multiply(a, graph.constant(2.0))
+    d = graph.add(c, b)
+    e = graph.exp(d)
+
+    # Create replacement nodes
+    a_new = graph.placeholder("a_new")
+    b_new = graph.placeholder("b_new")
+
+    # Replace nodes deep in the graph
+    result = replace.nodes(e, {a: a_new, b: b_new})
+
+    # Verify structure is properly transformed
+    assert isinstance(result, graph.exp)
+    assert isinstance(result.node, graph.add)
+
+    add_node = result.node
+    assert isinstance(add_node.left, graph.multiply)
+    assert add_node.right is b_new
+
+    mul_node = add_node.left
+    assert mul_node.left is a_new
+    assert isinstance(mul_node.right, graph.constant)
+    assert mul_node.right.value == 2.0
+
+    # Verify original graph is unchanged
+    assert e.node is d
+    assert d.left is c
+    assert d.right is b
+    assert c.left is a
+
+
+def test_attribute_preservation():
+    """Test that node attributes are preserved during replacement."""
+    a = graph.placeholder("a")
+    b = graph.constant(3.0)
+    c = graph.add(a, b)
+    c.name = "addition"
+    c.flags = graph.NODE_FLAG_TRACE
+
+    new_a = graph.placeholder("new_a")
+    result = replace.nodes(c, {a: new_a})
+
+    assert isinstance(result, graph.add)
+    assert result.left is new_a
+    assert result.right is b
+    assert result.name == "addition"
+    assert result.flags == graph.NODE_FLAG_TRACE
+
+
+def test_identity_cases():
+    """Test cases where no replacements are made (identity cases)."""
+    # Test with direct nodes
+    a = graph.placeholder("a")
+    b = graph.constant(5.0)
+    c = graph.add(a, b)
+
+    # Empty replacements
+    assert replace.nodes(a, {}) is a
+    assert replace.nodes(b, {}) is b
+    assert replace.nodes(c, {}) is c
+
+    # Non-matching replacements
+    d = graph.placeholder("d")
+    e = graph.placeholder("e")
+    assert replace.nodes(c, {d: e}) is c
+
+    # Test with various node types
+    exp_a = graph.exp(a)
+    assert replace.nodes(exp_a, {}) is exp_a
+    assert replace.nodes(exp_a, {d: e}) is exp_a
+
+    # Where operation identity case
+    where_op = graph.where(a, b, c)
+    assert replace.nodes(where_op, {}) is where_op
+
+    # Multi-clause where identity case
+    mcw = graph.multi_clause_where([(a, b), (c, graph.constant(5.0))], graph.constant(0.0))
+    assert replace.nodes(mcw, {}) is mcw
+
+    # Axis operator identity case
+    sum_a = graph.reduce_sum(a, axis=0)
+    assert replace.nodes(sum_a, {d: e}) is sum_a
+
+
+
+def test_replace_nodes_functional_evaluation():
+    """Test that replacements produce functionally equivalent graphs."""
+    # Create original graph: (a * 2) + (b * 3)
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+    a_times_2 = graph.multiply(a, graph.constant(2.0))
+    b_times_3 = graph.multiply(b, graph.constant(3.0))
+    original = graph.add(a_times_2, b_times_3)
+
+    # Create replacement graph: (x * 4) + (y * 3)
+    # This should double the effect of 'a' without changing 'b'
+    x = graph.placeholder("x")
+    x_times_4 = graph.multiply(x, graph.constant(4.0))
+
+    # Create replacements: a -> x, a_times_2 -> x_times_4
+    replacements = {a: x, a_times_2: x_times_4}
+    result = replace.nodes(original, replacements)
+
+    # Create execution plans
+    original_plan = linearize.forest(original)
+    result_plan = linearize.forest(result)
+
+    # Evaluate with test values
+    a_val = np.array([1.0, 2.0, 3.0])
+    b_val = np.array([4.0, 5.0, 6.0])
+    x_val = a_val  # Use same values for testing
+
+    # Evaluate original
+    orig_state = executor.State({a: a_val, b: b_val})
+    for node in original_plan:
+        executor.evaluate(orig_state, node)
+
+    # Evaluate replacement
+    result_state = executor.State({x: x_val, b: b_val})
+    for node in result_plan:
+        executor.evaluate(result_state, node)
+
+    # Verify the transformed graph produces expected results
+    expected_result = (a_val * 4.0) + (b_val * 3.0)
+    assert np.array_equal(result_state.values[result], expected_result)
+
+
+def test_replace_nodes_unsupported_type():
+    """Test that an error is raised for unsupported node types."""
+    # Create a custom node type not handled by the replace function
+    class CustomNode(graph.Node):
+        pass
+
+    custom_node = CustomNode()
+
+    with pytest.raises(TypeError, match="Unsupported node type"):
+        replace.nodes(custom_node, {graph.placeholder("a"): graph.placeholder("b")})

--- a/tests/engine/frontend/test_replace.py
+++ b/tests/engine/frontend/test_replace.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-from dt_model.engine.frontend import graph, replace, linearize
+from dt_model.engine.frontend import graph, linearize, replace
 from dt_model.engine.numpybackend import executor
 
 
@@ -188,7 +188,6 @@ def test_identity_cases():
     assert replace.nodes(sum_a, {d: e}) is sum_a
 
 
-
 def test_replace_nodes_functional_evaluation():
     """Test that replacements produce functionally equivalent graphs."""
     # Create original graph: (a * 2) + (b * 3)
@@ -233,6 +232,7 @@ def test_replace_nodes_functional_evaluation():
 
 def test_replace_nodes_unsupported_type():
     """Test that an error is raised for unsupported node types."""
+
     # Create a custom node type not handled by the replace function
     class CustomNode(graph.Node):
         pass


### PR DESCRIPTION
This patch introduces functionality to replace specific nodes within a graph or subgraph, ensuring that all expressions referencing those nodes are correctly updated.

This is useful for model variation and symbolic rewrites, which we’re currently exploring at the model level in https://github.com/fbk-most/dt-model/pull/24. This diff was extracted and isolated from that work.

The overall design is loosely inspired by `sympy.subs`, but adapted to the graph representation used in the `engine`.

The replacement is minimal: unchanged nodes are preserved, while new nodes are created with fresh identities (including distinct `id` values).

The attached test suite provides reasonable confidence that this change does not introduce regressions or structural inconsistencies.