### PR TITLE
fix(pyproject.toml): use hatchling for packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ pytest
 Each pull request is automatically tested using GitHub Actions. The workflow
 is defined in [`.github/workflows/test.yml`](.github/workflows/test.yml).
 
+## Releasing
+
+1. Make sure the version number in `pyproject.toml` is correct.
+
+2. Make sure you are outside the virtual environment.
+
+3. Make sure `python3-hatchling` is installed (`sudo apt install python3-hatchling`).
+
+4. Make sure `twine` is installed (`sudo apt install twine`).
+
+5. Build the package using `python3 -m hatchling build`.
+
+6. Check whether the package is okay using `twine check dist/*`.
+
+7. Upload the package to PyPI using `twine upload dist/*`.
+
 ## License
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "civic-digital-twins"
@@ -12,7 +12,7 @@ authors = [
     { name = "Marco Pistore", email = "pistore@fbk.eu" },
     { name = "Simone Basso", email = "sibasso@fbk.eu" },
 ]
-license = { file = "LICENSE" }
+license = "Apache-2.0"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.11",
@@ -35,10 +35,8 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/fbk-most/dt-model"
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["dt_model*"]
-exclude = ["dt_model.examples*", "tests*"]
+[tool.hatch.build.targets.wheel]
+packages = ["dt_model"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
The whole packaging procedure is significantly simpler if we use hatchling as opposed to setuptools. With out configuration, the packages generated by setuptools were broken according to the

    twin check dist/*

command. Conversely, hatchling, which is more modern, looks great and passes all the checks.

While there, extend the README.md file to explain how to build releases and publish them on pypi.

As a future looking note, we will see to automatically package using GitHub actions in the future.