### PR TITLE
chore: enforce numpy documenting syntax

### DIFF
--- a/dt_model/__init__.py
+++ b/dt_model/__init__.py
@@ -1,3 +1,5 @@
+"""The dt_model package implements the tool for digital twins modeling and simulation."""
+
 from dt_model.model.model import Model
 from dt_model.simulation.ensemble import Ensemble
 from dt_model.symbols.constraint import Constraint

--- a/dt_model/engine/__init__.py
+++ b/dt_model/engine/__init__.py
@@ -1,9 +1,4 @@
-"""
-Execution Engine
-================
-
-The execution engine is responsible for allowing other code to
-create and evaluate models as computation graphs.
+"""The execution engine allows creating and evaluating computation graphs models.
 
 Modules:
     frontend: Graph construction and manipulation frontend.

--- a/dt_model/engine/atomic/__init__.py
+++ b/dt_model/engine/atomic/__init__.py
@@ -1,8 +1,5 @@
-"""
-Atomic Operations
-=================
+"""The atomic module provides thread-safe atomic operations for integer values.
 
-This module provides thread-safe atomic operations for integer values.
 It implements an atomic integer counter class similar to Go's atomic.Int64.
 """
 
@@ -19,9 +16,7 @@ class Int:
     """
 
     def __init__(self):
-        """
-        Initialize an atomic integer with a value of 0.
-        """
+        """Initialize an atomic integer with a value of 0."""
         self.__value = 0
         self.__lock = threading.Lock()
 
@@ -32,7 +27,8 @@ class Int:
         Args:
             value (int): The value to add.
 
-        Returns:
+        Returns
+        -------
             int: The new value after addition.
         """
         with self.__lock:
@@ -43,7 +39,8 @@ class Int:
         """
         Atomically load and return the current value.
 
-        Returns:
+        Returns
+        -------
             int: The current value.
         """
         with self.__lock:

--- a/dt_model/engine/frontend/__init__.py
+++ b/dt_model/engine/frontend/__init__.py
@@ -1,8 +1,4 @@
-"""
-Engine Frontend
-===============
-
-The engine frontend allows expressing models as computation graphs.
+"""The engine frontend allows expressing models as computation graphs.
 
 Modules:
     graph: Graph construction and manipulation.

--- a/dt_model/engine/frontend/graph.py
+++ b/dt_model/engine/frontend/graph.py
@@ -1,6 +1,4 @@
-"""
-Computation Graph Building
-==========================
+"""Computation Graph Building.
 
 This module allows to build an abstract computation graph using TensorFlow-like
 computation primitives and concepts. These primitives and concepts are also similar
@@ -135,7 +133,7 @@ _id_generator = atomic.Int()
 
 
 def ensure_node(value: Node | Scalar) -> Node:
-    """Converts a scalar value to a constant node if necessary."""
+    """Convert a scalar value to a constant node if necessary."""
     return value if isinstance(value, Node) else constant(value)
 
 
@@ -163,76 +161,99 @@ class Node:
         self.id = _id_generator.add(1)
 
     def __hash__(self) -> int:
-        # Note: we need to implement identity based hashing because we
-        # override the `__eq__` method to support lazy equality.
+        """Override hash to use identity-based hashing.
+
+        We need to do this because we override the `__eq__` method to support lazy equality.
+        """
         return id(self)
 
     # Arithmetic operators
     def __add__(self, other: Node | Scalar) -> Node:
+        """Add two nodes or a node and a scalar."""
         return add(self, ensure_node(other))
 
     def __radd__(self, other: Node | Scalar) -> Node:
+        """Add two nodes or a node and a scalar."""
         return add(ensure_node(other), self)
 
     def __sub__(self, other: Node | Scalar) -> Node:
+        """Subtract two nodes or a node and a scalar."""
         return subtract(self, ensure_node(other))
 
     def __rsub__(self, other: Node | Scalar) -> Node:
+        """Subtract two nodes or a node and a scalar."""
         return subtract(ensure_node(other), self)
 
     def __mul__(self, other: Node | Scalar) -> Node:
+        """Multiply two nodes or a node and a scalar."""
         return multiply(self, ensure_node(other))
 
     def __rmul__(self, other: Node | Scalar) -> Node:
+        """Multiply two nodes or a node and a scalar."""
         return multiply(ensure_node(other), self)
 
     def __truediv__(self, other: Node | Scalar) -> Node:
+        """Divide two nodes or a node and a scalar."""
         return divide(self, ensure_node(other))
 
     def __rtruediv__(self, other: Node | Scalar) -> Node:
+        """Divide two nodes or a node and a scalar."""
         return divide(ensure_node(other), self)
 
     # Comparison operators
     #
     # See the companion `__hash__` comment.
     def __eq__(self, other: Node | Scalar) -> Node:  # type: ignore
+        """Lazily check whether two nodes are equal."""
         return equal(self, ensure_node(other))
 
     def __ne__(self, other: Node | Scalar) -> Node:  # type: ignore
+        """Lazily check whether two nodes are not equal."""
         return not_equal(self, ensure_node(other))
 
     def __lt__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is less than another."""
         return less(self, ensure_node(other))
 
     def __le__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is less than or equal to another."""
         return less_equal(self, ensure_node(other))
 
     def __gt__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is greater than another."""
         return greater(self, ensure_node(other))
 
     def __ge__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is greater than or equal to another."""
         return greater_equal(self, ensure_node(other))
 
     # Logical operators
     def __and__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is logically and with another."""
         return logical_and(self, ensure_node(other))
 
     def __rand__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is logically and with another."""
         return logical_and(ensure_node(other), self)
 
     def __or__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is logically or with another."""
         return logical_or(self, ensure_node(other))
 
     def __ror__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is logically or with another."""
         return logical_or(ensure_node(other), self)
 
     def __xor__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is logically xor with another."""
         return logical_xor(self, ensure_node(other))
 
     def __rxor__(self, other: Node | Scalar) -> Node:
+        """Lazily check whether one node is logically xor with another."""
         return logical_xor(ensure_node(other), self)
 
     def __invert__(self) -> Node:
+        """Lazily check whether one node is logically not."""
         return logical_not(self)
 
 
@@ -430,8 +451,10 @@ class AxisOp(Node):
 
 
 class expand_dims(AxisOp):
-    """Adds new axes of size 1 to a tensor's shape, thus expanding the
-    tensor to a higher-dimensional space."""
+    """Adds new axes of size 1 to a tensor's shape.
+
+    This expands the tensor to a higher-dimensional space.
+    """
 
 
 class squeeze(AxisOp):
@@ -439,8 +462,10 @@ class squeeze(AxisOp):
 
 
 class project_using_sum(AxisOp):
-    """Computes sum of tensor elements along specified axes, thus
-    projecting the tensor onto a lower-dimensional space."""
+    """Computes sum of tensor elements along specified axes.
+
+    This projects the tensor to a lower-dimensional space.
+    """
 
 
 reduce_sum = project_using_sum
@@ -450,8 +475,10 @@ the dt-model is complete."""
 
 
 class project_using_mean(AxisOp):
-    """Computes mean of tensor elements along specified axes, thus
-    projecting the tensor onto a lower-dimensional space."""
+    """Computes mean of tensor elements along specified axes.
+
+    This projects the tensor to a lower-dimensional space.
+    """
 
 
 reduce_mean = project_using_mean
@@ -465,9 +492,11 @@ yakof into the dt-model is complete."""
 
 def tracepoint(node: Node) -> Node:
     """
-    Marks the node as a tracepoint and returns it. The tracepoint
-    will take effect while evaluating the node. We will print information
-    before evaluating the node, evaluate it, then print the result.
+    Mark the node as a tracepoint and returns it.
+
+    The tracepoint will take effect while evaluating the node. We will
+    print information before evaluating the node, evaluate it, then
+    print the result.
 
     This function acts like the unit in the category with semantic side
     effects depending on the debug operation that is requested.
@@ -478,8 +507,10 @@ def tracepoint(node: Node) -> Node:
 
 def breakpoint(node: Node) -> Node:
     """
-    Marks the node as a breakpoint and returns it. The breakpoint will
-    cause the interpreter to stop before evaluating the node.
+    Mark the node as a breakpoint and returns it.
+
+    The breakpoint will cause the interpreter to stop before
+    evaluating the node.
 
     This function acts like the unit in the category with semantic side
     effects depending on the debug operation that is requested.

--- a/dt_model/engine/frontend/linearize.py
+++ b/dt_model/engine/frontend/linearize.py
@@ -1,10 +1,7 @@
-"""
-Linearization of Computation Graphs
-===================================
+"""Provide functions to linearize computation graphs into execution plans.
 
-This module provides functions to linearize computation graphs into execution
-plans. It performs topological sorting of graph nodes, ensuring dependencies are
-evaluated before the nodes that depend on them.
+This module performs topological sorting of graph nodes, ensuring dependencies
+are evaluated before the nodes that depend on them.
 
 While we could directly rely on the node's creation ID to perform sorting on
 the graph, relying on topological sorting makes the code slightly more robust
@@ -44,14 +41,17 @@ def forest(*leaves: graph.Node) -> list[graph.Node]:
         *leaves: the nodes to start the linearization process from. Use the
             unpacking operator `*` to pass a list of nodes.
 
-    Returns:
+    Returns
+    -------
         Topologically sorted list of nodes forming an execution plan
 
-    Raises:
+    Raises
+    ------
         ValueError: If a cycle is detected in the graph
         TypeError: If an unknown node type is encountered
 
-    Examples:
+    Examples
+    --------
         >>> # Single output
         >>> plan = linearize.forest(output_node)
         >>>
@@ -61,7 +61,6 @@ def forest(*leaves: graph.Node) -> list[graph.Node]:
         >>> # List of outputs
         >>> plan = linearize.forest(*output_list)
     """
-
     # plan contains the linearized output
     plan: list[graph.Node] = []
 
@@ -72,8 +71,6 @@ def forest(*leaves: graph.Node) -> list[graph.Node]:
     visited: set[graph.Node] = set()
 
     def _visit(node: graph.Node) -> None:
-        """Internal function that visits a given node."""
-
         # Ensure we only visit a node at most once
         if node in visited:
             return
@@ -118,13 +115,14 @@ def _get_dependencies(node: graph.Node) -> list[graph.Node]:
     Args:
         node: The node to get dependencies for
 
-    Returns:
+    Returns
+    -------
         List of nodes that are direct dependencies
 
-    Raises:
+    Raises
+    ------
         TypeError: If the node type is unknown
     """
-
     if isinstance(node, graph.BinaryOp):
         return [node.left, node.right]
 

--- a/dt_model/engine/frontend/pretty.py
+++ b/dt_model/engine/frontend/pretty.py
@@ -1,9 +1,6 @@
-"""
-Pretty Printing for Computation Graphs
-======================================
+"""Convert computation graphs into readable string representations.
 
-This module provides facilities for converting computation graphs into
-readable string representations. It handles:
+This module handles:
 
 1. Operator precedence
 2. Parentheses insertion
@@ -76,11 +73,13 @@ def format(node: graph.Node) -> str:
     Args:
         node: The node to format
 
-    Returns:
+    Returns
+    -------
         A string representation with appropriate parentheses
         and operator precedence.
 
-    Examples:
+    Examples
+    --------
         >>> x = graph.placeholder("x")
         >>> y = graph.add(graph.multiply(x, 2), 1)
         >>> print(pretty.format(y))
@@ -93,17 +92,6 @@ def format(node: graph.Node) -> str:
 
 
 def _format(node: graph.Node, toplevel: bool, parent_precedence: int) -> str:
-    """Internal recursive formatter.
-
-    Args:
-        node: The node to format
-        parent_precedence: The precedence of the parent operation
-
-    Returns:
-        Formatted string with appropriate parentheses based on
-        operator precedence.
-    """
-
     # If we're not at top-level and we have a named node,
     # stop formatting and return the node name, which means
     # we're printing formulae aligned with what the user

--- a/dt_model/engine/numpybackend/__init__.py
+++ b/dt_model/engine/numpybackend/__init__.py
@@ -1,9 +1,6 @@
-"""
-NumPy Backend
-=============
+"""Provide a NumPy Backend for evaluating computation graphs.
 
-This package provides a NumPy-based execution backend for the computation graph
-defined in the frontend. It transforms the symbolic operations defined in the graph
+This package transforms the symbolic operations defined in the graph
 into concrete numerical computations using NumPy, thus evaluating the model
 represented by the computation graph.
 

--- a/dt_model/engine/numpybackend/debug.py
+++ b/dt_model/engine/numpybackend/debug.py
@@ -1,9 +1,4 @@
-"""
-Debugging Code
-==============
-
-This module contains debugging code.
-"""
+"""The debug module contains debugging code."""
 
 import numpy as np
 

--- a/dt_model/engine/numpybackend/dispatch.py
+++ b/dt_model/engine/numpybackend/dispatch.py
@@ -1,9 +1,4 @@
-"""
-Dispatch Operations
-===================
-
-This module contains the dispatch tables mapping frontend graph
-operations to the corresponding numpy operations.
+"""Dispatch tables mapping frontend graph operations to numpy operations.
 
 These tables are used by the evaluator to map symbolic operations in the graph
 to their concrete NumPy implementations. To extend the system with new operations,
@@ -68,7 +63,8 @@ def _expand_dims(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
         x: The input array to expand
         axis: The position where the new axis is placed
 
-    Returns:
+    Returns
+    -------
         Array with the expanded dimension
     """
     return np.expand_dims(x, axis)
@@ -81,7 +77,8 @@ def _reduce_sum(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
         x: The input array to reduce
         axis: The axis along which to perform the sum
 
-    Returns:
+    Returns
+    -------
         Array with the specified axis reduced by summation
     """
     return np.sum(x, axis=axis)
@@ -94,7 +91,8 @@ def _reduce_mean(x: np.ndarray, axis: graph.Axis) -> np.ndarray:
         x: The input array to reduce
         axis: The axis along which to compute the mean
 
-    Returns:
+    Returns
+    -------
         Array with the specified axis reduced by averaging
     """
     return np.mean(x, axis=axis)

--- a/dt_model/engine/numpybackend/executor.py
+++ b/dt_model/engine/numpybackend/executor.py
@@ -1,6 +1,4 @@
-"""
-Topologically-Sorted-Graph Executor
-===================================
+"""Topologically-Sorted-Graph Executor.
 
 An evaluator for computation graphs that processes nodes sorted in
 topological order. Unlike recursive evaluators, this executor requires
@@ -55,7 +53,8 @@ class State:
     Note that, if graph.NODE_FLAG_TRACE is set, the State will print the
     nodes provided to the constructor in its __post_init__ method.
 
-    Attributes:
+    Attributes
+    ----------
         values: A dictionary caching the result of the computation.
         flags: Bitmask containing debug flags (e.g., graph.NODE_FLAG_BREAK).
     """
@@ -64,6 +63,7 @@ class State:
     flags: int = 0
 
     def __post_init__(self):
+        """Print the placeholder values provided to the constructor."""
         if self.flags & graph.NODE_FLAG_TRACE != 0:
             nodes = sorted(self.values.keys(), key=lambda n: n.id)
             for node in nodes:
@@ -71,15 +71,17 @@ class State:
                 debug.print_evaluated_node(self.values[node], cached=True)
 
     def get_node_value(self, node: graph.Node) -> np.ndarray:
-        """Helper function to access the value associated with a node.
+        """Access the value associated with a node.
 
         Args:
             node: The node whose value to retrieve.
 
-        Returns:
+        Returns
+        -------
             The value associated with the node.
 
-        Raises:
+        Raises
+        ------
             NodeValueNotFound: If the node has not been evaluated.
         """
         try:
@@ -89,10 +91,9 @@ class State:
 
 
 def evaluate(state: State, node: graph.Node) -> np.ndarray:
-    """
-    Evaluates a node assuming that all dependent nodes have already
-    been evaluated and cached in the state. In other words, this
-    function assumes you have already linearized the graph. If this
+    """Evaluate a node given the current state.
+
+    This function assumes you have already linearized the graph. If this
     is not the case, evaluation will fail. Use the `frontend.linearize`
     module to ensure the graph is topologically sorted.
 
@@ -100,7 +101,8 @@ def evaluate(state: State, node: graph.Node) -> np.ndarray:
         state: The current executor state.
         node: The node to evaluate.
 
-    Raises:
+    Raises
+    ------
         NodeValueNotFound: If a dependent node has not been evaluated
             and therefore its value cannot be found in the state.
         UnsupportedNodeType: If the executor does not support the given node type.
@@ -108,7 +110,6 @@ def evaluate(state: State, node: graph.Node) -> np.ndarray:
         PlaceholderValueNotProvided: If a placeholder node has no value provided
             and no default value.
     """
-
     # 1. check whether node has been already evaluated (note that this
     # covers the case of placeholders provided via the state)
     if node in state.values:

--- a/dt_model/ensemble/__init__.py
+++ b/dt_model/ensemble/__init__.py
@@ -1,3 +1,5 @@
+"""Backward compatibility ensemble symbols."""
+
 from ..simulation.ensemble import Ensemble
 
 __all__ = ["Ensemble"]

--- a/dt_model/examples/__init__.py
+++ b/dt_model/examples/__init__.py
@@ -1,5 +1,5 @@
 """
-This package contains examples.
+The example package contains examples.
 
 We do not install examples, as they are not needed for the library
 to work. Yet, we include them in the main package for testing.

--- a/dt_model/examples/molveno/__init__.py
+++ b/dt_model/examples/molveno/__init__.py
@@ -1,6 +1,7 @@
 """
-This package contains a definition of the Molveno overtourism model, which
-is mainly used for exploration and testing purposes.
+Definition of the Molveno overtourism model.
+
+We mainly use this model for testing and exploration purposes.
 
 See https://github.com/tn-aixpa/overtourism/ for the actual model used
 in production, which depends on this package.

--- a/dt_model/examples/molveno/overtourism.py
+++ b/dt_model/examples/molveno/overtourism.py
@@ -1,4 +1,4 @@
-"""This module contains the (mostly-immutable) model definition."""
+"""Mostly-immutable model definition."""
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/dt_model/examples/molveno/presence_stats.py
+++ b/dt_model/examples/molveno/presence_stats.py
@@ -71,6 +71,7 @@ weekday = weekday_stats.index
 
 
 def tourist_presences_stats(weekday, season, weather):
+    """Calculate the statistics for tourist presences."""
     # Season
     mean = season_stats.loc[season, "mean_tourists"]
     std2 = season_stats.loc[season, "std_tourists"] ** 2
@@ -85,6 +86,7 @@ def tourist_presences_stats(weekday, season, weather):
 
 
 def excursionist_presences_stats(weekday, season, weather):
+    """Calculate the statistics for excursionist presences."""
     # Season
     mean = season_stats.loc[season, "mean_excursionists"]
     std2 = season_stats.loc[season, "std_excursionists"] ** 2

--- a/dt_model/internal/__init__.py
+++ b/dt_model/internal/__init__.py
@@ -1,6 +1,4 @@
-"""
-Internal Packages
-=================
+"""Internal Packages.
 
 This package groups together internal packages. The semantics of internal
 packages is that there is no API stability guarantee.

--- a/dt_model/internal/sympyke/__init__.py
+++ b/dt_model/internal/sympyke/__init__.py
@@ -1,6 +1,4 @@
-"""
-SymPy compatibility layer
-=========================
+"""SymPy compatibility layer.
 
 This package implements a tiny SymPy compatibility layer that maps
 sympy-like methods and functions to frontend.graph operations.

--- a/dt_model/internal/sympyke/piecewise.py
+++ b/dt_model/internal/sympyke/piecewise.py
@@ -1,6 +1,4 @@
-"""
-Piecewise Emulation
-===================
+"""Piecewise Emulation.
 
 This module emulates sympy.Piecewise using the tensor language frontend, by mapping
 a Piecewise invocation to a graph.multi_clause_where tensor.
@@ -19,29 +17,33 @@ Clause = tuple[Expr, Cond]
 
 
 def Piecewise(*clauses: Clause) -> graph.Node:
-    """Converts the provided clauses arranged according to the sympy.Piecewise
+    """Sympy's piecewise compatibility layer.
+
+    Converts the provided clauses arranged according to the sympy.Piecewise
     convention into a graph.multi_clause_where computation tensor.
 
     Args:
         *clauses: The clauses to be converted.
 
-    Returns:
+    Returns
+    -------
         The computation tensor representing the piecewise function.
 
-    Raises:
+    Raises
+    ------
         ValueError: If no clauses are provided.
     """
     return _to_tensor(_filter_clauses(clauses))
 
 
 def _filter_clauses(clauses: tuple[Clause, ...]) -> list[Clause]:
-    """This function removes the clauses after the first true clause, to
-    correctly emulate the sumpy.Piecewise behaviour.
+    """Remove the clauses after the first true clause.
 
     Args:
         clauses: The clauses to be filtered.
 
-    Returns:
+    Returns
+    -------
         The filtered clauses.
     """
     filtered: list[Clause] = []

--- a/dt_model/internal/sympyke/symbol.py
+++ b/dt_model/internal/sympyke/symbol.py
@@ -1,6 +1,4 @@
-"""
-Minimal support for symbols
-===========================
+"""Minimal support for symbols.
 
 This module implements minimal support for sympy-like symbols
 so that we can write dt_model models.
@@ -42,7 +40,7 @@ symbol_table = _SymbolTable()
 
 
 def Symbol(name: str) -> SymbolValue:
-    """Constructor to create a new SymbolValue by name.
+    """Create a new SymbolValue by name.
 
     Subsequent invocations with the same name return the same SymbolValue.
     """

--- a/dt_model/model/__init__.py
+++ b/dt_model/model/__init__.py
@@ -1,0 +1,1 @@
+"""Support for writing Digital Twin Models."""

--- a/dt_model/model/abstract_model.py
+++ b/dt_model/model/abstract_model.py
@@ -1,3 +1,5 @@
+"""Abstract model definition."""
+
 from __future__ import annotations
 
 from dt_model.symbols.constraint import Constraint
@@ -7,6 +9,8 @@ from dt_model.symbols.presence_variable import PresenceVariable
 
 
 class AbstractModel:
+    """Abstract model definition."""
+
     def __init__(
         self,
         name,

--- a/dt_model/model/instantiated_model.py
+++ b/dt_model/model/instantiated_model.py
@@ -1,8 +1,12 @@
+"""Allow instantiation of AbstractModel."""
+
 from dt_model.model.abstract_model import AbstractModel
 from dt_model.model.legacy_model import LegacyModel
 
 
 class InstantiatedModel:
+    """Instantiation of AbstractModel."""
+
     def __init__(self, abs: AbstractModel) -> None:
         self.abs = abs
         self.legacy = LegacyModel(abs.name, abs.cvs, abs.pvs, abs.indexes, abs.capacities, abs.constraints)

--- a/dt_model/model/legacy_model.py
+++ b/dt_model/model/legacy_model.py
@@ -1,3 +1,5 @@
+"""Legacy implementation of model evaluation."""
+
 from __future__ import annotations
 
 from functools import reduce
@@ -15,6 +17,8 @@ from ..symbols.presence_variable import PresenceVariable
 
 
 class LegacyModel:
+    """Legacy model evaluator."""
+
     def __init__(
         self,
         name,
@@ -36,12 +40,14 @@ class LegacyModel:
         self.index_vals = None
 
     def reset(self):
+        """Reset the model state."""
         self.grid = None
         self.field = None
         self.field_elements = None
         self.index_vals = None
 
     def evaluate(self, grid, ensemble):
+        """Evaluate the model using the given grid and ensemble."""
         assert self.grid is None
 
         # [pre] extract the weights and the size of the ensemble
@@ -128,14 +134,17 @@ class LegacyModel:
         return self.field
 
     def get_index_value(self, i: Index) -> float:
+        """Get the value of the given index."""
         assert self.index_vals is not None
         return self.index_vals[i.node]
 
     def get_index_mean_value(self, i: Index) -> float:
+        """Get the mean value of the given index."""
         assert self.index_vals is not None
         return np.average(self.index_vals[i.node])
 
     def compute_sustainable_area(self) -> float:
+        """Compute the sustainable area."""
         assert self.grid is not None
         assert self.field is not None
 
@@ -148,6 +157,7 @@ class LegacyModel:
 
     # TODO: change API - order of presence variables
     def compute_sustainability_index(self, presences: list) -> float:
+        """Compute the sustainability index."""
         assert self.grid is not None
         grid = self.grid
         field = self.field
@@ -156,6 +166,7 @@ class LegacyModel:
         return np.mean(index)
 
     def compute_sustainability_index_per_constraint(self, presences: list) -> dict:
+        """Compute the sustainability index per constraint."""
         assert self.grid is not None
         assert self.field_elements is not None
 
@@ -171,6 +182,7 @@ class LegacyModel:
         return indexes
 
     def compute_modal_line_per_constraint(self) -> dict:
+        """Compute the modal line per constraint."""
         assert self.grid is not None
         assert self.field_elements is not None
 
@@ -205,14 +217,14 @@ class LegacyModel:
             # avoid hardcoding of the length (10000)
 
             def _vertical(regr) -> tuple[tuple[float, float], tuple[float, float]]:
-                """Logic for computing the points with vertical regression"""
+                """Logic for computing the points with vertical regression."""
                 if regr.slope != 0.00:
                     return ((regr.intercept, 0.0), (0.0, -regr.intercept / regr.slope))
                 else:
                     return ((regr.intercept, regr.intercept), (0.0, 10000.0))
 
             def _horizontal(regr) -> tuple[tuple[float, float], tuple[float, float]]:
-                """Logic for computing the points with horizontal regression"""
+                """Logic for computing the points with horizontal regression."""
                 if regr.slope != 0.0:
                     return ((0.0, -regr.intercept / regr.slope), (regr.intercept, 0.0))
                 else:

--- a/dt_model/model/model.py
+++ b/dt_model/model/model.py
@@ -1,3 +1,5 @@
+"""High-level model API."""
+
 from __future__ import annotations
 
 from dt_model.model.abstract_model import AbstractModel
@@ -10,6 +12,8 @@ from dt_model.symbols.presence_variable import PresenceVariable
 
 
 class Model:
+    """High-level model API."""
+
     def __init__(
         self,
         name: str,
@@ -24,47 +28,58 @@ class Model:
 
     @property
     def name(self):
+        """Name of the model."""
         return self.abs.name
 
     # TODO: Remove, should be immutable
     @name.setter
     def name(self, value):
+        """Set the name of the model."""
         self.abs.name = value
 
     @property
     def cvs(self):
+        """List of context variables in the model."""
         return self.abs.cvs
 
     @property
     def pvs(self):
+        """List of presence variables in the model."""
         return self.abs.pvs
 
     @property
     def indexes(self):
+        """List of indexes in the model."""
         return self.abs.indexes
 
     @property
     def capacities(self):
+        """List of capacities in the model."""
         return self.abs.capacities
 
     @property
     def constraints(self):
+        """List of constraints in the model."""
         return self.abs.constraints
 
     @property
     def index_vals(self):
+        """List of index values in the model."""
         assert self.evaluation is not None
         return self.evaluation.index_vals
 
     @property
     def field_elements(self):
+        """List of field elements in the model."""
         assert self.evaluation is not None
         return self.evaluation.field_elements
 
     def reset(self):
+        """Reset the model state."""
         self.evaluation = None
 
     def evaluate(self, grid, ensemble):
+        """Evaluate the model on the given grid and ensemble."""
         assert self.evaluation is None
         evaluation = Evaluation(InstantiatedModel(self.abs))
         result = evaluation.evaluate(grid, ensemble)
@@ -72,26 +87,32 @@ class Model:
         return result
 
     def get_index_value(self, i: Index) -> float:
+        """Get the value of the model at the given index."""
         assert self.evaluation is not None
         return self.evaluation.get_index_value(i)
 
     def get_index_mean_value(self, i: Index) -> float:
+        """Get the mean value of the model at the given index."""
         assert self.evaluation is not None
         return self.evaluation.get_index_mean_value(i)
 
     def compute_sustainable_area(self) -> float:
+        """Compute the sustainable area of the model."""
         assert self.evaluation is not None
         return self.evaluation.compute_sustainable_area()
 
     # TODO: change API - order of presence variables
     def compute_sustainability_index(self, presences: list) -> float:
+        """Compute the sustainability index of the model given the presence variables."""
         assert self.evaluation is not None
         return self.evaluation.compute_sustainability_index(presences)
 
     def compute_sustainability_index_per_constraint(self, presences: list) -> dict:
+        """Compute the sustainability index per constraint of the model given the presence variables."""
         assert self.evaluation is not None
         return self.evaluation.compute_sustainability_index_per_constraint(presences)
 
     def compute_modal_line_per_constraint(self) -> dict:
+        """Compute the modal line per constraint of the model."""
         assert self.evaluation is not None
         return self.evaluation.compute_modal_line_per_constraint()

--- a/dt_model/simulation/__init__.py
+++ b/dt_model/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""Simulate running a model with specific input parameters."""

--- a/dt_model/simulation/ensemble.py
+++ b/dt_model/simulation/ensemble.py
@@ -1,3 +1,5 @@
+"""Implementation of the ensemble."""
+
 from __future__ import annotations
 
 from functools import reduce
@@ -6,7 +8,10 @@ from dt_model.model.model import Model
 
 
 class Ensemble:
+    """Iterator generating ensemble conditions."""
+
     def __init__(self, model: Model, scenario, cv_ensemble_size=20):
+        """Initialize the ensemble."""
         # TODO: what if cvs is empty?
         self.model = model
         self.ensemble = {}
@@ -23,11 +28,13 @@ class Ensemble:
                 self.size *= cv_ensemble_size
 
     def __iter__(self):
+        """Return an iterator over the ensemble."""
         self.pos = {k: 0 for k in self.ensemble.keys()}
         self.pos[list(self.ensemble.keys())[0]] = -1
         return self
 
     def __next__(self):
+        """Return the next ensemble condition."""
         for k in self.ensemble.keys():
             self.pos[k] += 1
             if self.pos[k] < len(self.ensemble[k]):

--- a/dt_model/simulation/evaluation.py
+++ b/dt_model/simulation/evaluation.py
@@ -1,43 +1,56 @@
+"""Code to evaluate a model in specific conditions."""
+
 from dt_model.model.instantiated_model import InstantiatedModel
 from dt_model.symbols.index import Index
 
 
 class Evaluation:
+    """Evaluate a model in specific conditions."""
+
     def __init__(self, inst: InstantiatedModel):
         self.inst = inst
 
     def evaluate(self, grid, ensemble):
+        """Evaluate the model in the given grid and ensemble conditions."""
         return self.inst.legacy.evaluate(grid, ensemble)
 
     @property
     def index_vals(self):
+        """Return the values of the indices."""
         return self.inst.legacy.index_vals
 
     @property
     def field_elements(self):
+        """Return the elements of the field."""
         return self.inst.legacy.field_elements
 
     def get_index_value(self, i: Index) -> float:
+        """Return the value of the index."""
         assert self.inst.legacy is not None
         return self.inst.legacy.get_index_value(i)
 
     def get_index_mean_value(self, i: Index) -> float:
+        """Return the mean value of the index."""
         assert self.inst.legacy is not None
         return self.inst.legacy.get_index_mean_value(i)
 
     def compute_sustainable_area(self) -> float:
+        """Return the sustainable area."""
         assert self.inst.legacy is not None
         return self.inst.legacy.compute_sustainable_area()
 
     # TODO: change API - order of presence variables
     def compute_sustainability_index(self, presences: list) -> float:
+        """Return the sustainability index."""
         assert self.inst.legacy is not None
         return self.inst.legacy.compute_sustainability_index(presences)
 
     def compute_sustainability_index_per_constraint(self, presences: list) -> dict:
+        """Return the sustainability index per constraint."""
         assert self.inst.legacy is not None
         return self.inst.legacy.compute_sustainability_index_per_constraint(presences)
 
     def compute_modal_line_per_constraint(self) -> dict:
+        """Return the modal line per constraint."""
         assert self.inst.legacy is not None
         return self.inst.legacy.compute_modal_line_per_constraint()

--- a/dt_model/symbols/__init__.py
+++ b/dt_model/symbols/__init__.py
@@ -1,1 +1,1 @@
-"""This package contains the symbols used by the civic digital twins model."""
+"""Symbols used by the civic digital twins model."""

--- a/dt_model/symbols/constraint.py
+++ b/dt_model/symbols/constraint.py
@@ -1,5 +1,4 @@
-"""
-This module defines the Constraint symbol.
+"""Constraint symbol definition.
 
 A constraint represents the relationship between the capacity of a given
 resource and the usage of that resource. We model two types of constraints:

--- a/dt_model/symbols/context_variable.py
+++ b/dt_model/symbols/context_variable.py
@@ -1,8 +1,9 @@
 """
-This module defines context variables. A context variable models a model variable
-that is not directly controlled by the model, but that can influence the model
-behavior. In general, context variables are sampled from a distribution, either
-categorical or continuous.
+Context variables definition.
+
+A context variable models a model variable that is not directly controlled
+by the model, but that can influence the model behavior. In general, context
+variables are sampled from a distribution, either categorical or continuous.
 """
 
 from __future__ import annotations
@@ -17,22 +18,21 @@ from ..internal.sympyke.symbol import SymbolValue
 
 
 class ContextVariable(ABC):
-    """
-    Class to represent a context variable.
-    """
+    """Class to represent a context variable."""
 
     def __init__(self, name: str) -> None:
         self.name = name
         self.node = graph.placeholder(name)
 
     @abstractmethod
-    def support_size(self) -> int: ...
+    def support_size(self) -> int:
+        """Return the size of the support of the context variable."""
+        ...
 
     @abstractmethod
     def sample(self, nr: int = 1, *, subset: list | None = None, force_sample: bool = False) -> list:
         """
-        Returns a list of tuples (probability, value)  from the support variable or provided
-        subset.
+        Return a list of tuples (probability, value)  from the support variable or provided subset.
 
         If the distribution discrete, or if a subset is provided, it may return the whole support/subset,
         if its size is not larger that the requested number of sample values.
@@ -68,9 +68,11 @@ class UniformCategoricalContextVariable(ContextVariable):
         self.size = len(self.values)
 
     def support_size(self) -> int:
+        """Return the size of the support."""
         return self.size
 
     def sample(self, nr: int = 1, *, subset: list | None = None, force_sample: bool = False) -> list:
+        """Sample values from the support."""
         # TODO: subset (if defined) should be a subset of the support (also: with repetitions?)
 
         (values, size) = (self.values, self.size) if subset is None else (subset, len(subset))
@@ -83,9 +85,7 @@ class UniformCategoricalContextVariable(ContextVariable):
 
 
 class CategoricalContextVariable(ContextVariable):
-    """
-    Class to represent a categorical context variable.
-    """
+    """Class to represent a categorical context variable."""
 
     def __init__(self, name: str, distribution: dict) -> None:
         super().__init__(name)
@@ -95,9 +95,11 @@ class CategoricalContextVariable(ContextVariable):
         # TODO: check if distribution is, indeed, a distribution (sum = 1)
 
     def support_size(self) -> int:
+        """Return the size of the support of the categorical context variable."""
         return self.size
 
     def sample(self, nr: int = 1, *, subset: list | None = None, force_sample: bool = False) -> list:
+        """Return a sample from the categorical context variable."""
         (values, size) = (self.values, self.size) if subset is None else (subset, len(subset))
 
         if force_sample or nr < size:
@@ -113,9 +115,9 @@ class CategoricalContextVariable(ContextVariable):
 
 
 class ContinuousContextVariable(ContextVariable):
-    """
-    Class to represent a continuous context variable;
-    the distribution is any scipy.stats continuous random variable.
+    """Class to represent a continuous context variable.
+
+    The distribution is any scipy.stats continuous random variable.
     """
 
     def __init__(self, name: str, rvc: rv_continuous) -> None:
@@ -124,9 +126,11 @@ class ContinuousContextVariable(ContextVariable):
         # TODO: check if distribution is, indeed, a distribution (sum = 1)
 
     def support_size(self) -> int:
+        """Return the size of the support of the continuous context variable."""
         return -1  # TODO: do better
 
     def sample(self, nr: int = 1, *, subset: list | None = None, force_sample: bool = False) -> list:
+        """Sample from the continuous context variable."""
         if force_sample or subset is None or nr < len(subset):
             assert nr > 0
             return [(1 / nr, r) for r in list(self.rvc.rvs(size=nr))]

--- a/dt_model/symbols/index.py
+++ b/dt_model/symbols/index.py
@@ -1,8 +1,9 @@
 """
-This module contains the classes to represent index variables. An index variable is
-a variable that is used to represent a conversion factor or a parameter that is used
-to calculate the value of a symbol. The index variable can be a constant, a distribution,
-or a symbolic expression.
+Classes representing index variables.
+
+An index variable is a variable that is used to represent a conversion factor or a
+parameter that is used to calculate the value of a symbol. The index variable can
+be a constant, a distribution, or a symbolic expression.
 """
 
 from __future__ import annotations
@@ -25,19 +26,21 @@ class Distribution(Protocol):
         x: float | np.ndarray,
         *args,
         **kwds,
-    ) -> float | np.ndarray: ...
+    ) -> float | np.ndarray:
+        """Cumulative distribution function."""
+        ...
 
     def rvs(
         self,
         size: int | tuple[int, ...] | None = None,
         **kwargs,
-    ) -> float | np.ndarray: ...
+    ) -> float | np.ndarray:
+        """Random variable sampling."""
+        ...
 
 
 class Index:
-    """
-    Class to represent an index variable.
-    """
+    """Class to represent an index variable."""
 
     def __init__(
         self,
@@ -80,9 +83,7 @@ class Index:
 
 
 class UniformDistIndex(Index):
-    """
-    Class to represent an index as a uniform distribution
-    """
+    """Class to represent an index as a uniform distribution."""
 
     def __init__(
         self,
@@ -106,32 +107,35 @@ class UniformDistIndex(Index):
 
     @property
     def loc(self):
+        """Location parameter."""
         return self._loc
 
     @loc.setter
     def loc(self, new_loc):
+        """Location parameter setter."""
         if self._loc != new_loc:
             self._loc = new_loc
             self.value = stats.uniform(loc=self._loc, scale=self._scale)
 
     @property
     def scale(self):
+        """Scale parameter."""
         return self._scale
 
     @scale.setter
     def scale(self, new_scale):
+        """Scale parameter setter."""
         if self._scale != new_scale:
             self._scale = new_scale
             self.value = stats.uniform(loc=self._loc, scale=self._scale)
 
     def __str__(self):
+        """Represent the index using a string."""
         return f"uniform_dist_idx({self.loc}, {self.scale})"
 
 
 class LognormDistIndex(Index):
-    """
-    Class to represent an index as a lognorm distribution
-    """
+    """Class to represent an index as a lognorm distribution."""
 
     def __init__(
         self,
@@ -157,42 +161,47 @@ class LognormDistIndex(Index):
 
     @property
     def loc(self):
+        """Location parameter of the lognorm distribution."""
         return self._loc
 
     @loc.setter
     def loc(self, new_loc):
+        """Set the location parameter of the lognorm distribution."""
         if self._loc != new_loc:
             self._loc = new_loc
             self.value = stats.lognorm(loc=self._loc, scale=self._scale, s=self.s)
 
     @property
     def scale(self):
+        """Scale parameter of the lognorm distribution."""
         return self._scale
 
     @scale.setter
     def scale(self, new_scale):
+        """Set the scale parameter of the lognorm distribution."""
         if self._scale != new_scale:
             self._scale = new_scale
             self.value = stats.lognorm(loc=self._loc, scale=self._scale, s=self._s)
 
     @property
     def s(self):
+        """Shape parameter of the lognorm distribution."""
         return self._s
 
     @s.setter
     def s(self, new_s):
+        """Set the shape parameter of the lognorm distribution."""
         if self._s != new_s:
             self._s = new_s
             self.value = stats.lognorm(loc=self._loc, scale=self._scale, s=self._s)
 
     def __str__(self):
+        """Represent the index using a string."""
         return f"longnorm_dist_idx({self.loc}, {self.scale}, {self.s})"
 
 
 class TriangDistIndex(Index):
-    """
-    Class to represent an index as a triangular distribution
-    """
+    """Class to represent an index as a triangular distribution."""
 
     def __init__(
         self,
@@ -218,42 +227,47 @@ class TriangDistIndex(Index):
 
     @property
     def loc(self):
+        """Location parameter of the triangular distribution."""
         return self._loc
 
     @loc.setter
     def loc(self, new_loc):
+        """Set the location parameter of the triangular distribution."""
         if self._loc != new_loc:
             self._loc = new_loc
             self.value = stats.triang(loc=self._loc, scale=self._scale, c=self._c)
 
     @property
     def scale(self):
+        """Scale parameter of the triangular distribution."""
         return self._scale
 
     @scale.setter
     def scale(self, new_scale):
+        """Set the scale parameter of the triangular distribution."""
         if self._scale != new_scale:
             self._scale = new_scale
             self.value = stats.triang(loc=self._loc, scale=self._scale, c=self._c)
 
     @property
     def c(self):
+        """Shape parameter of the triangular distribution."""
         return self._c
 
     @c.setter
     def c(self, new_c):
+        """Set the shape parameter of the triangular distribution."""
         if self._c != new_c:
             self._c = new_c
             self.value = stats.triang(loc=self._loc, scale=self._scale, c=self._c)
 
     def __str__(self):
+        """Return a string representation of the triangular distribution index."""
         return f"triang_dist_idx({self.loc}, {self.scale}, {self.c})"
 
 
 class ConstIndex(Index):
-    """
-    Class to represent an index as a constant
-    """
+    """Class to represent an index as a constant."""
 
     def __init__(
         self,
@@ -267,23 +281,24 @@ class ConstIndex(Index):
 
     @property
     def v(self):
+        """Value of the constant index."""
         return self._v
 
     @v.setter
     def v(self, new_v):
+        """Set the value of the constant index."""
         if self._v != new_v:
             self._v = new_v
             self.value = new_v
             self.node = graph.constant(new_v, self.name)
 
     def __str__(self):
+        """Return a string representation of the constant index."""
         return f"const_idx({self.v})"
 
 
 class SymIndex(Index):
-    """
-    Class to represent an index as a symbolic value
-    """
+    """Class to represent an index as a symbolic value."""
 
     def __init__(
         self,
@@ -297,4 +312,5 @@ class SymIndex(Index):
         self.sym_value = value
 
     def __str__(self):
+        """Return a string representation of the symbolic index."""
         return f"sympy_idx({self.value})"

--- a/dt_model/symbols/presence_variable.py
+++ b/dt_model/symbols/presence_variable.py
@@ -1,6 +1,8 @@
 """
-This module defines presence variables. A presence variable is a model variable that
-represents the presence of a certain entity in the modeled system.
+Define presence variables.
+
+A presence variable is a model variable that represents the
+presence of a certain entity in the modeled system.
 """
 
 from __future__ import annotations
@@ -16,9 +18,7 @@ from .context_variable import ContextVariable
 
 
 class PresenceVariable:
-    """
-    Class to represent a presence variable.
-    """
+    """Class to represent a presence variable."""
 
     def __init__(
         self,
@@ -32,9 +32,8 @@ class PresenceVariable:
         self.distribution = distribution
 
     def sample(self, cvs: dict | None = None, nr: int = 1) -> np.ndarray:
-        """
-        Returns a list of values sampled from the presence variable or provided
-        subset.
+        """Return values sampled from the presence variable or provided subset.
+
         If a distribution is provided in the constructor, the values will be
         sampled according to that distribution.
 

--- a/examples/overtourism_molveno.py
+++ b/examples/overtourism_molveno.py
@@ -1,5 +1,7 @@
-"""This example allows to interactively explore the frozen Molveno model
-included into the source tree as an illustrative example."""
+"""Example to interactively explore the frozen Molveno model.
+
+We include this model into the source tree as an illustrative example.
+"""
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -41,14 +43,17 @@ ensemble_size = 20  # TODO: make configurable; may it be a CV parameter?
 
 
 def scale(p, v):
+    """Scale a probability by a value."""
     return p * v
 
 
 def threshold(p, t):
+    """Threshold a probability by a value."""
     return min(p, t) + 0.05 / (1 + np.exp(-(p - t)))
 
 
 def plot_scenario(ax, model, situation, title):
+    """Plot a scenario."""
     ensemble = Ensemble(model, situation, cv_ensemble_size=ensemble_size)
     tt = np.linspace(0, t_max, t_sample + 1)
     ee = np.linspace(0, e_max, e_sample + 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ line-ending = "lf"
 skip-magic-trailing-comma = false
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "D"]
 extend-select = ["W", "Q"]
 
 [tool.ruff.lint.pydocstyle]

--- a/tests/engine/frontend/test_linearize.py
+++ b/tests/engine/frontend/test_linearize.py
@@ -11,8 +11,8 @@ def find_node(plan, target_node):
     """Find the index of a node in the plan using identity comparison.
 
     We MUST use this method for finding the nodes because nodes override
-    their __eq__ method to implement lazy comparison."""
-
+    their __eq__ method to implement lazy comparison.
+    """
     for idx, node in enumerate(plan):
         if target_node is node:
             return idx

--- a/tests/engine/numpybackend/test_executor.py
+++ b/tests/engine/numpybackend/test_executor.py
@@ -387,7 +387,7 @@ def test_execute_plan_helper():
     # to simplify the common pattern of executing a linearized plan
 
     def execute_plan(plan, initial_state):
-        """Helper to execute a full plan with the given initial state."""
+        """Execute a full plan with the given initial state."""
         state = initial_state
         for node in plan:
             executor.evaluate(state, node)

--- a/tests/examples/molveno/test_overtourism.py
+++ b/tests/examples/molveno/test_overtourism.py
@@ -17,7 +17,7 @@ from dt_model.internal.sympyke.symbol import Symbol, SymbolValue
 
 
 def compare_constraint_results(got: dict[Constraint, np.ndarray], expect: dict[str, np.ndarray]) -> list[str]:
-    """Helper function to compare constraint results and return any failures."""
+    """Compare constraint results and return any failures."""
     # Ensure that we have the expected constraints
     if len(got) != len(expect):
         return [f"Constraint count mismatch: expected {len(expect)}, got {len(got)}"]

--- a/tests/internal/sympyke/test_piecewise.py
+++ b/tests/internal/sympyke/test_piecewise.py
@@ -12,7 +12,6 @@ from dt_model.internal.sympyke import Piecewise, Symbol
 
 def test_piecewise_basics():
     """Make sure that Piecewise works as intended with Symbol."""
-
     # Create the placeholders as symbols
     x = Symbol("x")
     y = Symbol("y")

--- a/tests/symbols/test_context_variable.py
+++ b/tests/symbols/test_context_variable.py
@@ -14,16 +14,19 @@ from dt_model import (
 
 @pytest.fixture
 def uniform_cv():
+    """Create a UniformCategoricalContextVariable."""
     return UniformCategoricalContextVariable("Uniform", ["a", "b", "c", "d"])
 
 
 @pytest.fixture
 def categorical_cv():
+    """Create a CategoricalContextVariable."""
     return CategoricalContextVariable("Categorical", {"a": 0.1, "b": 0.2, "c": 0.3, "d": 0.4})
 
 
 @pytest.fixture
 def continuous_cv():
+    """Create a ContinuousContextVariable."""
     return ContinuousContextVariable("Continuous", scipy.stats.norm(3, 1))
 
 
@@ -36,6 +39,7 @@ def continuous_cv():
     ],
 )
 def test_cv(cv_fixture_name, sizes, values, request):
+    """Test ContextVariable classes."""
     cv = request.getfixturevalue(cv_fixture_name)
     print(f"Testing: {cv.name} (support size = {cv.support_size()})")
     # TODO(bassosimone): turn these prints into assertions


### PR DESCRIPTION
I am going to consider this activity as an experiment to understand whether enforcing numpy docstring syntax is actually good for us or too strict. Speaking in purely practical terms, doing this right now is good for me. I have a separate codebase (bassosimone/yakof) that I need to keep in sync, so I am trying to reduce the code duplication. In turn, predictable formatting helps me to do this.