### PR TITLE
fix: type correctness around symbols and context variables

### DIFF
--- a/dt_model/simulation/ensemble.py
+++ b/dt_model/simulation/ensemble.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 from functools import reduce
 
 from dt_model.model.model import Model
+from dt_model.symbols.context_variable import ContextVariable
+from dt_model.internal.sympyke.symbol import SymbolValue
 
 
 class Ensemble:
     """Iterator generating ensemble conditions."""
 
-    def __init__(self, model: Model, scenario, cv_ensemble_size=20):
+    def __init__(
+        self,
+        model: Model,
+        scenario: dict[ContextVariable, list[SymbolValue]],
+        cv_ensemble_size: int = 20,
+    ):
         """Initialize the ensemble."""
         # TODO: what if cvs is empty?
         self.model = model

--- a/dt_model/simulation/ensemble.py
+++ b/dt_model/simulation/ensemble.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from functools import reduce
 
+from dt_model.internal.sympyke.symbol import SymbolValue
 from dt_model.model.model import Model
 from dt_model.symbols.context_variable import ContextVariable
-from dt_model.internal.sympyke.symbol import SymbolValue
 
 
 class Ensemble:

--- a/dt_model/symbols/context_variable.py
+++ b/dt_model/symbols/context_variable.py
@@ -30,7 +30,13 @@ class ContextVariable(ABC):
         ...
 
     @abstractmethod
-    def sample(self, nr: int = 1, *, subset: list | None = None, force_sample: bool = False) -> list:
+    def sample(
+        self,
+        nr: int = 1,
+        *,
+        subset: list | None = None,
+        force_sample: bool = False,
+    ) -> list:
         """
         Return a list of tuples (probability, value)  from the support variable or provided subset.
 
@@ -62,16 +68,22 @@ class UniformCategoricalContextVariable(ContextVariable):
     All values returned in sample have the same probability value, even if all the support is returned.
     """
 
-    def __init__(self, name: str, values: list) -> None:
+    def __init__(self, name: str, values: list[SymbolValue]) -> None:
         super().__init__(name)
-        self.values = [value.name if isinstance(value, SymbolValue) else value for value in values]
+        self.values = values
         self.size = len(self.values)
 
     def support_size(self) -> int:
         """Return the size of the support."""
         return self.size
 
-    def sample(self, nr: int = 1, *, subset: list | None = None, force_sample: bool = False) -> list:
+    def sample(
+        self,
+        nr: int = 1,
+        *,
+        subset: list[SymbolValue] | None = None,
+        force_sample: bool = False,
+    ) -> list[tuple[float, SymbolValue]]:
         """Sample values from the support."""
         # TODO: subset (if defined) should be a subset of the support (also: with repetitions?)
 
@@ -87,9 +99,9 @@ class UniformCategoricalContextVariable(ContextVariable):
 class CategoricalContextVariable(ContextVariable):
     """Class to represent a categorical context variable."""
 
-    def __init__(self, name: str, distribution: dict) -> None:
+    def __init__(self, name: str, distribution: dict[SymbolValue, float]) -> None:
         super().__init__(name)
-        self.distribution = {k.name if isinstance(k, SymbolValue) else k: v for k, v in distribution.items()}
+        self.distribution = distribution
         self.values = list(self.distribution.keys())
         self.size = len(self.values)
         # TODO: check if distribution is, indeed, a distribution (sum = 1)
@@ -98,7 +110,13 @@ class CategoricalContextVariable(ContextVariable):
         """Return the size of the support of the categorical context variable."""
         return self.size
 
-    def sample(self, nr: int = 1, *, subset: list | None = None, force_sample: bool = False) -> list:
+    def sample(
+        self,
+        nr: int = 1,
+        *,
+        subset: list[SymbolValue] | None = None,
+        force_sample: bool = False,
+    ) -> list[tuple[float, SymbolValue]]:
         """Return a sample from the categorical context variable."""
         (values, size) = (self.values, self.size) if subset is None else (subset, len(subset))
 

--- a/examples/overtourism_molveno.py
+++ b/examples/overtourism_molveno.py
@@ -29,7 +29,7 @@ from dt_model.internal.sympyke import Symbol
 S_Base = {}
 
 # Good weather situation
-S_Good_Weather = {CV_weather: [Symbol("good")]}
+S_Good_Weather = {CV_weather: [Symbol("good"), Symbol("unsettled")]}
 
 # Bad weather situation
 S_Bad_Weather = {CV_weather: [Symbol("bad")]}

--- a/tests/symbols/test_context_variable.py
+++ b/tests/symbols/test_context_variable.py
@@ -50,8 +50,8 @@ def continuous_cv():
 @pytest.mark.parametrize(
     "cv_fixture_name,sizes,values",
     [
-        ("uniform_cv", [1, 2, 4, 8], ["a", "b", "c"]),
-        ("categorical_cv", [1, 2, 4, 8], ["a", "b", "c"]),
+        ("uniform_cv", [1, 2, 4, 8], [Symbol("a"), Symbol("b"), Symbol("c")]),
+        ("categorical_cv", [1, 2, 4, 8], [Symbol("a"), Symbol("b"), Symbol("c")]),
         ("continuous_cv", [1, 2, 4, 8], [2.1, 3.0, 3.9]),
     ],
 )

--- a/tests/symbols/test_context_variable.py
+++ b/tests/symbols/test_context_variable.py
@@ -10,18 +10,35 @@ from dt_model import (
     ContinuousContextVariable,
     UniformCategoricalContextVariable,
 )
+from dt_model.internal.sympyke import Symbol
 
 
 @pytest.fixture
 def uniform_cv():
     """Create a UniformCategoricalContextVariable."""
-    return UniformCategoricalContextVariable("Uniform", ["a", "b", "c", "d"])
+    return UniformCategoricalContextVariable(
+        "Uniform",
+        [
+            Symbol("a"),
+            Symbol("b"),
+            Symbol("c"),
+            Symbol("d"),
+        ],
+    )
 
 
 @pytest.fixture
 def categorical_cv():
     """Create a CategoricalContextVariable."""
-    return CategoricalContextVariable("Categorical", {"a": 0.1, "b": 0.2, "c": 0.3, "d": 0.4})
+    return CategoricalContextVariable(
+        "Categorical",
+        {
+            Symbol("a"): 0.1,
+            Symbol("b"): 0.2,
+            Symbol("c"): 0.3,
+            Symbol("d"): 0.4,
+        },
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
This diff adds type annotations and updates the context variables code to make the expectations explicity regarding when we want symbols, and when we want context variables.

Additionally, we change the molveno example to include a more complex weather situation, to exercise the previous bug.

The related issue is https://github.com/fbk-most/dt-model/issues/37.

If this diff is accepted, I'll add more tests either to this PR or to a follow up PR, depending on how we proceed.