### PR TITLE
cleanup: avoid using executor.evaluate()

### DIFF
--- a/civic_digital_twins/dt_model/engine/__init__.py
+++ b/civic_digital_twins/dt_model/engine/__init__.py
@@ -1,7 +1,10 @@
 """The execution engine allows creating and evaluating computation graphs models.
 
 Modules:
+    atomic: Atomic counters.
+    compileflags: Common definitions of flags influencing the engine.
     frontend: Graph construction and manipulation frontend.
+    numpybackend: NumPy-specific backend
 """
 
 # SPDX-License-Identifier: Apache-2.0

--- a/civic_digital_twins/dt_model/engine/numpybackend/__init__.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/__init__.py
@@ -37,8 +37,7 @@ sorted_nodes = linearize.forest(z)
 state = executor.State(values={x: np.array(2), y: np.array(3)})
 
 # Execute the graph
-for node in sorted_nodes:
-    executor.evaluate(state, node)
+executor.evaluate_nodes(state, *sorted_nodes)
 
 # Access result
 result = state.values[z]  # array(5)

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -192,8 +192,7 @@ class Evaluation:
 
         # [eval] actually evaluate all the nodes
         state = executor.State(c_subs)
-        for node in linearize.forest(*all_nodes):
-            executor.evaluate(state, node)
+        executor.evaluate_nodes(state, *linearize.forest(*all_nodes))
 
         # CHANGED FROM HERE
         # [post] compute the usage map

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -61,8 +61,7 @@ def test_placeholder_evaluation():
     # Test missing binding
     state_missing = executor.State({})
     with pytest.raises(executor.PlaceholderValueNotProvided):
-        for node in plan_x:
-            executor.evaluate(state_missing, node)
+        executor.evaluate_nodes(state_missing, *plan_x)
 
 
 def test_arithmetic_operations():
@@ -273,7 +272,7 @@ def test_error_handling():
         pass
 
     with pytest.raises(executor.UnsupportedNodeType):
-        executor.evaluate(executor.State({}), unknown_node())
+        executor.evaluate_single_node(executor.State({}), unknown_node())
 
     # Test unknown operation
     class unknown_binary(graph.BinaryOp):
@@ -293,7 +292,7 @@ def test_error_handling():
     # Not following the plan order - trying to evaluate y before x
     state = executor.State({x: np.array([1.0])})
     with pytest.raises(executor.NodeValueNotFound):
-        executor.evaluate(state, y)  # Should fail, x not evaluated yet
+        executor.evaluate_single_node(state, y)  # Should fail, x not evaluated yet
 
 
 def test_reduction_operations():
@@ -407,7 +406,7 @@ def test_state_value_access():
     state = executor.State({x: np.array([1.0, 2.0, 3.0])})
 
     # Evaluate constant node
-    executor.evaluate(state, y)
+    executor.evaluate_single_node(state, y)
 
     # Test that node exists in state.values
     assert y in state.values

--- a/tests/dt_model/internal/sympyke/test_operators.py
+++ b/tests/dt_model/internal/sympyke/test_operators.py
@@ -27,8 +27,7 @@ def test_eq_basics():
         }
     )
 
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     # Expected: True, False, True, False
     expected = np.array([True, False, True, False])
@@ -53,8 +52,7 @@ def test_eq_with_constants():
         }
     )
 
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     expected = np.array([False, False, True, False])
     assert np.array_equal(state.values[eq1], expected)
@@ -77,8 +75,7 @@ def test_eq_with_mixed_inputs():
         }
     )
 
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     expected = np.array([True, False, True])
     assert np.array_equal(state.values[eq], expected)
@@ -107,8 +104,7 @@ def test_eq_chaining():
         }
     )
 
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     # Expected: True, True, False, False
     expected = np.array([True, True, False, False])

--- a/tests/dt_model/internal/sympyke/test_piecewise.py
+++ b/tests/dt_model/internal/sympyke/test_piecewise.py
@@ -42,8 +42,7 @@ def test_piecewise_basics():
     )
 
     # Actually evaluate the piecewise function
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     # Ensure the result is the expected one
     expect = np.array([2, 27, 256])
@@ -60,8 +59,7 @@ def test_piecewise_with_scalars():
     state = executor.State(values={})
 
     # Evaluate
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     assert state.values[result] == 1
 
@@ -116,8 +114,7 @@ def test_piecewise_with_constant_conditions():
     )
 
     # Evaluate the piecewise function
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     # Since the second condition is True, the result should be expr2
     result = state.values[pw]
@@ -139,7 +136,6 @@ def test_piecewise_only_default_case():
     state = executor.State(values={})
 
     # Evaluate
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     assert state.values[pw] == 1

--- a/tests/dt_model/internal/sympyke/test_symbol.py
+++ b/tests/dt_model/internal/sympyke/test_symbol.py
@@ -52,8 +52,7 @@ def test_symbol_execution():
     )
 
     # Evaluate
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     # Check result
     expected = np.array([5, 7, 9])
@@ -79,8 +78,7 @@ def test_symbol_multiple_operations():
         }
     )
 
-    for node in plan:
-        executor.evaluate(state, node)
+    executor.evaluate_nodes(state, *plan)
 
     # Expected: (1+4)*2, (2+5)*3, (3+6)*4 = 10, 21, 36
     expected = np.array([10, 21, 36])


### PR DESCRIPTION
In most cases, we can use executor.evaluate_nodes(). In some cases, executor.evaluate_single_node() will suffice.

This diff is a cleanup I did not include in https://github.com/fbk-most/civic-digital-twins/pull/73.