### PR TITLE
feat(forest): repr explicit node type

### DIFF
--- a/civic_digital_twins/dt_model/engine/frontend/forest.py
+++ b/civic_digital_twins/dt_model/engine/frontend/forest.py
@@ -18,6 +18,17 @@ from typing import Any
 from . import graph, linearize
 
 
+def _node_type_repr(node: graph.Node) -> str:
+    """Return one of graph.placeholder, graph.constant, and graph.Node."""
+    return (
+        "graph.placeholder"
+        if isinstance(node, graph.placeholder)
+        else "graph.constant"
+        if isinstance(node, graph.constant)
+        else "graph.Node"
+    )
+
+
 @dataclass(frozen=True)
 class Tree:
     """Tree representing the computation of a root node.
@@ -68,7 +79,7 @@ class Tree:
 
         # Format the function name
         root = self.root()
-        inputs = ", ".join(f"n{input.id}: graph.Node" for input in self.inputs)
+        inputs = ", ".join(f"n{input.id}: {_node_type_repr(input)}" for input in self.inputs)
         lines.append(f"def t{root.id}({inputs}) -> graph.Node:")
 
         # Format the function body

--- a/tests/dt_model/engine/frontend/test_forest.py
+++ b/tests/dt_model/engine/frontend/test_forest.py
@@ -44,7 +44,7 @@ def test_partition():
     assert trees[2].root() is h
 
     # Ensure that the string representation is correct
-    expect = f"""def t{g.id}(n{y.id}: graph.Node, n{k1.id}: graph.Node, n{c.id}: graph.Node) -> graph.Node:
+    expect = f"""def t{g.id}(n{y.id}: graph.placeholder, n{k1.id}: graph.constant, n{c.id}: graph.Node) -> graph.Node:
     n{d.id} = graph.exp(node=n{y.id}, name='d')
     n{e.id} = graph.add(left=n{c.id}, right=n{k1.id}, name='e')
     n{f.id} = graph.log(node=n{e.id}, name='f')


### PR DESCRIPTION
This diff improves the debuggability of a tree by making it explicit which nodes are placeholders and constants among the set of dependencies within a given tree belonging to a DAG.

Part of https://github.com/fbk-most/civic-digital-twins/issues/58.