### PR TITLE
fix(executor): call functions by name

### DIFF
--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -237,7 +237,7 @@ class State:
 
     values: dict[graph.Node, np.ndarray]
     flags: int = compileflags.defaults
-    functions: dict[graph.Node, Functor] = field(default_factory=dict)
+    functions: dict[str, Functor] = field(default_factory=dict)
 
     def __post_init__(self):
         """Print the placeholder values provided to the constructor."""
@@ -487,9 +487,9 @@ def _eval_function(state: State, node: graph.Node) -> np.ndarray:
     for key, value in node.kwargs.items():
         kwargs[key] = state.get_node_value(value)
     try:
-        function = state.functions[node]
+        function = state.functions[node.name]
     except KeyError:
-        raise FunctionNotFound(f"executor: cannot find functor for: {node}")
+        raise FunctionNotFound(f"executor: cannot find functor for: {node.name}")
     return function(*args, **kwargs)
 
 

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -675,7 +675,7 @@ def test_user_defined_function():
             c: np.asarray(55),
         },
         functions={
-            f: functor,
+            "f": functor,
         },
     )
     executor.evaluate_nodes(state1, *linearize.forest(g))


### PR DESCRIPTION
Calling functions by node is wrong since it prevents to apply the same function instance to multiple nodes, and then we need to bend ourselves backwards(TM) to reuse user-defined functions.

Instead, do the most logical thing and call them by name, which allows us to reuse the same function many times.

Noticed while working on https://github.com/fbk-most/civic-digital-twins/issues/57.