### PR TITLE
feat(model): replace distribution-specific index classes with DistributionIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - unreleased
+
+### Added
+
+**Distribution indexes**
+
+- `DistributionIndex(name, distribution, params)` — a single, distribution-agnostic
+  index class that replaces the three distribution-specific classes removed below.
+  `distribution` is any callable (e.g. a `scipy.stats` frozen-distribution factory)
+  that accepts `**params` and returns a `Distribution`-conformant object; `params` is
+  a `dict[str, Any]` forwarded verbatim to it, so scipy validates the values at
+  construction time.  `DistributionIndex.params` supports full replacement
+  (`idx.params = {"loc": 0, "scale": 1}`) and partial update via the Python
+  dict-merge operator (`idx.params |= {"loc": 200}`).
+
+### Removed
+
+**Distribution indexes - Breaking changes**
+
+- `UniformDistIndex` — use `DistributionIndex("x", scipy.stats.uniform, {"loc": 0, "scale": 1})`.
+- `LognormDistIndex` — use `DistributionIndex("x", scipy.stats.lognorm, {"loc": 0, "scale": 1, "s": 0.5})`.
+- `TriangDistIndex` — use `DistributionIndex("x", scipy.stats.triang, {"loc": 0, "scale": 1, "c": 0.5})`.
 
 ## [0.6.0] - 2026-03-01
 
@@ -110,6 +131,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2025-07-14
 
-[Unreleased]: https://github.com/fbk-most/dt-model/compare/v0.6.0...HEAD
+[0.7.0]: https://github.com/fbk-most/dt-model/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/fbk-most/dt-model/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/fbk-most/dt-model/releases/tag/v0.5.0

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -4,13 +4,11 @@ from .engine.frontend.graph import piecewise
 from .model import (
     ConstIndex,
     Distribution,
+    DistributionIndex,
     GenericIndex,
     Index,
-    LognormDistIndex,
     Model,
     TimeseriesIndex,
-    TriangDistIndex,
-    UniformDistIndex,
 )
 from .simulation import DistributionEnsemble, Ensemble, Evaluation, EvaluationResult, WeightedScenario
 
@@ -18,16 +16,14 @@ __all__ = [
     "ConstIndex",
     "Distribution",
     "DistributionEnsemble",
+    "DistributionIndex",
     "Ensemble",
     "Evaluation",
     "EvaluationResult",
     "GenericIndex",
     "Index",
-    "LognormDistIndex",
     "Model",
     "TimeseriesIndex",
-    "TriangDistIndex",
-    "UniformDistIndex",
     "WeightedScenario",
     "piecewise",
 ]

--- a/civic_digital_twins/dt_model/model/__init__.py
+++ b/civic_digital_twins/dt_model/model/__init__.py
@@ -3,23 +3,19 @@
 from .index import (
     ConstIndex,
     Distribution,
+    DistributionIndex,
     GenericIndex,
     Index,
-    LognormDistIndex,
     TimeseriesIndex,
-    TriangDistIndex,
-    UniformDistIndex,
 )
 from .model import Model
 
 __all__ = [
     "ConstIndex",
     "Distribution",
+    "DistributionIndex",
     "GenericIndex",
     "Index",
-    "LognormDistIndex",
     "Model",
     "TimeseriesIndex",
-    "TriangDistIndex",
-    "UniformDistIndex",
 ]

--- a/civic_digital_twins/dt_model/model/index.py
+++ b/civic_digital_twins/dt_model/model/index.py
@@ -9,10 +9,9 @@ be a constant, a distribution, or a symbolic expression.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Protocol, cast, runtime_checkable
+from typing import Any, Callable, Protocol, cast, runtime_checkable
 
 import numpy as np
-from scipy import stats
 
 from ..engine.frontend import graph
 
@@ -231,176 +230,60 @@ class Index(GenericIndex):
         self._node = value
 
 
-class UniformDistIndex(Index):
-    """Class to represent an index as a uniform distribution."""
+class DistributionIndex(Index):
+    """Index backed by any scipy-compatible distribution.
+
+    Parameters
+    ----------
+    name:
+        Human-readable name for this index.
+    distribution:
+        A callable (e.g. ``scipy.stats.uniform``) that, when called with
+        ``**params``, returns a frozen ``Distribution``-conformant object.
+    params:
+        Keyword arguments forwarded verbatim to *distribution*.  scipy
+        validates the parameter values at construction time.
+
+    Examples
+    --------
+    >>> from scipy import stats
+    >>> idx = DistributionIndex("parking capacity", stats.uniform, {"loc": 350.0, "scale": 100.0})
+    >>> idx.params |= {"loc": 400.0}   # partial update — scipy re-validates
+    """
 
     def __init__(
         self,
         name: str,
-        loc: float,
-        scale: float,
+        distribution: Callable[..., Any],
+        params: dict[str, Any],
     ) -> None:
-        super().__init__(
-            name,
-            cast(
-                Distribution,
-                stats.uniform(loc=loc, scale=scale),
-            ),
-        )
-        self._loc = loc
-        self._scale = scale
+        self._distribution = distribution
+        self._params = dict(params)
+        super().__init__(name, cast(Distribution, distribution(**params)))
 
     @property
-    def loc(self):
-        """Location parameter."""
-        return self._loc
-
-    @loc.setter
-    def loc(self, new_loc):
-        """Location parameter setter."""
-        if self._loc != new_loc:
-            self._loc = new_loc
-            self.value = stats.uniform(loc=self._loc, scale=self._scale)
+    def distribution(self) -> Callable[..., Any]:
+        """The callable used to create the frozen distribution."""
+        return self._distribution
 
     @property
-    def scale(self):
-        """Scale parameter."""
-        return self._scale
+    def params(self) -> dict[str, Any]:
+        """Copy of the parameters used to create the frozen distribution."""
+        return dict(self._params)
 
-    @scale.setter
-    def scale(self, new_scale):
-        """Scale parameter setter."""
-        if self._scale != new_scale:
-            self._scale = new_scale
-            self.value = stats.uniform(loc=self._loc, scale=self._scale)
+    @params.setter
+    def params(self, new_params: dict[str, Any]) -> None:
+        """Re-freeze the distribution with new params.
 
-    def __str__(self):
-        """Represent the index using a string."""
-        return f"uniform_dist_idx({self.loc}, {self.scale})"
+        scipy validates the parameter values; invalid params raise at
+        assignment time.  Supports full replacement or partial update via
+        the dict-merge operator::
 
-
-class LognormDistIndex(Index):
-    """Class to represent an index as a lognorm distribution."""
-
-    def __init__(
-        self,
-        name: str,
-        loc: float,
-        scale: float,
-        s: float,
-    ) -> None:
-        super().__init__(
-            name,
-            cast(
-                Distribution,
-                stats.lognorm(loc=loc, scale=scale, s=s),
-            ),
-        )
-        self._loc = loc
-        self._scale = scale
-        self._s = s
-
-    @property
-    def loc(self):
-        """Location parameter of the lognorm distribution."""
-        return self._loc
-
-    @loc.setter
-    def loc(self, new_loc):
-        """Set the location parameter of the lognorm distribution."""
-        if self._loc != new_loc:
-            self._loc = new_loc
-            self.value = stats.lognorm(loc=self._loc, scale=self._scale, s=self.s)
-
-    @property
-    def scale(self):
-        """Scale parameter of the lognorm distribution."""
-        return self._scale
-
-    @scale.setter
-    def scale(self, new_scale):
-        """Set the scale parameter of the lognorm distribution."""
-        if self._scale != new_scale:
-            self._scale = new_scale
-            self.value = stats.lognorm(loc=self._loc, scale=self._scale, s=self._s)
-
-    @property
-    def s(self):
-        """Shape parameter of the lognorm distribution."""
-        return self._s
-
-    @s.setter
-    def s(self, new_s):
-        """Set the shape parameter of the lognorm distribution."""
-        if self._s != new_s:
-            self._s = new_s
-            self.value = stats.lognorm(loc=self._loc, scale=self._scale, s=self._s)
-
-    def __str__(self):
-        """Represent the index using a string."""
-        return f"longnorm_dist_idx({self.loc}, {self.scale}, {self.s})"
-
-
-class TriangDistIndex(Index):
-    """Class to represent an index as a triangular distribution."""
-
-    def __init__(
-        self,
-        name: str,
-        loc: float,
-        scale: float,
-        c: float,
-    ) -> None:
-        super().__init__(
-            name,
-            cast(
-                Distribution,
-                stats.triang(loc=loc, scale=scale, c=c),
-            ),
-        )
-        self._loc = loc
-        self._scale = scale
-        self._c = c
-
-    @property
-    def loc(self):
-        """Location parameter of the triangular distribution."""
-        return self._loc
-
-    @loc.setter
-    def loc(self, new_loc):
-        """Set the location parameter of the triangular distribution."""
-        if self._loc != new_loc:
-            self._loc = new_loc
-            self.value = stats.triang(loc=self._loc, scale=self._scale, c=self._c)
-
-    @property
-    def scale(self):
-        """Scale parameter of the triangular distribution."""
-        return self._scale
-
-    @scale.setter
-    def scale(self, new_scale):
-        """Set the scale parameter of the triangular distribution."""
-        if self._scale != new_scale:
-            self._scale = new_scale
-            self.value = stats.triang(loc=self._loc, scale=self._scale, c=self._c)
-
-    @property
-    def c(self):
-        """Shape parameter of the triangular distribution."""
-        return self._c
-
-    @c.setter
-    def c(self, new_c):
-        """Set the shape parameter of the triangular distribution."""
-        if self._c != new_c:
-            self._c = new_c
-            self.value = stats.triang(loc=self._loc, scale=self._scale, c=self._c)
-
-    def __str__(self):
-        """Return a string representation of the triangular distribution index."""
-        return f"triang_dist_idx({self.loc}, {self.scale}, {self.c})"
+            idx.params = {"loc": 200.0, "scale": 100.0}  # full replacement
+            idx.params |= {"loc": 200.0}                 # partial update (Python 3.9+)
+        """
+        self._params = dict(new_params)
+        self.value = cast(Distribution, self._distribution(**self._params))
 
 
 class ConstIndex(Index):

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -57,9 +57,7 @@ defines all index types.  The class hierarchy is:
 ```
 GenericIndex  (ABC)
 ├── Index
-│   ├── UniformDistIndex
-│   ├── LognormDistIndex
-│   ├── TriangDistIndex
+│   ├── DistributionIndex
 │   └── ConstIndex
 └── TimeseriesIndex
 ```
@@ -92,12 +90,16 @@ determines the mode:
 | `None` | explicit placeholder (abstract) | `graph.placeholder` |
 
 ```python
-from civic_digital_twins.dt_model.model.index import (
-    Index, UniformDistIndex, ConstIndex
-)
 from scipy import stats
+from civic_digital_twins.dt_model.model.index import (
+    ConstIndex, DistributionIndex, Index
+)
 
 # Distribution-backed (abstract — must be resolved in each scenario)
+# Pass any scipy-compatible distribution callable and a params dict:
+cap_dist = DistributionIndex("capacity", stats.uniform, {"loc": 400.0, "scale": 200.0})
+
+# Or use Index directly with a pre-frozen distribution:
 mu = Index("mu", stats.norm(loc=0.5, scale=0.1))
 
 # Constant
@@ -110,10 +112,14 @@ load = Index("load", mu * cap)
 demand = Index("demand", None)
 ```
 
-The concrete subclasses `UniformDistIndex`, `LognormDistIndex`,
-`TriangDistIndex`, and `ConstIndex` are convenience wrappers that
-construct the appropriate `scipy.stats` frozen distribution or scalar
-constant and pass it to `Index.__init__`.
+`DistributionIndex(name, distribution, params)` accepts any callable that
+returns a `Distribution`-conformant object (e.g. any `scipy.stats`
+distribution) plus a `params` dict forwarded verbatim.  The `params`
+property supports full replacement (`idx.params = {...}`) and partial
+update via the Python dict-merge operator (`idx.params |= {"loc": 200}`).
+
+`ConstIndex` is a convenience wrapper that accepts a scalar constant and
+passes it to `Index.__init__`.
 
 ### TimeseriesIndex
 
@@ -157,11 +163,12 @@ can inspect which indexes are abstract.
 and are not returned.
 
 ```python
+from scipy import stats
 from civic_digital_twins.dt_model.model.model import Model
-from civic_digital_twins.dt_model.model.index import UniformDistIndex, Index
+from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
 
-x = UniformDistIndex("x", loc=0.0, scale=10.0)
-y = UniformDistIndex("y", loc=0.0, scale=10.0)
+x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
+y = DistributionIndex("y", stats.uniform, {"loc": 0.0, "scale": 10.0})
 z = Index("z", x + y)
 
 model = Model("demo", [x, y, z])
@@ -289,13 +296,14 @@ axes.
 
 ```python
 import numpy as np
+from scipy import stats
 from civic_digital_twins.dt_model import Evaluation, Model
-from civic_digital_twins.dt_model.model.index import UniformDistIndex, Index
+from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
 from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
 
 # Define the model
-x = UniformDistIndex("x", loc=0.0, scale=10.0)
-y = UniformDistIndex("y", loc=0.0, scale=10.0)
+x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
+y = DistributionIndex("y", stats.uniform, {"loc": 0.0, "scale": 10.0})
 z = Index("z", x + y)
 model = Model("demo", [x, y, z])
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,18 +26,18 @@ engine layer see [`docs/design/dd-cdt-engine.md`](design/dd-cdt-engine.md).)
 ## 1 — Define the model
 
 Define indexes as attributes of a `Model` subclass (or pass a list to
-`Model` directly).  Use `UniformDistIndex`, `LognormDistIndex`, or
-`TriangDistIndex` for uncertain parameters and plain `Index` for formulas
-and constants.
+`Model` directly).  Use `DistributionIndex` for uncertain parameters and
+plain `Index` for formulas and constants.
 
 ```python
 import numpy as np
+from scipy import stats
 from civic_digital_twins.dt_model import Model
-from civic_digital_twins.dt_model.model.index import Index, UniformDistIndex
+from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
 
 # Two uncertain parameters
-fuel_efficiency = UniformDistIndex("fuel_efficiency_km_l", loc=10.0, scale=5.0)
-distance         = UniformDistIndex("distance_km",          loc=50.0, scale=30.0)
+fuel_efficiency = DistributionIndex("fuel_efficiency_km_l", stats.uniform, {"loc": 10.0, "scale": 5.0})
+distance        = DistributionIndex("distance_km",          stats.uniform, {"loc": 50.0, "scale": 30.0})
 
 # Derived formula: litres consumed
 litres = Index("litres", distance / fuel_efficiency)

--- a/examples/doc/doc_getting_started.py
+++ b/examples/doc/doc_getting_started.py
@@ -1,18 +1,19 @@
 """Runnable snippets from docs/getting-started.md."""
 
 import numpy as np
+from scipy import stats
 
 from civic_digital_twins.dt_model import DistributionEnsemble, Evaluation, Model
 from civic_digital_twins.dt_model.engine.frontend import graph
 from civic_digital_twins.dt_model.engine.numpybackend import executor
-from civic_digital_twins.dt_model.model.index import Index, TimeseriesIndex, UniformDistIndex
+from civic_digital_twins.dt_model.model.index import DistributionIndex, Index, TimeseriesIndex
 
 # ---------------------------------------------------------------------------
 # getting-started.md §1 — Define the model
 # ---------------------------------------------------------------------------
 
-fuel_efficiency = UniformDistIndex("fuel_efficiency_km_l", loc=10.0, scale=5.0)
-distance = UniformDistIndex("distance_km", loc=50.0, scale=30.0)
+fuel_efficiency = DistributionIndex("fuel_efficiency_km_l", stats.uniform, {"loc": 10.0, "scale": 5.0})
+distance = DistributionIndex("distance_km", stats.uniform, {"loc": 50.0, "scale": 30.0})
 
 litres = Index("litres", distance / fuel_efficiency)
 co2_per_litre = Index("co2_per_litre", 2.31)

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -6,9 +6,9 @@ from scipy import stats
 from civic_digital_twins.dt_model import Evaluation, Model
 from civic_digital_twins.dt_model.model.index import (
     ConstIndex,
+    DistributionIndex,
     Index,
     TimeseriesIndex,
-    UniformDistIndex,
 )
 from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
 
@@ -48,8 +48,8 @@ assert demand_ts.value is None
 # dd-cdt-model.md — Model: abstract_indexes / is_instantiated
 # ---------------------------------------------------------------------------
 
-x = UniformDistIndex("x", loc=0.0, scale=10.0)
-y = UniformDistIndex("y", loc=0.0, scale=10.0)
+x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
+y = DistributionIndex("y", stats.uniform, {"loc": 0.0, "scale": 10.0})
 z = Index("z", x + y)
 
 model = Model("demo", [x, y, z])
@@ -75,8 +75,8 @@ assert y in assignments
 # dd-cdt-model.md — End-to-End Example (1-D mode)
 # ---------------------------------------------------------------------------
 
-x2 = UniformDistIndex("x2", loc=0.0, scale=10.0)
-y2 = UniformDistIndex("y2", loc=0.0, scale=10.0)
+x2 = DistributionIndex("x2", stats.uniform, {"loc": 0.0, "scale": 10.0})
+y2 = DistributionIndex("y2", stats.uniform, {"loc": 0.0, "scale": 10.0})
 z2 = Index("z2", x2 + y2)
 model2 = Model("demo2", [x2, y2, z2])
 

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -10,9 +10,10 @@ if str(_examples_dir) not in sys.path:
     sys.path.insert(0, str(_examples_dir))
 
 import numpy as np
+from scipy import stats
 
 from civic_digital_twins.dt_model import Evaluation, piecewise
-from civic_digital_twins.dt_model.model.index import Distribution, Index, TriangDistIndex
+from civic_digital_twins.dt_model.model.index import Distribution, DistributionIndex, Index
 from overtourism_molveno.overtourism_metamodel import (
     CategoricalContextVariable,
     Constraint,
@@ -68,7 +69,7 @@ assert PV_visitors.value is None  # placeholder (axis in grid evaluation)
 # ---------------------------------------------------------------------------
 
 # Capacity with uncertainty
-I_C_beach = TriangDistIndex("beach_capacity", loc=3000.0, scale=2000.0, c=0.5)
+I_C_beach = DistributionIndex("beach_capacity", stats.triang, {"loc": 3000.0, "scale": 2000.0, "c": 0.5})
 
 # Usage factor: depends on context variable (bad weather reduces beach use)
 I_U_beach_visitors = Index(

--- a/examples/mobility_bologna/mobility_bologna.py
+++ b/examples/mobility_bologna/mobility_bologna.py
@@ -15,7 +15,7 @@ from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.ticker import FuncFormatter
 from scipy import stats
 
-from civic_digital_twins.dt_model import DistributionEnsemble, Index, Model, TimeseriesIndex, UniformDistIndex
+from civic_digital_twins.dt_model import DistributionEnsemble, DistributionIndex, Index, Model, TimeseriesIndex
 from civic_digital_twins.dt_model.engine.frontend import graph
 from civic_digital_twins.dt_model.engine.numpybackend import executor
 from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
@@ -83,7 +83,7 @@ class BolognaModel(Model):
 
         self.I_P_fraction_exempted = Index("exempted vehicles %", 0.15)
 
-        self.I_B_p50_cost = UniformDistIndex("cost 50% threshold", loc=4.00, scale=7.00)
+        self.I_B_p50_cost = DistributionIndex("cost 50% threshold", stats.uniform, {"loc": 4.00, "scale": 7.00})
         self.I_B_p50_anticipating = Index("anticipation 50% likelihood", 0.5)
         self.I_B_p50_anticipation = Index("anticipation distribution 50% threshold", 0.25)
         self.I_B_p50_postponing = Index("postponement 50% likelihood", 0.8)

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -2,8 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from scipy import stats
+
 from civic_digital_twins.dt_model import piecewise
-from civic_digital_twins.dt_model.model.index import Index, LognormDistIndex, TriangDistIndex, UniformDistIndex
+from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
 
 try:
     from .molveno_presence_stats import (
@@ -49,10 +51,12 @@ PV_excursionists = PresenceVariable("excursionists", [CV_weekday, CV_season, CV_
 
 # Capacity indexes
 
-I_C_parking = UniformDistIndex("parking capacity", loc=350.0, scale=100.0)
-I_C_beach = UniformDistIndex("beach capacity", loc=6000.0, scale=1000.0)
-I_C_accommodation = LognormDistIndex("accommodation capacity", s=0.125, loc=0.0, scale=5000.0)
-I_C_food = TriangDistIndex("food service capacity", loc=3000.0, scale=1000.0, c=0.5)
+I_C_parking = DistributionIndex("parking capacity", stats.uniform, {"loc": 350.0, "scale": 100.0})
+I_C_beach = DistributionIndex("beach capacity", stats.uniform, {"loc": 6000.0, "scale": 1000.0})
+I_C_accommodation = DistributionIndex(
+    "accommodation capacity", stats.lognorm, {"s": 0.125, "loc": 0.0, "scale": 5000.0}
+)
+I_C_food = DistributionIndex("food service capacity", stats.triang, {"loc": 3000.0, "scale": 1000.0, "c": 0.5})
 
 # Usage indexes
 
@@ -83,7 +87,7 @@ I_Xa_excursionists_per_vehicle = Index("excursionists per vehicle allocation fac
 I_Xo_tourists_parking = Index("tourists in parking rotation factor", 1.02)
 I_Xo_excursionists_parking = Index("excursionists in parking rotation factor", 3.5)
 
-I_Xo_tourists_beach = UniformDistIndex("tourists on beach rotation factor", loc=1.0, scale=2.0)
+I_Xo_tourists_beach = DistributionIndex("tourists on beach rotation factor", stats.uniform, {"loc": 1.0, "scale": 2.0})
 I_Xo_excursionists_beach = Index("excursionists on beach rotation factor", 1.02)
 
 I_Xa_tourists_accommodation = Index("tourists per accommodation allocation factor", 1.05)

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -84,12 +84,13 @@ dense range of visitor counts.
 ## 3 — Constraints
 
 ```python
+from scipy import stats
 from civic_digital_twins.dt_model import piecewise
-from civic_digital_twins.dt_model.model.index import Index, TriangDistIndex
+from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
 from overtourism_molveno.overtourism_metamodel import Constraint
 
 # Capacity with uncertainty
-I_C_beach = TriangDistIndex("beach_capacity", loc=3000.0, scale=2000.0, c=0.5)
+I_C_beach = DistributionIndex("beach_capacity", stats.triang, {"loc": 3000.0, "scale": 2000.0, "c": 0.5})
 
 # Usage factor: depends on context variable (bad weather reduces beach use)
 I_U_beach_visitors = Index(


### PR DESCRIPTION
 ## Summary

- Removes `UniformDistIndex`, `LognormDistIndex`, and `TriangDistIndex` — three distribution-specific `Index` subclasses, each hardcoding a single `scipy.stats` distribution and duplicating parameter management logic.
- Adds `DistributionIndex(name, distribution, params)`: a single, distribution-agnostic class that accepts any callable (e.g. any `scipy.stats` factory) plus a `params` dict forwarded verbatim to it. `scipy` validates parameters at construction time.
- `DistributionIndex.params` supports full replacement (`idx.params = {...}`) and partial update via the dict-merge operator (`idx.params |= {"loc": 200}`).
- `scipy` import removed from `model/index.py`; callers supply the distribution callable, keeping the index layer distribution-agnostic.
- All examples, docs, exports, and tests migrated to the new API.

## Breaking changes

- `UniformDistIndex`, `LognormDistIndex`, `TriangDistIndex` removed. Migration:
- `UniformDistIndex("x", loc=0, scale=1)` → `DistributionIndex("x", scipy.stats.uniform, {"loc": 0, "scale": 1})`
- `LognormDistIndex("x", loc=0, scale=1, s=0.5)` → `DistributionIndex("x", scipy.stats.lognorm, {"loc": 0, "scale": 1, "s": 0.5})`
- `TriangDistIndex("x", loc=0, scale=1, c=0.5)` → `DistributionIndex("x", scipy.stats.triang, {"loc": 0, "scale": 1, "c": 0.5})`

