### PR TITLE
feat(example): modular rewrite of Molveno overtourism model (step 3 of v0.8.0 modularity plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `__main__` updated to use `m.expose.*` for plot data; graphs saved via
   `fig.savefig()` (headless-safe).
 
+**Molveno overtourism example — modular rewrite**
+
+- `molveno_model.py` decomposed into five concern sub-models with explicit typed
+  interfaces: `PresenceModel` (CVs and PVs as `Outputs`), `ParkingModel`,
+  `BeachModel`, `AccommodationModel`, `FoodModel`.
+- Every `i_*` parameter — including uncertain `DistributionIndex` values — is an
+  `Input` to the sub-model that uses it; default values are created by
+  `MolvenoModel` and passed via constructors.
+- `MolvenoModel` wires the five sub-models and subclasses `OvertourismModel` so
+  that `OvertourismEnsemble` and `evaluate_scenario` work without modification.
+- All original module-level names (`M_Base`, `CV_*`, `PV_*`, `I_P_*`) preserved
+  as aliases — `overtourism_molveno.py` requires no changes.
+
+### Deprecated
+
+- **`indexes=` argument to `Model.__init__`**: passing a flat index list
+  explicitly emits a `DeprecationWarning`.  Use the dataclass-based
+  `inputs=` / `outputs=` / `expose=` API instead.  The legacy path will
+  be removed in a future version.
+
 ## [0.7.0] - 2026-03-15
 
 ### Added

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -1,11 +1,86 @@
-"""Molveno overtourism model definition."""
+"""Molveno overtourism model definition — modular decomposition.
+
+The model is split into five concern sub-models:
+
+:class:`PresenceModel` — *Stage 1, context and presence*
+    **Inputs**: —
+    **Outputs**: ``cv_weekday``, ``cv_season``, ``cv_weather``,
+    ``pv_tourists``, ``pv_excursionists``
+
+:class:`ParkingModel` — *Parking usage*
+    **Inputs**: ``pv_tourists``, ``pv_excursionists``, ``cv_weather``,
+    ``i_u_tourists_parking``, ``i_u_excursionists_parking``,
+    ``i_xa_tourists_per_vehicle``, ``i_xa_excursionists_per_vehicle``,
+    ``i_xo_tourists_parking``, ``i_xo_excursionists_parking``,
+    ``i_c_parking``
+    **Outputs**: ``i_u_parking``
+
+:class:`BeachModel` — *Beach usage*
+    **Inputs**: ``pv_tourists``, ``pv_excursionists``, ``cv_weather``,
+    ``i_u_tourists_beach``, ``i_u_excursionists_beach``,
+    ``i_xo_tourists_beach`` *(uncertain)*, ``i_xo_excursionists_beach``,
+    ``i_c_beach``
+    **Outputs**: ``i_u_beach``
+
+:class:`AccommodationModel` — *Accommodation usage*
+    **Inputs**: ``pv_tourists``,
+    ``i_u_tourists_accommodation``, ``i_xa_tourists_accommodation``,
+    ``i_c_accommodation``
+    **Outputs**: ``i_u_accommodation``
+
+:class:`FoodModel` — *Food-service usage*
+    **Inputs**: ``pv_tourists``, ``pv_excursionists``, ``cv_weather``,
+    ``i_u_tourists_food``, ``i_u_excursionists_food``,
+    ``i_xa_visitors_food``, ``i_xo_visitors_food``, ``i_c_food``
+    **Outputs**: ``i_u_food``
+
+:class:`MolvenoModel` — *Root, owns all* ``i_*`` *defaults*
+    Creates all ``i_*`` indexes with their default values and passes them
+    to the concern sub-models.  Forwards ``PresenceModel`` outputs as
+    needed.  Retains the domain attributes (``cvs``, ``pvs``,
+    ``constraints``) required by
+    :class:`~overtourism_molveno.overtourism_metamodel.OvertourismEnsemble`.
+
+
+Design rules:
+
+* **All** ``i_*`` parameters are ``Inputs`` to the sub-model that uses
+  them, including uncertain ``DistributionIndex`` values.  The default
+  values are created by :class:`MolvenoModel` and passed down via
+  constructors.  A caller who wants to override a parameter simply
+  supplies a different index object at construction time.
+* All context variables (``cv_*``) and presence variables (``pv_*``) are
+  ``Outputs`` of :class:`PresenceModel`.  ``cv_weather`` is also wired as
+  an ``Input`` to the three concern sub-models that contain
+  weather-dependent piecewise formulas.
+* Each concern sub-model's ``Outputs`` contains only the usage-formula
+  index (``i_u_*``).  Capacity indexes (``i_c_*``) remain as ``Inputs``
+  because they are parameters, not computed results.
+* Each concern sub-model stores its
+  :class:`~overtourism_molveno.overtourism_metamodel.Constraint` as a
+  plain instance attribute (``self.constraint``) because
+  :class:`~overtourism_molveno.overtourism_metamodel.Constraint` is not a
+  :class:`~dt_model.model.index.GenericIndex` and must not appear inside
+  an :class:`~dt_model.model.model.IOProxy`.
+* :class:`MolvenoModel` subclasses
+  :class:`~overtourism_molveno.overtourism_metamodel.OvertourismModel` so
+  that the existing
+  :class:`~overtourism_molveno.overtourism_metamodel.OvertourismEnsemble`
+  and :func:`~overtourism_molveno.overtourism_molveno.evaluate_scenario`
+  code works without modification.
+"""
 
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
 
 from scipy import stats
 
 from civic_digital_twins.dt_model import piecewise
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+from civic_digital_twins.dt_model.model.index import DistributionIndex, GenericIndex, Index
+from civic_digital_twins.dt_model.model.model import Model
 
 try:
     from .molveno_presence_stats import (
@@ -38,133 +113,715 @@ except ImportError:
         UniformCategoricalContextVariable,
     )
 
-# Context variables
 
-CV_weekday = UniformCategoricalContextVariable("weekday", list(weekday))
-CV_season = CategoricalContextVariable("season", {v: season[v] for v in season.keys()})
-CV_weather = CategoricalContextVariable("weather", {v: weather[v] for v in weather.keys()})
+# ---------------------------------------------------------------------------
+# PresenceModel
+# ---------------------------------------------------------------------------
+
+
+class PresenceModel(Model):
+    """Stage 1 — context variables and presence variables.
+
+    Has no inputs of its own: the context variables and presence variables
+    are self-contained.  All five are declared as ``Outputs`` so that
+    :class:`MolvenoModel` can pick them up and forward them as needed.
+
+    ``cv_weather`` is forwarded as an ``Input`` to :class:`ParkingModel`,
+    :class:`BeachModel`, and :class:`FoodModel`.  ``cv_weekday`` and
+    ``cv_season`` are consumed only by
+    :class:`~overtourism_molveno.overtourism_metamodel.OvertourismEnsemble`
+    (via :meth:`~dt_model.model.model.Model.abstract_indexes` on the root
+    model) but are declared in ``Outputs`` for consistency and so that the
+    root model can hand them to the ensemble explicitly.
+
+    Outputs
+    -------
+    cv_weekday : UniformCategoricalContextVariable
+        Day-of-week context variable.
+    cv_season : CategoricalContextVariable
+        Season context variable.
+    cv_weather : CategoricalContextVariable
+        Weather context variable.
+    pv_tourists : PresenceVariable
+        Tourist presence (grid axis in evaluation).
+    pv_excursionists : PresenceVariable
+        Excursionist presence (grid axis in evaluation).
+    """
+
+    @dataclass
+    class Outputs:
+        """Contractual outputs of :class:`PresenceModel`."""
+
+        cv_weekday: UniformCategoricalContextVariable
+        cv_season: CategoricalContextVariable
+        cv_weather: CategoricalContextVariable
+        pv_tourists: PresenceVariable
+        pv_excursionists: PresenceVariable
+
+    def __init__(self) -> None:
+        Outputs = PresenceModel.Outputs
+
+        cv_weekday = UniformCategoricalContextVariable("weekday", list(weekday))
+        cv_season = CategoricalContextVariable("season", {v: season[v] for v in season.keys()})
+        cv_weather = CategoricalContextVariable("weather", {v: weather[v] for v in weather.keys()})
+
+        pv_tourists = PresenceVariable(
+            "tourists",
+            [cv_weekday, cv_season, cv_weather],
+            tourist_presences_stats,
+        )
+        pv_excursionists = PresenceVariable(
+            "excursionists",
+            [cv_weekday, cv_season, cv_weather],
+            excursionist_presences_stats,
+        )
+
+        super().__init__(
+            "Presence",
+            outputs=Outputs(
+                cv_weekday=cv_weekday,
+                cv_season=cv_season,
+                cv_weather=cv_weather,
+                pv_tourists=pv_tourists,
+                pv_excursionists=pv_excursionists,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# ParkingModel
+# ---------------------------------------------------------------------------
+
+
+class ParkingModel(Model):
+    """Concern sub-model — parking usage.
+
+    All parameters (usage factors, conversion factors, capacity) are
+    received as ``Inputs`` so that callers can override any default.
+    :class:`MolvenoModel` creates the indexes with their default values and
+    passes them in.
+
+    The usage formula ``i_u_parking`` is the single contractual ``Output``.
+    The :class:`~overtourism_molveno.overtourism_metamodel.Constraint` is
+    stored as a plain instance attribute ``self.constraint``.
+
+    Parameters
+    ----------
+    pv_tourists : PresenceVariable
+        Tourist presence (wired from :class:`PresenceModel`).
+    pv_excursionists : PresenceVariable
+        Excursionist presence (wired from :class:`PresenceModel`).
+    cv_weather : CategoricalContextVariable
+        Weather context variable (needed for the piecewise usage factor).
+    i_u_tourists_parking : Index
+        Tourist parking usage factor.
+    i_u_excursionists_parking : Index
+        Excursionist parking usage factor (piecewise on weather).
+    i_xa_tourists_per_vehicle : Index
+        Tourists per vehicle allocation factor.
+    i_xa_excursionists_per_vehicle : Index
+        Excursionists per vehicle allocation factor.
+    i_xo_tourists_parking : Index
+        Tourists in parking rotation factor.
+    i_xo_excursionists_parking : Index
+        Excursionists in parking rotation factor.
+    i_c_parking : DistributionIndex
+        Parking capacity (uncertain).
+
+    Attributes
+    ----------
+    constraint : Constraint
+        The parking constraint (usage / capacity pair).
+    """
+
+    @dataclass
+    class Inputs:
+        """Contractual inputs of :class:`ParkingModel`."""
+
+        pv_tourists: PresenceVariable
+        pv_excursionists: PresenceVariable
+        cv_weather: CategoricalContextVariable
+        i_u_tourists_parking: Index
+        i_u_excursionists_parking: Index
+        i_xa_tourists_per_vehicle: Index
+        i_xa_excursionists_per_vehicle: Index
+        i_xo_tourists_parking: Index
+        i_xo_excursionists_parking: Index
+        i_c_parking: DistributionIndex
+
+    @dataclass
+    class Outputs:
+        """Contractual outputs of :class:`ParkingModel`."""
+
+        i_u_parking: Index
+
+    def __init__(
+        self,
+        pv_tourists: PresenceVariable,
+        pv_excursionists: PresenceVariable,
+        cv_weather: CategoricalContextVariable,
+        i_u_tourists_parking: Index,
+        i_u_excursionists_parking: Index,
+        i_xa_tourists_per_vehicle: Index,
+        i_xa_excursionists_per_vehicle: Index,
+        i_xo_tourists_parking: Index,
+        i_xo_excursionists_parking: Index,
+        i_c_parking: DistributionIndex,
+    ) -> None:
+        Inputs = ParkingModel.Inputs
+        Outputs = ParkingModel.Outputs
+
+        inputs = Inputs(
+            pv_tourists=pv_tourists,
+            pv_excursionists=pv_excursionists,
+            cv_weather=cv_weather,
+            i_u_tourists_parking=i_u_tourists_parking,
+            i_u_excursionists_parking=i_u_excursionists_parking,
+            i_xa_tourists_per_vehicle=i_xa_tourists_per_vehicle,
+            i_xa_excursionists_per_vehicle=i_xa_excursionists_per_vehicle,
+            i_xo_tourists_parking=i_xo_tourists_parking,
+            i_xo_excursionists_parking=i_xo_excursionists_parking,
+            i_c_parking=i_c_parking,
+        )
+
+        i_u_parking = Index(
+            "parking usage",
+            inputs.pv_tourists.node
+            * inputs.i_u_tourists_parking.node
+            / (inputs.i_xa_tourists_per_vehicle.node * inputs.i_xo_tourists_parking.node)
+            + inputs.pv_excursionists.node
+            * inputs.i_u_excursionists_parking.node
+            / (inputs.i_xa_excursionists_per_vehicle.node * inputs.i_xo_excursionists_parking.node),
+        )
+
+        super().__init__(
+            "Parking",
+            inputs=inputs,
+            outputs=Outputs(i_u_parking=i_u_parking),
+        )
+
+        # Constraint stored as a plain attribute — not a GenericIndex.
+        self.constraint = Constraint(name="parking", usage=i_u_parking, capacity=inputs.i_c_parking)
+
+
+# ---------------------------------------------------------------------------
+# BeachModel
+# ---------------------------------------------------------------------------
+
+
+class BeachModel(Model):
+    """Concern sub-model — beach usage.
+
+    All parameters (usage factors, rotation factors, capacity) are received
+    as ``Inputs``.  The uncertain rotation factor ``i_xo_tourists_beach`` is
+    passed in from :class:`MolvenoModel` so it appears in the root
+    ``model.indexes`` and is sampled by
+    :class:`~overtourism_molveno.overtourism_metamodel.OvertourismEnsemble`.
+
+    Parameters
+    ----------
+    pv_tourists : PresenceVariable
+        Tourist presence (wired from :class:`PresenceModel`).
+    pv_excursionists : PresenceVariable
+        Excursionist presence (wired from :class:`PresenceModel`).
+    cv_weather : CategoricalContextVariable
+        Weather context variable (needed for the piecewise usage factors).
+    i_u_tourists_beach : Index
+        Tourist beach usage factor (piecewise on weather).
+    i_u_excursionists_beach : Index
+        Excursionist beach usage factor (piecewise on weather).
+    i_xo_tourists_beach : DistributionIndex
+        Tourists on beach rotation factor (uncertain).
+    i_xo_excursionists_beach : Index
+        Excursionists on beach rotation factor.
+    i_c_beach : DistributionIndex
+        Beach capacity (uncertain).
+
+    Attributes
+    ----------
+    constraint : Constraint
+        The beach constraint (usage / capacity pair).
+    """
+
+    @dataclass
+    class Inputs:
+        """Contractual inputs of :class:`BeachModel`."""
+
+        pv_tourists: PresenceVariable
+        pv_excursionists: PresenceVariable
+        cv_weather: CategoricalContextVariable
+        i_u_tourists_beach: Index
+        i_u_excursionists_beach: Index
+        i_xo_tourists_beach: DistributionIndex
+        i_xo_excursionists_beach: Index
+        i_c_beach: DistributionIndex
+
+    @dataclass
+    class Outputs:
+        """Contractual outputs of :class:`BeachModel`."""
+
+        i_u_beach: Index
+
+    def __init__(
+        self,
+        pv_tourists: PresenceVariable,
+        pv_excursionists: PresenceVariable,
+        cv_weather: CategoricalContextVariable,
+        i_u_tourists_beach: Index,
+        i_u_excursionists_beach: Index,
+        i_xo_tourists_beach: DistributionIndex,
+        i_xo_excursionists_beach: Index,
+        i_c_beach: DistributionIndex,
+    ) -> None:
+        Inputs = BeachModel.Inputs
+        Outputs = BeachModel.Outputs
+
+        inputs = Inputs(
+            pv_tourists=pv_tourists,
+            pv_excursionists=pv_excursionists,
+            cv_weather=cv_weather,
+            i_u_tourists_beach=i_u_tourists_beach,
+            i_u_excursionists_beach=i_u_excursionists_beach,
+            i_xo_tourists_beach=i_xo_tourists_beach,
+            i_xo_excursionists_beach=i_xo_excursionists_beach,
+            i_c_beach=i_c_beach,
+        )
+
+        i_u_beach = Index(
+            "beach usage",
+            inputs.pv_tourists.node * inputs.i_u_tourists_beach.node / inputs.i_xo_tourists_beach.node
+            + inputs.pv_excursionists.node * inputs.i_u_excursionists_beach.node / inputs.i_xo_excursionists_beach.node,
+        )
+
+        super().__init__(
+            "Beach",
+            inputs=inputs,
+            outputs=Outputs(i_u_beach=i_u_beach),
+        )
+
+        # Constraint stored as a plain attribute — not a GenericIndex.
+        self.constraint = Constraint(name="beach", usage=i_u_beach, capacity=inputs.i_c_beach)
+
+
+# ---------------------------------------------------------------------------
+# AccommodationModel
+# ---------------------------------------------------------------------------
+
+
+class AccommodationModel(Model):
+    """Concern sub-model — accommodation usage.
+
+    Parameters
+    ----------
+    pv_tourists : PresenceVariable
+        Tourist presence (wired from :class:`PresenceModel`).
+    i_u_tourists_accommodation : Index
+        Tourist accommodation usage factor.
+    i_xa_tourists_accommodation : Index
+        Tourists per accommodation allocation factor.
+    i_c_accommodation : DistributionIndex
+        Accommodation capacity (uncertain).
+
+    Attributes
+    ----------
+    constraint : Constraint
+        The accommodation constraint (usage / capacity pair).
+    """
+
+    @dataclass
+    class Inputs:
+        """Contractual inputs of :class:`AccommodationModel`."""
+
+        pv_tourists: PresenceVariable
+        i_u_tourists_accommodation: Index
+        i_xa_tourists_accommodation: Index
+        i_c_accommodation: DistributionIndex
+
+    @dataclass
+    class Outputs:
+        """Contractual outputs of :class:`AccommodationModel`."""
+
+        i_u_accommodation: Index
+
+    def __init__(
+        self,
+        pv_tourists: PresenceVariable,
+        i_u_tourists_accommodation: Index,
+        i_xa_tourists_accommodation: Index,
+        i_c_accommodation: DistributionIndex,
+    ) -> None:
+        Inputs = AccommodationModel.Inputs
+        Outputs = AccommodationModel.Outputs
+
+        inputs = Inputs(
+            pv_tourists=pv_tourists,
+            i_u_tourists_accommodation=i_u_tourists_accommodation,
+            i_xa_tourists_accommodation=i_xa_tourists_accommodation,
+            i_c_accommodation=i_c_accommodation,
+        )
+
+        i_u_accommodation = Index(
+            "accommodation usage",
+            inputs.pv_tourists.node * inputs.i_u_tourists_accommodation.node / inputs.i_xa_tourists_accommodation.node,
+        )
+
+        super().__init__(
+            "Accommodation",
+            inputs=inputs,
+            outputs=Outputs(i_u_accommodation=i_u_accommodation),
+        )
+
+        # Constraint stored as a plain attribute — not a GenericIndex.
+        self.constraint = Constraint(
+            name="accommodation",
+            usage=i_u_accommodation,
+            capacity=inputs.i_c_accommodation,
+        )
+
+
+# ---------------------------------------------------------------------------
+# FoodModel
+# ---------------------------------------------------------------------------
+
+
+class FoodModel(Model):
+    """Concern sub-model — food-service usage.
+
+    Parameters
+    ----------
+    pv_tourists : PresenceVariable
+        Tourist presence (wired from :class:`PresenceModel`).
+    pv_excursionists : PresenceVariable
+        Excursionist presence (wired from :class:`PresenceModel`).
+    cv_weather : CategoricalContextVariable
+        Weather context variable (needed for the piecewise usage factor).
+    i_u_tourists_food : Index
+        Tourist food-service usage factor.
+    i_u_excursionists_food : Index
+        Excursionist food-service usage factor (piecewise on weather).
+    i_xa_visitors_food : Index
+        Visitors in food-service allocation factor.
+    i_xo_visitors_food : Index
+        Visitors in food-service rotation factor.
+    i_c_food : DistributionIndex
+        Food-service capacity (uncertain).
+
+    Attributes
+    ----------
+    constraint : Constraint
+        The food-service constraint (usage / capacity pair).
+    """
+
+    @dataclass
+    class Inputs:
+        """Contractual inputs of :class:`FoodModel`."""
+
+        pv_tourists: PresenceVariable
+        pv_excursionists: PresenceVariable
+        cv_weather: CategoricalContextVariable
+        i_u_tourists_food: Index
+        i_u_excursionists_food: Index
+        i_xa_visitors_food: Index
+        i_xo_visitors_food: Index
+        i_c_food: DistributionIndex
+
+    @dataclass
+    class Outputs:
+        """Contractual outputs of :class:`FoodModel`."""
+
+        i_u_food: Index
+
+    def __init__(
+        self,
+        pv_tourists: PresenceVariable,
+        pv_excursionists: PresenceVariable,
+        cv_weather: CategoricalContextVariable,
+        i_u_tourists_food: Index,
+        i_u_excursionists_food: Index,
+        i_xa_visitors_food: Index,
+        i_xo_visitors_food: Index,
+        i_c_food: DistributionIndex,
+    ) -> None:
+        Inputs = FoodModel.Inputs
+        Outputs = FoodModel.Outputs
+
+        inputs = Inputs(
+            pv_tourists=pv_tourists,
+            pv_excursionists=pv_excursionists,
+            cv_weather=cv_weather,
+            i_u_tourists_food=i_u_tourists_food,
+            i_u_excursionists_food=i_u_excursionists_food,
+            i_xa_visitors_food=i_xa_visitors_food,
+            i_xo_visitors_food=i_xo_visitors_food,
+            i_c_food=i_c_food,
+        )
+
+        i_u_food = Index(
+            "food usage",
+            (
+                inputs.pv_tourists.node * inputs.i_u_tourists_food.node
+                + inputs.pv_excursionists.node * inputs.i_u_excursionists_food.node
+            )
+            / (inputs.i_xa_visitors_food.node * inputs.i_xo_visitors_food.node),
+        )
+
+        super().__init__(
+            "Food",
+            inputs=inputs,
+            outputs=Outputs(i_u_food=i_u_food),
+        )
+
+        # Constraint stored as a plain attribute — not a GenericIndex.
+        self.constraint = Constraint(name="food", usage=i_u_food, capacity=inputs.i_c_food)
+
+
+# ---------------------------------------------------------------------------
+# MolvenoModel  (root)
+# ---------------------------------------------------------------------------
+
+
+class MolvenoModel(OvertourismModel):
+    """Root overtourism model that wires the five concern sub-models.
+
+    ``MolvenoModel`` owns the default values for every ``i_*`` parameter.
+    Callers who need to override a parameter can subclass ``MolvenoModel``
+    or construct the concern sub-models directly with different values.
+
+    ``MolvenoModel`` is a subclass of
+    :class:`~overtourism_molveno.overtourism_metamodel.OvertourismModel` so
+    that it is fully compatible with the existing
+    :class:`~overtourism_molveno.overtourism_metamodel.OvertourismEnsemble`
+    and :func:`~overtourism_molveno.overtourism_molveno.evaluate_scenario`
+    code.
+
+    Sub-models are accessible as named attributes:
+
+    * ``model.presence``      — :class:`PresenceModel`
+    * ``model.parking``       — :class:`ParkingModel`
+    * ``model.beach``         — :class:`BeachModel`
+    * ``model.accommodation`` — :class:`AccommodationModel`
+    * ``model.food``          — :class:`FoodModel`
+
+    Example usage::
+
+        m = MolvenoModel()
+        m.parking.inputs.i_c_parking      # capacity DistributionIndex
+        m.beach.inputs.i_xo_tourists_beach  # rotation DistributionIndex
+        m.parking.outputs.i_u_parking     # usage formula Index
+        m.presence.outputs.pv_tourists    # PresenceVariable
+        m.parking.constraint              # Constraint object
+    """
+
+    def __init__(self) -> None:
+        # ------------------------------------------------------------------
+        # Stage 1 — presence
+        # ------------------------------------------------------------------
+        presence = PresenceModel()
+
+        pv_tourists = presence.outputs.pv_tourists
+        pv_excursionists = presence.outputs.pv_excursionists
+        cv_weather = presence.outputs.cv_weather
+
+        # ------------------------------------------------------------------
+        # Default i_* parameters — created here so callers can override them
+        # ------------------------------------------------------------------
+
+        # Parking parameters
+        i_u_tourists_parking = Index("tourist parking usage factor", 0.02)
+        i_u_excursionists_parking = Index(
+            "excursionist parking usage factor",
+            piecewise((0.55, cv_weather == "bad"), (0.80, True)),
+        )
+        i_xa_tourists_per_vehicle = Index("tourists per vehicle allocation factor", 2.5)
+        i_xa_excursionists_per_vehicle = Index("excursionists per vehicle allocation factor", 2.5)
+        i_xo_tourists_parking = Index("tourists in parking rotation factor", 1.02)
+        i_xo_excursionists_parking = Index("excursionists in parking rotation factor", 3.5)
+        i_c_parking = DistributionIndex("parking capacity", stats.uniform, {"loc": 350.0, "scale": 100.0})
+
+        # Beach parameters
+        i_u_tourists_beach = Index(
+            "tourist beach usage factor",
+            piecewise((0.25, cv_weather == "bad"), (0.50, True)),
+        )
+        i_u_excursionists_beach = Index(
+            "excursionist beach usage factor",
+            piecewise((0.35, cv_weather == "bad"), (0.80, True)),
+        )
+        i_xo_tourists_beach = DistributionIndex(
+            "tourists on beach rotation factor",
+            stats.uniform,
+            {"loc": 1.0, "scale": 2.0},
+        )
+        i_xo_excursionists_beach = Index("excursionists on beach rotation factor", 1.02)
+        i_c_beach = DistributionIndex("beach capacity", stats.uniform, {"loc": 6000.0, "scale": 1000.0})
+
+        # Accommodation parameters
+        i_u_tourists_accommodation = Index("tourist accommodation usage factor", 0.90)
+        i_xa_tourists_accommodation = Index("tourists per accommodation allocation factor", 1.05)
+        i_c_accommodation = DistributionIndex(
+            "accommodation capacity",
+            stats.lognorm,
+            {"s": 0.125, "loc": 0.0, "scale": 5000.0},
+        )
+
+        # Food parameters
+        i_u_tourists_food = Index("tourist food service usage factor", 0.20)
+        i_u_excursionists_food = Index(
+            "excursionist food service usage factor",
+            piecewise((0.80, cv_weather == "bad"), (0.40, True)),
+        )
+        i_xa_visitors_food = Index("visitors in food service allocation factor", 0.9)
+        i_xo_visitors_food = Index("visitors in food service rotation factor", 2.0)
+        i_c_food = DistributionIndex(
+            "food service capacity",
+            stats.triang,
+            {"loc": 3000.0, "scale": 1000.0, "c": 0.5},
+        )
+
+        # Presence-transformation parameters (used in overtourism_molveno.py)
+        i_p_tourists_reduction_factor = Index("tourists reduction factor", 1.0)
+        i_p_excursionists_reduction_factor = Index("excursionists reduction factor", 1.0)
+        i_p_tourists_saturation_level = Index("tourists saturation level", 10000)
+        i_p_excursionists_saturation_level = Index("excursionists saturation level", 10000)
+
+        # ------------------------------------------------------------------
+        # Stage 2 / 3 — concern sub-models
+        # ------------------------------------------------------------------
+        parking = ParkingModel(
+            pv_tourists=pv_tourists,
+            pv_excursionists=pv_excursionists,
+            cv_weather=cv_weather,
+            i_u_tourists_parking=i_u_tourists_parking,
+            i_u_excursionists_parking=i_u_excursionists_parking,
+            i_xa_tourists_per_vehicle=i_xa_tourists_per_vehicle,
+            i_xa_excursionists_per_vehicle=i_xa_excursionists_per_vehicle,
+            i_xo_tourists_parking=i_xo_tourists_parking,
+            i_xo_excursionists_parking=i_xo_excursionists_parking,
+            i_c_parking=i_c_parking,
+        )
+        beach = BeachModel(
+            pv_tourists=pv_tourists,
+            pv_excursionists=pv_excursionists,
+            cv_weather=cv_weather,
+            i_u_tourists_beach=i_u_tourists_beach,
+            i_u_excursionists_beach=i_u_excursionists_beach,
+            i_xo_tourists_beach=i_xo_tourists_beach,
+            i_xo_excursionists_beach=i_xo_excursionists_beach,
+            i_c_beach=i_c_beach,
+        )
+        accommodation = AccommodationModel(
+            pv_tourists=pv_tourists,
+            i_u_tourists_accommodation=i_u_tourists_accommodation,
+            i_xa_tourists_accommodation=i_xa_tourists_accommodation,
+            i_c_accommodation=i_c_accommodation,
+        )
+        food = FoodModel(
+            pv_tourists=pv_tourists,
+            pv_excursionists=pv_excursionists,
+            cv_weather=cv_weather,
+            i_u_tourists_food=i_u_tourists_food,
+            i_u_excursionists_food=i_u_excursionists_food,
+            i_xa_visitors_food=i_xa_visitors_food,
+            i_xo_visitors_food=i_xo_visitors_food,
+            i_c_food=i_c_food,
+        )
+
+        # ------------------------------------------------------------------
+        # Collect domain lists expected by OvertourismModel / OvertourismEnsemble
+        # ------------------------------------------------------------------
+        cvs = [presence.outputs.cv_weekday, presence.outputs.cv_season, presence.outputs.cv_weather]
+        pvs = [pv_tourists, pv_excursionists]
+        constraints = [
+            parking.constraint,
+            beach.constraint,
+            accommodation.constraint,
+            food.constraint,
+        ]
+        capacities: list[GenericIndex] = [i_c_parking, i_c_beach, i_c_accommodation, i_c_food]
+
+        # Collect and deduplicate all indexes from sub-models plus the root
+        # presence-transformation parameters.  Identity-based deduplication
+        # ensures shared indexes (pv_*, cv_*) are not registered twice.
+        seen: set[int] = set()
+        all_indexes: list[GenericIndex] = []
+        for idx in (
+            list(presence.indexes)
+            + list(parking.indexes)
+            + list(beach.indexes)
+            + list(accommodation.indexes)
+            + list(food.indexes)
+            + [
+                i_p_tourists_reduction_factor,
+                i_p_excursionists_reduction_factor,
+                i_p_tourists_saturation_level,
+                i_p_excursionists_saturation_level,
+            ]
+        ):
+            if id(idx) not in seen:
+                seen.add(id(idx))
+                all_indexes.append(idx)
+
+        # domain_indexes: everything that is not a CV, PV, capacity, or
+        # usage-formula index (OvertourismModel keeps those lists separate).
+        cv_pv_ids = {id(x) for x in cvs + pvs}
+        cap_ids = {id(x) for x in capacities}
+        usage_ids = {id(c.usage) for c in constraints}
+        domain_indexes: list[GenericIndex] = [
+            idx
+            for idx in all_indexes
+            if id(idx) not in cv_pv_ids and id(idx) not in cap_ids and id(idx) not in usage_ids
+        ]
+
+        # ------------------------------------------------------------------
+        # Initialise OvertourismModel (the DeprecationWarning for the legacy
+        # flat-list path is suppressed inside OvertourismModel.__init__)
+        # ------------------------------------------------------------------
+        super().__init__(
+            "base model",
+            cvs=cvs,
+            pvs=pvs,
+            indexes=domain_indexes,
+            capacities=capacities,
+            constraints=constraints,
+        )
+
+        # ------------------------------------------------------------------
+        # Attach sub-models as named attributes for structured access
+        # ------------------------------------------------------------------
+        self.presence = presence
+        self.parking = parking
+        self.beach = beach
+        self.accommodation = accommodation
+        self.food = food
+
+        # Presence-transformation parameters — kept as top-level attributes
+        # so that overtourism_molveno.py can reference them by the original
+        # names without modification.
+        self.I_P_tourists_reduction_factor = i_p_tourists_reduction_factor
+        self.I_P_excursionists_reduction_factor = i_p_excursionists_reduction_factor
+        self.I_P_tourists_saturation_level = i_p_tourists_saturation_level
+        self.I_P_excursionists_saturation_level = i_p_excursionists_saturation_level
+
+
+# ---------------------------------------------------------------------------
+# Module-level aliases — preserved for backward compatibility with
+# overtourism_molveno.py and the existing test suite
+# ---------------------------------------------------------------------------
+
+#: Shared model instance (mirrors the previous ``M_Base`` module-level object).
+M_Base = MolvenoModel()
+
+# Context variables — exposed at module level for the script / test imports
+CV_weekday = M_Base.presence.outputs.cv_weekday
+CV_season = M_Base.presence.outputs.cv_season
+CV_weather = M_Base.presence.outputs.cv_weather
 
 # Presence variables
+PV_tourists = M_Base.presence.outputs.pv_tourists
+PV_excursionists = M_Base.presence.outputs.pv_excursionists
 
-PV_tourists = PresenceVariable("tourists", [CV_weekday, CV_season, CV_weather], tourist_presences_stats)
-PV_excursionists = PresenceVariable("excursionists", [CV_weekday, CV_season, CV_weather], excursionist_presences_stats)
-
-# Capacity indexes
-
-I_C_parking = DistributionIndex("parking capacity", stats.uniform, {"loc": 350.0, "scale": 100.0})
-I_C_beach = DistributionIndex("beach capacity", stats.uniform, {"loc": 6000.0, "scale": 1000.0})
-I_C_accommodation = DistributionIndex(
-    "accommodation capacity", stats.lognorm, {"s": 0.125, "loc": 0.0, "scale": 5000.0}
-)
-I_C_food = DistributionIndex("food service capacity", stats.triang, {"loc": 3000.0, "scale": 1000.0, "c": 0.5})
-
-# Usage indexes
-
-I_U_tourists_parking = Index("tourist parking usage factor", 0.02)
-I_U_excursionists_parking = Index(
-    "excursionist parking usage factor",
-    piecewise((0.55, CV_weather == "bad"), (0.80, True)),
-)
-
-I_U_tourists_beach = Index("tourist beach usage factor", piecewise((0.25, CV_weather == "bad"), (0.50, True)))
-I_U_excursionists_beach = Index(
-    "excursionist beach usage factor",
-    piecewise((0.35, CV_weather == "bad"), (0.80, True)),
-)
-
-I_U_tourists_accommodation = Index("tourist accommodation usage factor", 0.90)
-
-I_U_tourists_food = Index("tourist food service usage factor", 0.20)
-I_U_excursionists_food = Index(
-    "excursionist food service usage factor",
-    piecewise((0.80, CV_weather == "bad"), (0.40, True)),
-)
-
-# Conversion indexes
-
-I_Xa_tourists_per_vehicle = Index("tourists per vehicle allocation factor", 2.5)
-I_Xa_excursionists_per_vehicle = Index("excursionists per vehicle allocation factor", 2.5)
-I_Xo_tourists_parking = Index("tourists in parking rotation factor", 1.02)
-I_Xo_excursionists_parking = Index("excursionists in parking rotation factor", 3.5)
-
-I_Xo_tourists_beach = DistributionIndex("tourists on beach rotation factor", stats.uniform, {"loc": 1.0, "scale": 2.0})
-I_Xo_excursionists_beach = Index("excursionists on beach rotation factor", 1.02)
-
-I_Xa_tourists_accommodation = Index("tourists per accommodation allocation factor", 1.05)
-
-I_Xa_visitors_food = Index("visitors in food service allocation factor", 0.9)
-I_Xo_visitors_food = Index("visitors in food service rotation factor", 2.0)
-
-# Presence indexes
-
-I_P_tourists_reduction_factor = Index("tourists reduction factor", 1.0)
-I_P_excursionists_reduction_factor = Index("excursionists reduction factor", 1.0)
-
-I_P_tourists_saturation_level = Index("tourists saturation level", 10000)
-I_P_excursionists_saturation_level = Index("excursionists saturation level", 10000)
-
-# Usage indexes (formula-mode Index objects wrapping the usage expressions)
-
-I_U_parking = Index(
-    "parking usage",
-    PV_tourists.node * I_U_tourists_parking.node / (I_Xa_tourists_per_vehicle.node * I_Xo_tourists_parking.node)
-    + PV_excursionists.node
-    * I_U_excursionists_parking.node
-    / (I_Xa_excursionists_per_vehicle.node * I_Xo_excursionists_parking.node),
-)
-
-I_U_beach = Index(
-    "beach usage",
-    PV_tourists.node * I_U_tourists_beach.node / I_Xo_tourists_beach.node
-    + PV_excursionists.node * I_U_excursionists_beach.node / I_Xo_excursionists_beach.node,
-)
-
-I_U_accommodation = Index(
-    "accommodation usage",
-    PV_tourists.node * I_U_tourists_accommodation.node / I_Xa_tourists_accommodation.node,
-)
-
-I_U_food = Index(
-    "food usage",
-    (PV_tourists.node * I_U_tourists_food.node + PV_excursionists.node * I_U_excursionists_food.node)
-    / (I_Xa_visitors_food.node * I_Xo_visitors_food.node),
-)
-
-# Constraints
-
-C_parking = Constraint(name="parking", usage=I_U_parking, capacity=I_C_parking)
-C_beach = Constraint(name="beach", usage=I_U_beach, capacity=I_C_beach)
-C_accommodation = Constraint(name="accommodation", usage=I_U_accommodation, capacity=I_C_accommodation)
-C_food = Constraint(name="food", usage=I_U_food, capacity=I_C_food)
-
-# Model
-
-M_Base = OvertourismModel(
-    "base model",
-    [CV_weekday, CV_season, CV_weather],
-    [PV_tourists, PV_excursionists],
-    [
-        I_U_tourists_parking,
-        I_U_excursionists_parking,
-        I_U_tourists_beach,
-        I_U_excursionists_beach,
-        I_U_tourists_accommodation,
-        I_U_tourists_food,
-        I_U_excursionists_food,
-        I_Xa_tourists_per_vehicle,
-        I_Xa_excursionists_per_vehicle,
-        I_Xa_tourists_accommodation,
-        I_Xo_tourists_parking,
-        I_Xo_excursionists_parking,
-        I_Xo_tourists_beach,
-        I_Xo_excursionists_beach,
-        I_Xa_visitors_food,
-        I_Xo_visitors_food,
-        I_P_tourists_reduction_factor,
-        I_P_excursionists_reduction_factor,
-        I_P_tourists_saturation_level,
-        I_P_excursionists_saturation_level,
-    ],
-    [I_C_parking, I_C_beach, I_C_accommodation, I_C_food],
-    [C_parking, C_beach, C_accommodation, C_food],
-)
+# Presence-transformation parameters
+I_P_tourists_reduction_factor = M_Base.I_P_tourists_reduction_factor
+I_P_excursionists_reduction_factor = M_Base.I_P_excursionists_reduction_factor
+I_P_tourists_saturation_level = M_Base.I_P_tourists_saturation_level
+I_P_excursionists_saturation_level = M_Base.I_P_excursionists_saturation_level

--- a/examples/overtourism_molveno/overtourism_metamodel.py
+++ b/examples/overtourism_molveno/overtourism_metamodel.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import itertools
 import random
+import warnings
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -312,7 +313,9 @@ class OvertourismModel(Model):
         # nodes_of_interest=None in Evaluation.evaluate covers them.
         usage_indexes: list[GenericIndex] = [c.usage for c in constraints]
         all_indexes: list[GenericIndex] = list(cvs) + list(pvs) + list(indexes) + list(capacities) + usage_indexes
-        super().__init__(name, all_indexes)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            super().__init__(name, all_indexes)
 
         self.cvs = cvs
         self.pvs = pvs

--- a/tests/dt_model/examples/test_overtourism_molveno.py
+++ b/tests/dt_model/examples/test_overtourism_molveno.py
@@ -7,17 +7,34 @@ import random
 import numpy as np
 import pytest
 from overtourism_molveno.molveno_model import (
+    AccommodationModel,
+    BeachModel,
     CV_season,
     CV_weather,
     CV_weekday,
+    FoodModel,
+    I_P_excursionists_reduction_factor,
+    I_P_excursionists_saturation_level,
+    I_P_tourists_reduction_factor,
+    I_P_tourists_saturation_level,
     M_Base,
+    MolvenoModel,
+    ParkingModel,
+    PresenceModel,
     PV_excursionists,
     PV_tourists,
 )
-from overtourism_molveno.overtourism_metamodel import Constraint, ContextVariable, OvertourismEnsemble
+from overtourism_molveno.overtourism_metamodel import (
+    CategoricalContextVariable,
+    Constraint,
+    ContextVariable,
+    OvertourismEnsemble,
+    PresenceVariable,
+    UniformCategoricalContextVariable,
+)
 
 from civic_digital_twins.dt_model import Evaluation
-from civic_digital_twins.dt_model.model.index import Distribution
+from civic_digital_twins.dt_model.model.index import Distribution, DistributionIndex, GenericIndex, Index
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -278,6 +295,317 @@ def test_multiple_ensemble_members():
     assert field is not None
     assert field_elements is not None
     assert field.shape == (tourists.size, excursionists.size)
+
+
+# ---------------------------------------------------------------------------
+# Sub-model hierarchy — structure and typing
+# ---------------------------------------------------------------------------
+
+
+def test_molveno_model_has_five_sub_models():
+    """MolvenoModel exposes all five concern sub-models as named attributes."""
+    m = MolvenoModel()
+    assert isinstance(m.presence, PresenceModel)
+    assert isinstance(m.parking, ParkingModel)
+    assert isinstance(m.beach, BeachModel)
+    assert isinstance(m.accommodation, AccommodationModel)
+    assert isinstance(m.food, FoodModel)
+
+
+def test_presence_model_outputs_pvs():
+    """PresenceModel.outputs exposes pv_tourists and pv_excursionists."""
+    m = MolvenoModel()
+    assert isinstance(m.presence.outputs.pv_tourists, PresenceVariable)
+    assert isinstance(m.presence.outputs.pv_excursionists, PresenceVariable)
+    assert m.presence.outputs.pv_tourists.name == "tourists"
+    assert m.presence.outputs.pv_excursionists.name == "excursionists"
+
+
+def test_presence_model_outputs_context_variables():
+    """PresenceModel.outputs holds all three context variables."""
+    m = MolvenoModel()
+    assert isinstance(m.presence.outputs.cv_weekday, UniformCategoricalContextVariable)
+    assert isinstance(m.presence.outputs.cv_season, CategoricalContextVariable)
+    assert isinstance(m.presence.outputs.cv_weather, CategoricalContextVariable)
+    assert m.presence.outputs.cv_weekday.name == "weekday"
+    assert m.presence.outputs.cv_season.name == "season"
+    assert m.presence.outputs.cv_weather.name == "weather"
+
+
+def test_presence_model_has_no_expose():
+    """PresenceModel has no Expose — all outputs are contractual."""
+    m = MolvenoModel()
+    assert len(m.presence.expose) == 0
+
+
+def test_parking_model_inputs_wired_from_presence():
+    """ParkingModel presence inputs are the same objects as PresenceModel outputs."""
+    m = MolvenoModel()
+    assert m.parking.inputs.pv_tourists is m.presence.outputs.pv_tourists
+    assert m.parking.inputs.pv_excursionists is m.presence.outputs.pv_excursionists
+    assert m.parking.inputs.cv_weather is m.presence.outputs.cv_weather
+
+
+def test_beach_model_inputs_wired_from_presence():
+    """BeachModel presence inputs are the same objects as PresenceModel outputs."""
+    m = MolvenoModel()
+    assert m.beach.inputs.pv_tourists is m.presence.outputs.pv_tourists
+    assert m.beach.inputs.pv_excursionists is m.presence.outputs.pv_excursionists
+    assert m.beach.inputs.cv_weather is m.presence.outputs.cv_weather
+
+
+def test_accommodation_model_inputs_wired_from_presence():
+    """AccommodationModel.inputs.pv_tourists is the same object as PresenceModel outputs."""
+    m = MolvenoModel()
+    assert m.accommodation.inputs.pv_tourists is m.presence.outputs.pv_tourists
+
+
+def test_food_model_inputs_wired_from_presence():
+    """FoodModel presence inputs are the same objects as PresenceModel outputs."""
+    m = MolvenoModel()
+    assert m.food.inputs.pv_tourists is m.presence.outputs.pv_tourists
+    assert m.food.inputs.pv_excursionists is m.presence.outputs.pv_excursionists
+    assert m.food.inputs.cv_weather is m.presence.outputs.cv_weather
+
+
+def test_concern_model_outputs_are_generic_indexes_only():
+    """Outputs dataclasses contain only GenericIndex instances (no Constraint)."""
+    m = MolvenoModel()
+    for submodel in (m.parking, m.beach, m.accommodation, m.food):
+        for idx in submodel.outputs:
+            assert isinstance(idx, GenericIndex), (
+                f"{type(submodel).__name__}.outputs yielded a non-GenericIndex: {type(idx)}"
+            )
+
+
+def test_concern_model_inputs_include_all_i_parameters():
+    """All i_* parameters are Inputs to the concern sub-model that uses them."""
+    m = MolvenoModel()
+
+    # Parking: 7 i_* params + 3 presence/cv inputs
+    assert isinstance(m.parking.inputs.i_u_tourists_parking, Index)
+    assert isinstance(m.parking.inputs.i_u_excursionists_parking, Index)
+    assert isinstance(m.parking.inputs.i_xa_tourists_per_vehicle, Index)
+    assert isinstance(m.parking.inputs.i_xa_excursionists_per_vehicle, Index)
+    assert isinstance(m.parking.inputs.i_xo_tourists_parking, Index)
+    assert isinstance(m.parking.inputs.i_xo_excursionists_parking, Index)
+    assert isinstance(m.parking.inputs.i_c_parking, DistributionIndex)
+
+    # Beach: 5 i_* params + 3 presence/cv inputs
+    assert isinstance(m.beach.inputs.i_u_tourists_beach, Index)
+    assert isinstance(m.beach.inputs.i_u_excursionists_beach, Index)
+    assert isinstance(m.beach.inputs.i_xo_tourists_beach, DistributionIndex)
+    assert isinstance(m.beach.inputs.i_xo_excursionists_beach, Index)
+    assert isinstance(m.beach.inputs.i_c_beach, DistributionIndex)
+
+    # Accommodation: 3 i_* params + 1 presence input
+    assert isinstance(m.accommodation.inputs.i_u_tourists_accommodation, Index)
+    assert isinstance(m.accommodation.inputs.i_xa_tourists_accommodation, Index)
+    assert isinstance(m.accommodation.inputs.i_c_accommodation, DistributionIndex)
+
+    # Food: 5 i_* params + 3 presence/cv inputs
+    assert isinstance(m.food.inputs.i_u_tourists_food, Index)
+    assert isinstance(m.food.inputs.i_u_excursionists_food, Index)
+    assert isinstance(m.food.inputs.i_xa_visitors_food, Index)
+    assert isinstance(m.food.inputs.i_xo_visitors_food, Index)
+    assert isinstance(m.food.inputs.i_c_food, DistributionIndex)
+
+
+def test_concern_models_have_no_expose():
+    """Concern sub-models have no Expose — no internal uncertain parameters."""
+    m = MolvenoModel()
+    for submodel in (m.parking, m.beach, m.accommodation, m.food):
+        assert len(submodel.expose) == 0, f"{type(submodel).__name__}.expose is not empty: {submodel.expose}"
+
+
+def test_concern_model_constraint_is_plain_attribute():
+    """Each concern sub-model exposes its Constraint as a plain instance attribute."""
+    m = MolvenoModel()
+    for submodel in (m.parking, m.beach, m.accommodation, m.food):
+        assert isinstance(submodel.constraint, Constraint), f"{type(submodel).__name__}.constraint is not a Constraint"
+
+
+def test_parking_outputs_index_types():
+    """ParkingModel.outputs contains only the usage formula index."""
+    m = MolvenoModel()
+    assert isinstance(m.parking.outputs.i_u_parking, Index)
+    assert len(m.parking.outputs) == 1
+    assert m.parking.constraint.name == "parking"
+
+
+def test_beach_outputs_index_types():
+    """BeachModel.outputs contains only the usage formula index."""
+    m = MolvenoModel()
+    assert isinstance(m.beach.outputs.i_u_beach, Index)
+    assert len(m.beach.outputs) == 1
+    assert m.beach.constraint.name == "beach"
+
+
+def test_accommodation_outputs_index_types():
+    """AccommodationModel.outputs contains only the usage formula index."""
+    m = MolvenoModel()
+    assert isinstance(m.accommodation.outputs.i_u_accommodation, Index)
+    assert len(m.accommodation.outputs) == 1
+    assert m.accommodation.constraint.name == "accommodation"
+
+
+def test_food_outputs_index_types():
+    """FoodModel.outputs contains only the usage formula index."""
+    m = MolvenoModel()
+    assert isinstance(m.food.outputs.i_u_food, Index)
+    assert len(m.food.outputs) == 1
+    assert m.food.constraint.name == "food"
+
+
+# ---------------------------------------------------------------------------
+# Sub-model hierarchy — indexes coverage
+# ---------------------------------------------------------------------------
+
+
+def test_presence_cvs_in_root_indexes():
+    """All three context variables from PresenceModel appear in M_Base.indexes."""
+    cv_ids = {
+        id(M_Base.presence.outputs.cv_weekday),
+        id(M_Base.presence.outputs.cv_season),
+        id(M_Base.presence.outputs.cv_weather),
+    }
+    root_ids = {id(idx) for idx in M_Base.indexes}
+    assert cv_ids <= root_ids
+
+
+def test_presence_pvs_in_root_indexes():
+    """Both presence variables from PresenceModel appear in M_Base.indexes."""
+    pv_ids = {
+        id(M_Base.presence.outputs.pv_tourists),
+        id(M_Base.presence.outputs.pv_excursionists),
+    }
+    root_ids = {id(idx) for idx in M_Base.indexes}
+    assert pv_ids <= root_ids
+
+
+def test_all_capacity_indexes_in_root_indexes():
+    """All four capacity DistributionIndexes appear in M_Base.indexes."""
+    cap_ids = {
+        id(M_Base.parking.inputs.i_c_parking),
+        id(M_Base.beach.inputs.i_c_beach),
+        id(M_Base.accommodation.inputs.i_c_accommodation),
+        id(M_Base.food.inputs.i_c_food),
+    }
+    root_ids = {id(idx) for idx in M_Base.indexes}
+    assert cap_ids <= root_ids
+
+
+def test_beach_rotation_factor_in_root_indexes():
+    """i_xo_tourists_beach (DistributionIndex in BeachModel.Inputs) is in M_Base.indexes."""
+    rotation_id = id(M_Base.beach.inputs.i_xo_tourists_beach)
+    root_ids = {id(idx) for idx in M_Base.indexes}
+    assert rotation_id in root_ids
+
+
+def test_usage_formula_indexes_in_root_indexes():
+    """All four usage formula indexes appear in M_Base.indexes."""
+    usage_ids = {
+        id(M_Base.parking.outputs.i_u_parking),
+        id(M_Base.beach.outputs.i_u_beach),
+        id(M_Base.accommodation.outputs.i_u_accommodation),
+        id(M_Base.food.outputs.i_u_food),
+    }
+    root_ids = {id(idx) for idx in M_Base.indexes}
+    assert usage_ids <= root_ids
+
+
+def test_root_indexes_has_no_duplicates():
+    """M_Base.indexes contains no duplicate objects (identity check)."""
+    ids = [id(idx) for idx in M_Base.indexes]
+    assert len(ids) == len(set(ids))
+
+
+def test_beach_rotation_factor_is_abstract():
+    """i_xo_tourists_beach is distribution-backed and therefore abstract."""
+    assert M_Base.beach.inputs.i_xo_tourists_beach in M_Base.abstract_indexes()
+
+
+# ---------------------------------------------------------------------------
+# OvertourismModel domain attributes preserved on MolvenoModel
+# ---------------------------------------------------------------------------
+
+
+def test_molveno_model_cvs_list():
+    """M_Base.cvs contains exactly the three context variables."""
+    assert len(M_Base.cvs) == 3
+    cv_ids = {id(cv) for cv in M_Base.cvs}
+    assert id(M_Base.presence.outputs.cv_weekday) in cv_ids
+    assert id(M_Base.presence.outputs.cv_season) in cv_ids
+    assert id(M_Base.presence.outputs.cv_weather) in cv_ids
+
+
+def test_molveno_model_pvs_list():
+    """M_Base.pvs contains exactly the two presence variables."""
+    assert len(M_Base.pvs) == 2
+    pv_ids = {id(pv) for pv in M_Base.pvs}
+    assert id(M_Base.presence.outputs.pv_tourists) in pv_ids
+    assert id(M_Base.presence.outputs.pv_excursionists) in pv_ids
+
+
+def test_molveno_model_constraints_list():
+    """M_Base.constraints contains exactly four Constraint objects, one per concern."""
+    assert len(M_Base.constraints) == 4
+    names = {c.name for c in M_Base.constraints}
+    assert names == {"parking", "beach", "accommodation", "food"}
+
+
+def test_molveno_model_constraints_match_sub_model_attributes():
+    """M_Base.constraints entries are the same objects as sub-model .constraint attributes."""
+    sub_constraints = {
+        M_Base.parking.constraint,
+        M_Base.beach.constraint,
+        M_Base.accommodation.constraint,
+        M_Base.food.constraint,
+    }
+    root_constraints = set(M_Base.constraints)
+    # Identity check via id()
+    assert {id(c) for c in sub_constraints} == {id(c) for c in root_constraints}
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat module-level aliases
+# ---------------------------------------------------------------------------
+
+
+def test_module_aliases_cv_identity():
+    """Module-level CV_* aliases are identical to PresenceModel.outputs attributes."""
+    assert CV_weekday is M_Base.presence.outputs.cv_weekday
+    assert CV_season is M_Base.presence.outputs.cv_season
+    assert CV_weather is M_Base.presence.outputs.cv_weather
+
+
+def test_module_aliases_pv_identity():
+    """Module-level PV_* aliases are identical to the presence sub-model outputs."""
+    assert PV_tourists is M_Base.presence.outputs.pv_tourists
+    assert PV_excursionists is M_Base.presence.outputs.pv_excursionists
+
+
+def test_module_aliases_presence_transformation_identity():
+    """Module-level I_P_* aliases are identical to the root model attributes."""
+    assert I_P_tourists_reduction_factor is M_Base.I_P_tourists_reduction_factor
+    assert I_P_excursionists_reduction_factor is M_Base.I_P_excursionists_reduction_factor
+    assert I_P_tourists_saturation_level is M_Base.I_P_tourists_saturation_level
+    assert I_P_excursionists_saturation_level is M_Base.I_P_excursionists_saturation_level
+
+
+def test_presence_transformation_indexes_in_root_indexes():
+    """The four presence-transformation indexes appear in M_Base.indexes."""
+    pt_ids = {
+        id(I_P_tourists_reduction_factor),
+        id(I_P_excursionists_reduction_factor),
+        id(I_P_tourists_saturation_level),
+        id(I_P_excursionists_saturation_level),
+    }
+    root_ids = {id(idx) for idx in M_Base.indexes}
+    assert pt_ids <= root_ids
+
+
+# ---------------------------------------------------------------------------
 
 
 def test_bug_37():


### PR DESCRIPTION
## Summary

Step 3 of the v0.8.0 modularity plan. Decomposes `molveno_model.py` into five concern sub-models with explicit typed `Inputs`/`Outputs` inner dataclasses, plus a `MolvenoModel` root that wires them.

## Sub-model structure

| Sub-model | Role | Inputs | Outputs |
|---|---|---|---|
| `PresenceModel` | Stage 1 — context and presence | — | `cv_weekday`, `cv_season`, `cv_weather`, `pv_tourists`, `pv_excursionists` |
| `ParkingModel` | Parking usage | presence/CV indexes + 7 `i_*` params | `i_u_parking` |
| `BeachModel` | Beach usage | presence/CV indexes + 5 `i_*` params | `i_u_beach` |
| `AccommodationModel` | Accommodation usage | `pv_tourists` + 3 `i_*` params | `i_u_accommodation` |
| `FoodModel` | Food-service usage | presence/CV indexes + 5 `i_*` params | `i_u_food` |
| `MolvenoModel` | Root — owns all `i_*` defaults | (creates and forwards) | `cvs`, `pvs`, `constraints` |

## Design rules

- Every `i_*` parameter — including uncertain `DistributionIndex` values — is an `Input` to the sub-model that uses it. Default values are created by `MolvenoModel` and passed via constructors. Callers override by supplying different index objects.
- Each concern sub-model stores its `Constraint` as a plain `self.constraint` attribute (`Constraint` is not a `GenericIndex`).
- `MolvenoModel` subclasses `OvertourismModel` — `OvertourismEnsemble` and `evaluate_scenario` work without modification.
- All original module-level aliases (`M_Base`, `CV_*`, `PV_*`, `I_P_*`) preserved.