### PR TITLE
feat: typed axes — Axis/AxisRole, AxisEnsemble, PartitionedEnsemble (v0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**Typed axes — canonical shape contract for evaluation results**
+
+- `Axis(name, role)` and `AxisRole` (`PARAMETER`, `ENSEMBLE`, `DOMAIN`) — explicit
+  named dimensions for result arrays; exported from `civic_digital_twins.dt_model`.
+- `AxisEnsemble` protocol — batched ensemble interface exposing `ensemble_axes`,
+  `ensemble_weights`, and `assignments()`.  `DistributionEnsemble` now implements
+  it natively; the legacy `Iterable[WeightedScenario]` path is still accepted via a
+  deprecation adapter.
+- `PartitionedEnsemble(model, axes, default_axis, rng)` — N-on-M independent ENSEMBLE
+  axes; each `EnsembleAxisSpec` covers a disjoint subset of abstract indexes with its
+  own sample budget.  Validates unique axis names and full index coverage.
+- `Evaluation.evaluate()` — new `ensemble=` and `parameters=` keyword arguments
+  (canonical names replacing the deprecated `scenarios=` / `axes=`).  Accepts any
+  `AxisEnsemble`; a single batched evaluation pass replaces the old per-scenario loop.
+- `EvaluationResult.parameter_values` — replaces the deprecated `result.axes`.
+- Every result array is guaranteed to carry explicit ENSEMBLE singleton dims for
+  nodes not downstream of ENSEMBLE substitutions, eliminating the `S == T` shape
+  ambiguity (#142).
+- `OvertourismEnsemble` refactored to implement `AxisEnsemble`.
+
+**Document snippes - test alignment check**
+
 - `tests/test_doc_sync.py` — automated snippet-alignment test that compares
   every Python code block in the design docs and guides against its paired
   runnable example script in `examples/doc/`.  Run without arguments for a
@@ -37,8 +59,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `EvaluationResult.marginalize()` contracted the wrong axis when the ENSEMBLE size
+  equalled the timeseries length (`S == T`, #142).  The fix injects explicit ENSEMBLE
+  singleton dims post-evaluation so `marginalize()` always contracts the correct axis.
+- `marginalize()` no longer calls `squeeze()` on the result: only ENSEMBLE axes are
+  contracted; PARAMETER dims and non-trivial DOMAIN dims are preserved.
 - Dependabot vulnerability alerts resolved: `fonttools` bumped to `>=4.60.2`
   (moderate) and `pillow` to `>=12.1.1` (high) via lockfile regeneration. (#132)
+
+### Deprecated
+
+- `evaluate(scenarios, …)` positional argument — use `ensemble=` instead.
+- `evaluate(axes={…})` keyword — use `parameters=` instead.
+- `result.axes` property — use `result.parameter_values` instead.
+- Passing `Iterable[WeightedScenario]` to `evaluate()` — use an `AxisEnsemble`
+  (e.g. `DistributionEnsemble`) instead.
 
 ## [0.8.1] - 2026-04-02
 

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -20,7 +20,7 @@ from .model import (
     ModelVariant,
     TimeseriesIndex,
 )
-from .simulation import AxisEnsemble, DistributionEnsemble, Ensemble, EnsembleAxisSpec, Evaluation, EvaluationResult, WeightedScenario
+from .simulation import AxisEnsemble, DistributionEnsemble, Ensemble, EnsembleAxisSpec, Evaluation, EvaluationResult, PartitionedEnsemble, WeightedScenario
 
 __all__ = [
     "AbstractIndexNotInInputsWarning",
@@ -45,6 +45,7 @@ __all__ = [
     "ModelContractWarning",
     "ModelVariant",
     "PARAMETER",
+    "PartitionedEnsemble",
     "TimeseriesIndex",
     "WeightedScenario",
     "piecewise",

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -2,7 +2,12 @@
 
 from .engine.frontend.graph import piecewise
 from .model import (
+    DOMAIN,
+    ENSEMBLE,
+    PARAMETER,
     AbstractIndexNotInInputsWarning,
+    Axis,
+    AxisRole,
     CategoricalIndex,
     ConstIndex,
     Distribution,
@@ -15,16 +20,22 @@ from .model import (
     ModelVariant,
     TimeseriesIndex,
 )
-from .simulation import DistributionEnsemble, Ensemble, Evaluation, EvaluationResult, WeightedScenario
+from .simulation import AxisEnsemble, DistributionEnsemble, Ensemble, EnsembleAxisSpec, Evaluation, EvaluationResult, WeightedScenario
 
 __all__ = [
     "AbstractIndexNotInInputsWarning",
+    "Axis",
+    "AxisEnsemble",
+    "AxisRole",
     "CategoricalIndex",
     "ConstIndex",
     "Distribution",
+    "DOMAIN",
     "DistributionEnsemble",
     "DistributionIndex",
+    "ENSEMBLE",
     "Ensemble",
+    "EnsembleAxisSpec",
     "Evaluation",
     "EvaluationResult",
     "GenericIndex",
@@ -33,6 +44,7 @@ __all__ = [
     "Model",
     "ModelContractWarning",
     "ModelVariant",
+    "PARAMETER",
     "TimeseriesIndex",
     "WeightedScenario",
     "piecewise",

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -20,7 +20,16 @@ from .model import (
     ModelVariant,
     TimeseriesIndex,
 )
-from .simulation import AxisEnsemble, DistributionEnsemble, Ensemble, EnsembleAxisSpec, Evaluation, EvaluationResult, PartitionedEnsemble, WeightedScenario
+from .simulation import (
+    AxisEnsemble,
+    DistributionEnsemble,
+    Ensemble,
+    EnsembleAxisSpec,
+    Evaluation,
+    EvaluationResult,
+    PartitionedEnsemble,
+    WeightedScenario,
+)
 
 __all__ = [
     "AbstractIndexNotInInputsWarning",

--- a/civic_digital_twins/dt_model/model/__init__.py
+++ b/civic_digital_twins/dt_model/model/__init__.py
@@ -1,5 +1,6 @@
 """Model and index types for digital twin models."""
 
+from .axis import DOMAIN, ENSEMBLE, PARAMETER, Axis, AxisRole
 from .index import (
     CategoricalIndex,
     ConstIndex,
@@ -14,15 +15,20 @@ from .model_variant import ModelVariant
 
 __all__ = [
     "AbstractIndexNotInInputsWarning",
+    "Axis",
+    "AxisRole",
     "CategoricalIndex",
     "ConstIndex",
     "Distribution",
     "DistributionIndex",
+    "DOMAIN",
+    "ENSEMBLE",
     "GenericIndex",
     "Index",
     "InputsContractWarning",
     "Model",
     "ModelContractWarning",
     "ModelVariant",
+    "PARAMETER",
     "TimeseriesIndex",
 ]

--- a/civic_digital_twins/dt_model/model/axis.py
+++ b/civic_digital_twins/dt_model/model/axis.py
@@ -1,0 +1,48 @@
+"""Axis identity: role constants and the Axis class."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+__all__ = ["AxisRole", "DOMAIN", "PARAMETER", "ENSEMBLE", "Axis"]
+
+# Open string type alias — users can define additional roles as plain strings
+# following the UPPER_CASE convention.
+AxisRole = str
+
+# Built-in role constants.
+DOMAIN: AxisRole = "DOMAIN"
+PARAMETER: AxisRole = "PARAMETER"
+ENSEMBLE: AxisRole = "ENSEMBLE"
+
+
+class Axis:
+    """A named, role-tagged axis object with identity-based equality.
+
+    Parameters
+    ----------
+    name:
+        Lower-case string; globally unique within an :class:`EvaluationResult`.
+        Names starting with ``_`` are reserved for framework use (e.g.
+        ``_ensemble`` for the default ENSEMBLE axis created by
+        :class:`~civic_digital_twins.dt_model.simulation.ensemble.DistributionEnsemble`).
+    role:
+        One of the built-in constants :data:`DOMAIN`, :data:`PARAMETER`,
+        :data:`ENSEMBLE`, or a user-defined UPPER_CASE string.
+
+    Notes
+    -----
+    Equality and hashing are identity-based (the default Python behaviour
+    when neither ``__eq__`` nor ``__hash__`` is overridden).  Two ``Axis``
+    objects with the same *name* and *role* are **not** equal unless they
+    are the same instance.  This mirrors the convention used by
+    :class:`~civic_digital_twins.dt_model.model.index.GenericIndex`.
+    """
+
+    __slots__ = ("name", "role")
+
+    def __init__(self, name: str, role: AxisRole) -> None:
+        self.name = name
+        self.role = role
+
+    def __repr__(self) -> str:
+        """Return a concise string representation."""
+        return f"Axis({self.name!r}, role={self.role!r})"

--- a/civic_digital_twins/dt_model/simulation/__init__.py
+++ b/civic_digital_twins/dt_model/simulation/__init__.py
@@ -1,6 +1,13 @@
 """Scenario-based simulation and evaluation of digital twin models."""
 
-from .ensemble import AxisEnsemble, DistributionEnsemble, Ensemble, EnsembleAxisSpec, PartitionedEnsemble, WeightedScenario
+from .ensemble import (
+    AxisEnsemble,
+    DistributionEnsemble,
+    Ensemble,
+    EnsembleAxisSpec,
+    PartitionedEnsemble,
+    WeightedScenario,
+)
 from .evaluation import Evaluation, EvaluationResult
 
 __all__ = [

--- a/civic_digital_twins/dt_model/simulation/__init__.py
+++ b/civic_digital_twins/dt_model/simulation/__init__.py
@@ -1,6 +1,14 @@
 """Scenario-based simulation and evaluation of digital twin models."""
 
-from .ensemble import DistributionEnsemble, Ensemble, WeightedScenario
+from .ensemble import AxisEnsemble, DistributionEnsemble, Ensemble, EnsembleAxisSpec, WeightedScenario
 from .evaluation import Evaluation, EvaluationResult
 
-__all__ = ["DistributionEnsemble", "Ensemble", "Evaluation", "EvaluationResult", "WeightedScenario"]
+__all__ = [
+    "AxisEnsemble",
+    "DistributionEnsemble",
+    "Ensemble",
+    "EnsembleAxisSpec",
+    "Evaluation",
+    "EvaluationResult",
+    "WeightedScenario",
+]

--- a/civic_digital_twins/dt_model/simulation/__init__.py
+++ b/civic_digital_twins/dt_model/simulation/__init__.py
@@ -1,6 +1,6 @@
 """Scenario-based simulation and evaluation of digital twin models."""
 
-from .ensemble import AxisEnsemble, DistributionEnsemble, Ensemble, EnsembleAxisSpec, WeightedScenario
+from .ensemble import AxisEnsemble, DistributionEnsemble, Ensemble, EnsembleAxisSpec, PartitionedEnsemble, WeightedScenario
 from .evaluation import Evaluation, EvaluationResult
 
 __all__ = [
@@ -10,5 +10,6 @@ __all__ = [
     "EnsembleAxisSpec",
     "Evaluation",
     "EvaluationResult",
+    "PartitionedEnsemble",
     "WeightedScenario",
 ]

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -205,9 +205,7 @@ class PartitionedEnsemble:
             seen_names.add(spec.name)
 
         self._axes: tuple[Axis, ...] = tuple(Axis(spec.name, ENSEMBLE) for spec in all_specs)
-        self._weights: tuple[np.ndarray, ...] = tuple(
-            np.full(spec.size, 1.0 / spec.size) for spec in all_specs
-        )
+        self._weights: tuple[np.ndarray, ...] = tuple(np.full(spec.size, 1.0 / spec.size) for spec in all_specs)
         self._specs = all_specs
         self._assigned = assigned
         self._rng = rng

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -214,10 +214,12 @@ class PartitionedEnsemble:
 
     @property
     def ensemble_axes(self) -> tuple[Axis, ...]:
+        """Return the ENSEMBLE axes, one per partition."""
         return self._axes
 
     @property
     def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        """Return the weight arrays, one per partition axis."""
         return self._weights
 
     def assignments(self) -> Mapping[GenericIndex, np.ndarray]:

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -123,6 +123,138 @@ class AxisEnsemble(Protocol):
         ...  # pragma: no cover
 
 
+class PartitionedEnsemble:
+    """Ensemble that distributes abstract indexes across multiple named ENSEMBLE axes.
+
+    Each :class:`EnsembleAxisSpec` defines one ENSEMBLE axis: its name, which
+    abstract indexes belong to it, and how many independent samples to draw.
+    The result tensor has shape ``(S0, S1, …, S(M-1))`` before marginalization,
+    where ``Sj`` is the size of axis ``j``.  This allows orthogonal Monte Carlo
+    budgets for independent uncertainty sources.
+
+    Abstract indexes not mentioned in any ``axes`` spec must be covered by
+    ``default_axis``; otherwise a :class:`ValueError` is raised at construction.
+
+    Parameters
+    ----------
+    model:
+        The model whose abstract indexes are sampled.
+    axes:
+        Ordered list of :class:`EnsembleAxisSpec` objects, each naming a subset
+        of abstract indexes and a sample size.
+    default_axis:
+        Optional catch-all :class:`EnsembleAxisSpec` for abstract indexes not
+        listed in *axes*.  Its ``indexes`` list is extended automatically.
+    rng:
+        Optional :class:`numpy.random.Generator` for reproducibility.
+
+    Raises
+    ------
+    ValueError
+        If any abstract index is not covered by any spec and no *default_axis*
+        is provided, or if any spec index is not abstract in *model*.
+    """
+
+    def __init__(
+        self,
+        model: Model | ModelVariant,
+        axes: list[EnsembleAxisSpec],
+        default_axis: EnsembleAxisSpec | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> None:
+        abstract = list(model.abstract_indexes())
+        abstract_set = set(abstract)
+
+        # Build mapping: index → spec
+        assigned: dict[GenericIndex, EnsembleAxisSpec] = {}
+        for spec in axes:
+            for idx in spec.indexes:
+                if idx not in abstract_set:
+                    raise ValueError(
+                        f"Index {getattr(idx, 'name', repr(idx))!r} in EnsembleAxisSpec "
+                        f"{spec.name!r} is not an abstract index of the model."
+                    )
+                if idx in assigned:
+                    raise ValueError(
+                        f"Index {getattr(idx, 'name', repr(idx))!r} appears in more than one EnsembleAxisSpec."
+                    )
+                assigned[idx] = spec
+
+        # Handle unassigned indexes
+        unassigned = [idx for idx in abstract if idx not in assigned]
+        if unassigned:
+            if default_axis is None:
+                names = ", ".join(getattr(idx, "name", repr(idx)) for idx in unassigned)
+                raise ValueError(
+                    f"Abstract indexes not covered by any EnsembleAxisSpec and no default_axis provided: {names}"
+                )
+            for idx in unassigned:
+                default_axis.indexes.append(idx)
+                assigned[idx] = default_axis
+
+        # Final ordered spec list (include default_axis if used)
+        all_specs: list[EnsembleAxisSpec] = list(axes)
+        if default_axis is not None and default_axis.indexes:
+            all_specs.append(default_axis)
+
+        # Validate unique axis names across all specs (including default_axis).
+        seen_names: set[str] = set()
+        for spec in all_specs:
+            if spec.name in seen_names:
+                raise ValueError(f"Duplicate EnsembleAxisSpec name: {spec.name!r}")
+            seen_names.add(spec.name)
+
+        self._axes: tuple[Axis, ...] = tuple(Axis(spec.name, ENSEMBLE) for spec in all_specs)
+        self._weights: tuple[np.ndarray, ...] = tuple(
+            np.full(spec.size, 1.0 / spec.size) for spec in all_specs
+        )
+        self._specs = all_specs
+        self._assigned = assigned
+        self._rng = rng
+
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]:
+        return self._axes
+
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        return self._weights
+
+    def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
+        """Return batched samples for every abstract index.
+
+        Each value has shape ``(1, …, Sj, …, 1)`` — size ``Sj`` only at the
+        dimension corresponding to the index's own axis, 1 everywhere else.
+        """
+        M = len(self._specs)
+        result: dict[GenericIndex, np.ndarray] = {}
+
+        for j, spec in enumerate(self._specs):
+            Sj = spec.size
+            for idx in spec.indexes:
+                # Sample Sj values for this index.
+                if isinstance(idx, CategoricalIndex):
+                    raw = [idx.sample(self._rng) for _ in range(Sj)]
+                    samples = np.array(raw, dtype=object)  # shape (Sj,)
+                elif isinstance(idx, Index) and isinstance(idx.value, Distribution):
+                    if self._rng is not None:
+                        samples = np.asarray(idx.value.rvs(size=Sj, random_state=self._rng))
+                    else:
+                        samples = np.asarray(idx.value.rvs(size=Sj))
+                else:
+                    raise ValueError(
+                        f"Index {getattr(idx, 'name', repr(idx))!r} is not Distribution-backed "
+                        f"or CategoricalIndex; cannot sample."
+                    )
+
+                # Reshape to (1, …, Sj, …, 1): size Sj at position j, 1 elsewhere.
+                shape = [1] * M
+                shape[j] = Sj
+                result[idx] = samples.reshape(shape)
+
+        return result
+
+
 class DistributionEnsemble:
     """Ensemble that independently samples each samplable abstract index.
 

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -1,10 +1,14 @@
 """Ensemble protocol and built-in ensemble implementations."""
 
-from collections.abc import Iterator
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
+from ..model.axis import ENSEMBLE, Axis
 from ..model.index import CategoricalIndex, Distribution, GenericIndex, Index
 from ..model.model import Model
 from ..model.model_variant import ModelVariant
@@ -34,6 +38,91 @@ class Ensemble(Protocol):
         ...  # pragma: no cover
 
 
+@dataclass(eq=False)
+class EnsembleAxisSpec:
+    """Specification for one named ENSEMBLE axis in a :class:`PartitionedEnsemble`.
+
+    Parameters
+    ----------
+    name:
+        Lower-case axis name; must be unique within the ensemble.
+    indexes:
+        Abstract indexes assigned to this axis.  Each index must appear in
+        at most one :class:`EnsembleAxisSpec` within a single
+        :class:`PartitionedEnsemble`.
+    size:
+        Number of samples along this axis.
+    """
+
+    name: str
+    indexes: list[GenericIndex] = field(default_factory=list)
+    size: int = 1
+
+
+@runtime_checkable
+class AxisEnsemble(Protocol):
+    """Batched ensemble over one or more ENSEMBLE axes (no scenario enumeration).
+
+    This protocol is the canonical ensemble input to
+    :meth:`~civic_digital_twins.dt_model.simulation.evaluation.Evaluation.evaluate`.
+    :class:`DistributionEnsemble` implements it natively.
+
+    Conventions / invariants
+    ------------------------
+    - All axes in ``ensemble_axes`` have ``role == "ENSEMBLE"``.
+    - ``ensemble_axes`` order defines the canonical ENSEMBLE dimension order.
+    - ``ensemble_weights[i]`` is the factorized weight vector for
+      ``ensemble_axes[i]``.
+    - :meth:`assignments` returns concrete batched arrays for abstract indexes,
+      without enumerating scenarios.
+
+    Shape contract (strict)
+    -----------------------
+    Let ``M = len(ensemble_axes)`` and sizes ``S0..S(M-1)``.
+
+    For each ``(idx, value)`` in :meth:`assignments`:
+
+    .. code-block:: text
+
+        value.shape == (d0, d1, ..., d(M-1), *domain_shape(idx))
+
+    where for each ``j``:
+
+    - ``dj == Sj`` if *idx* is assigned to ``ensemble_axes[j]``
+    - ``dj == 1``  otherwise
+
+    and:
+
+    - scalar values: ``domain_shape(idx) == ()``
+    - timeseries values: ``domain_shape(idx) == (T,)``  (time is last)
+
+    The ENSEMBLE dims ``(d0..d(M-1))`` are **mandatory** and must be present
+    in-order for every assigned index (size 1 where not applicable).  No axis
+    may be omitted.  This is the rule that prevents ``S == T`` ambiguities.
+    """
+
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]:
+        """Ordered ENSEMBLE axes for this ensemble."""
+        ...  # pragma: no cover
+
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        """Factorized weight vectors aligned with :attr:`ensemble_axes`.
+
+        For each ``i``:
+
+        - ``ensemble_weights[i].ndim == 1``
+        - ``ensemble_weights[i].shape == (size_of(ensemble_axes[i]),)``
+        - weights sum to 1.0 (recommended invariant)
+        """
+        ...  # pragma: no cover
+
+    def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
+        """Return batched concrete values for abstract indexes (index-keyed)."""
+        ...  # pragma: no cover
+
+
 class DistributionEnsemble:
     """Ensemble that independently samples each samplable abstract index.
 
@@ -50,6 +139,11 @@ class DistributionEnsemble:
     is a set of independently distributed parameters (e.g., the Bologna
     mobility example) or runtime model variants selected via a
     :class:`~model.index.CategoricalIndex`.
+
+    Implements the :class:`AxisEnsemble` protocol: :meth:`assignments` returns
+    batched arrays of shape ``(size,)`` for each abstract index (no scenario
+    enumeration).  The legacy :meth:`__iter__` interface is preserved for
+    backward compatibility.
 
     Parameters
     ----------
@@ -102,6 +196,48 @@ class DistributionEnsemble:
         self._model = model
         self._size = size
         self._rng = rng
+        self._axis = Axis("_ensemble", ENSEMBLE)
+
+    # ------------------------------------------------------------------
+    # AxisEnsemble protocol
+    # ------------------------------------------------------------------
+
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]:
+        """Single ENSEMBLE axis of size *size*."""
+        return (self._axis,)
+
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        """Uniform weight vector of shape ``(size,)``."""
+        return (np.full(self._size, 1.0 / self._size),)
+
+    def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
+        """Return batched samples for every abstract index.
+
+        Each value has shape ``(size,)`` — the single ENSEMBLE axis dimension.
+        Scalar-valued :class:`~model.index.Distribution`-backed indexes yield
+        float arrays; :class:`~model.index.CategoricalIndex` indexes yield
+        object arrays of string keys.
+        """
+        abstract = self._model.abstract_indexes()
+        result: dict[GenericIndex, np.ndarray] = {}
+        for idx in abstract:
+            if isinstance(idx, CategoricalIndex):
+                raw_keys = [idx.sample(self._rng) for _ in range(self._size)]
+                result[idx] = np.array(raw_keys, dtype=object)  # shape (S,)
+            else:
+                assert isinstance(idx, Index) and isinstance(idx.value, Distribution)
+                if self._rng is not None:
+                    raw = idx.value.rvs(size=self._size, random_state=self._rng)
+                else:
+                    raw = idx.value.rvs(size=self._size)
+                result[idx] = np.asarray(raw)  # shape (S,)
+        return result
+
+    # ------------------------------------------------------------------
+    # Legacy iterable interface (backward compatible)
+    # ------------------------------------------------------------------
 
     def __iter__(self) -> Iterator[WeightedScenario]:
         """Yield *size* equally-weighted scenarios, one sample per index per scenario."""

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -170,7 +170,11 @@ class EvaluationResult:
     def marginalize(self, index: GenericIndex) -> np.ndarray:
         """Contract ENSEMBLE axes using their weights and return the result.
 
-        Uses the explicit axis layout — no shape heuristics.
+        Uses the explicit axis layout — no shape heuristics.  After
+        contracting all ENSEMBLE axes the result shape is
+        ``(*PARAMETER_sizes, *DOMAIN_dims)``; trailing size-1 dims that lie
+        beyond the PARAMETER positions are squeezed away (they are internal
+        DOMAIN placeholders, not meaningful dimensions).
         """
         arr = np.asarray(self._state.values[index.node])
 
@@ -180,23 +184,36 @@ class EvaluationResult:
             reverse=True,
         )
 
+        n_params = len(self._parameter_arrays)
+
         if not ensemble_entries:
-            return arr.squeeze()
+            return self._squeeze_domain(arr, n_params)
 
         for ax, pos in ensemble_entries:
-            weights = self._factorized_weights[ax]
-            S = self._axis_sizes[ax]
-            # Ensure the ENSEMBLE dimension exists at `pos` with size S.
-            # Constant or PARAMETER-only nodes may have fewer dims or size 1
-            # at `pos` — expand before contracting.
-            target = list(arr.shape)
-            while len(target) <= pos:
-                target.insert(0, 1)
-            if target[pos] != S:
-                target[pos] = S
-            arr = np.average(np.broadcast_to(arr, target), weights=weights, axis=pos)
+            # evaluate() guarantees shape[pos] is either S (ENSEMBLE-touched
+            # nodes) or 1 (injected singleton for non-touched nodes).
+            # For the singleton case: weighted average of S identical copies
+            # (weights summing to 1) equals the value itself — squeeze directly.
+            if arr.shape[pos] == 1:
+                arr = arr.squeeze(axis=pos)
+            else:
+                arr = np.average(arr, weights=self._factorized_weights[ax], axis=pos)
 
-        return arr.squeeze()
+        return self._squeeze_domain(arr, n_params)
+
+    @staticmethod
+    def _squeeze_domain(arr: np.ndarray, n_params: int) -> np.ndarray:
+        """Squeeze size-1 dims beyond the first *n_params* dimensions.
+
+        PARAMETER dims (positions 0..n_params-1) are preserved even if
+        size 1.  Trailing size-1 DOMAIN placeholder dims are removed so
+        that pure-scalar results are returned as 0-d arrays rather than
+        shape ``(1,)`` arrays.
+        """
+        domain_dims = tuple(i for i in range(n_params, arr.ndim) if arr.shape[i] == 1)
+        if domain_dims:
+            arr = np.squeeze(arr, axis=domain_dims)
+        return arr
 
 
 class Evaluation:
@@ -365,6 +382,41 @@ class Evaluation:
         actual_nodes = [idx.node for idx in nodes_of_interest]
         state = executor.State(c_subs, functions=functions or {})
         executor.evaluate_nodes(state, *linearize.forest(*actual_nodes))
+
+        # Normalize result arrays: inject an explicit ENSEMBLE singleton dim at
+        # every ENSEMBLE axis position for nodes that did NOT receive any ENSEMBLE
+        # substitution (directly or transitively).  Without this, a constant
+        # timeseries node (T,) is indistinguishable from an ENSEMBLE result (S,)
+        # when S == T, causing marginalize() to erroneously contract the time axis.
+        if n_ensemble > 0:
+            ensemble_positions: list[tuple[int, int]] = [
+                (n_params + j, axis_sizes[ax])
+                for j, ax in enumerate(ensemble.ensemble_axes)  # type: ignore[union-attr]
+            ]
+            # Build the set of nodes that are downstream of ENSEMBLE substitutions
+            # (i.e., touched by ENSEMBLE data) via forward BFS through the graph.
+            ens_touched: set[graph.Node] = set(ens_subs)
+            for node in linearize.forest(*actual_nodes):
+                if node in ens_touched:
+                    continue
+                if any(dep in ens_touched for dep in linearize._get_dependencies(node)):
+                    ens_touched.add(node)
+
+            for node in actual_nodes:
+                if node in ens_touched or node not in state.values:
+                    continue  # already has correct ENSEMBLE dims
+                arr = np.asarray(state.values[node])
+                modified = False
+                for pos, _ in ensemble_positions:
+                    # Insert singleton at pos: node has no ENSEMBLE data there.
+                    # Clamp insertion point to arr.ndim (appending at end for
+                    # arrays shorter than pos, e.g. scalars or 1-D constants).
+                    insert_at = min(pos, arr.ndim)
+                    if arr.ndim <= pos or arr.shape[pos] != 1:
+                        arr = np.expand_dims(arr, axis=insert_at)
+                        modified = True
+                if modified:
+                    state.values[node] = arr
 
         return EvaluationResult(
             state,

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -1,13 +1,17 @@
 """Generic model evaluation."""
 
+import warnings
+from collections.abc import Mapping
+
 import numpy as np
 
 from ..engine.frontend import graph, linearize
 from ..engine.numpybackend import executor
+from ..model.axis import ENSEMBLE, PARAMETER, Axis
 from ..model.index import GenericIndex
 from ..model.model import Model
 from ..model.model_variant import ModelVariant
-from .ensemble import Ensemble, WeightedScenario
+from .ensemble import AxisEnsemble, Ensemble, WeightedScenario
 
 __all__ = ["EvaluationResult", "Evaluation"]
 
@@ -24,96 +28,183 @@ def _validate_scenarios(
             raise ValueError(f"Scenario {i}: abstract index(es) not resolved: {names}")
 
 
+class _LegacyEnsembleAdapter:
+    """Adapt ``Iterable[WeightedScenario]`` to :class:`AxisEnsemble`.
+
+    Materialises the scenario list into batched arrays matching the
+    ``AxisEnsemble`` shape contract so that the single batched evaluation
+    path can handle both legacy and canonical inputs.
+    """
+
+    def __init__(
+        self,
+        scenarios: list[WeightedScenario],
+        non_param_abstract: list[GenericIndex],
+    ) -> None:
+        self._axis = Axis("_ensemble", ENSEMBLE)
+        self._weights = np.array([w for w, _ in scenarios])
+        self._assignments: dict[GenericIndex, np.ndarray] = {}
+        for idx in non_param_abstract:
+            values = [assignments[idx] for _, assignments in scenarios]
+            # Normalize: 1-element array assignments (common when values come
+            # from DistributionEnsemble.__iter__) are unwrapped to scalars so
+            # that np.asarray produces shape (S,) rather than (S, 1).
+            normalized = [v.flat[0] if isinstance(v, np.ndarray) and v.size == 1 else v for v in values]
+            self._assignments[idx] = np.asarray(normalized)  # shape (S,) or (S, T)
+
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]:
+        return (self._axis,)
+
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        return (self._weights,)
+
+    def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
+        return self._assignments
+
+
 class EvaluationResult:
     """Result of :meth:`Evaluation.evaluate`.
 
     Wraps the executor :class:`~executor.State` and provides typed access to
-    node values and weighted marginalization over the scenario dimension.
+    node values and weighted marginalization over ENSEMBLE and PARAMETER axes.
 
     Parameters
     ----------
     state:
         The executor state after evaluation.
-    weights:
-        Scenario weights, shape ``(S,)``.
-    axes:
-        The axis arrays passed to :meth:`Evaluation.evaluate`, mapping each
-        axis index to its 1-D value array.  Empty dict for 1-D mode.
+    axis_layout:
+        Maps each :class:`~dt_model.model.axis.Axis` to its numpy dimension
+        position in result arrays.
+    parameter_arrays:
+        The value arrays passed in ``parameters=``, keyed by index.  Used by
+        :meth:`parameter_values_for`.  Empty dict when no PARAMETER axes.
+    axis_sizes:
+        Maps each :class:`~dt_model.model.axis.Axis` to its size.
+    factorized_weights:
+        Per-ENSEMBLE-axis weight vectors.
     """
 
     def __init__(
         self,
         state: executor.State,
-        weights: np.ndarray,
-        axes: dict[GenericIndex, np.ndarray],
+        axis_layout: dict[Axis, int],
+        parameter_arrays: dict[GenericIndex, np.ndarray],
+        axis_sizes: dict[Axis, int] | None = None,
+        factorized_weights: dict[Axis, np.ndarray] | None = None,
     ) -> None:
         self._state = state
-        self._weights = weights
-        self._axes = axes
+        self._axis_layout = axis_layout
+        self._parameter_arrays = parameter_arrays
+        self._axis_sizes: dict[Axis, int] = axis_sizes or {}
+        self._factorized_weights: dict[Axis, np.ndarray] = factorized_weights or {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     @property
     def weights(self) -> np.ndarray:
-        """Scenario weights, shape ``(S,)``."""
-        return self._weights
+        """Scenario weight array.
+
+        Returns the joint weight array (outer product of factorized per-axis
+        weights).  Returns an empty array when there are no ENSEMBLE axes.
+        """
+        if not self._factorized_weights:
+            return np.empty(0)
+        joint: np.ndarray = next(iter(self._factorized_weights.values()))
+        for w in list(self._factorized_weights.values())[1:]:
+            joint = np.multiply.outer(joint, w)
+        return joint
 
     @property
     def axes(self) -> dict[GenericIndex, np.ndarray]:
-        """Axis value arrays as passed to :meth:`Evaluation.evaluate`."""
-        return self._axes
+        """Deprecated. Use :attr:`parameter_values` instead."""
+        warnings.warn(
+            "'result.axes' is deprecated; use 'result.parameter_values'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._parameter_arrays
+
+    @property
+    def parameter_values(self) -> dict[GenericIndex, np.ndarray]:
+        """Parameter value arrays, keyed by the index passed in ``parameters=``."""
+        return self._parameter_arrays
+
+    def parameter_values_for(self, index: GenericIndex) -> np.ndarray:
+        """Return the value array for a specific PARAMETER index.
+
+        Parameters
+        ----------
+        index:
+            An index that was passed in ``parameters=`` to
+            :meth:`Evaluation.evaluate`.
+
+        Raises
+        ------
+        KeyError
+            If *index* was not a PARAMETER axis in this result.
+        """
+        return self._parameter_arrays[index]
 
     @property
     def full_shape(self) -> tuple[int, ...]:
-        """Shape ``(N_0, ..., N_k, S)`` of a fully-broadcast result array."""
-        return tuple(arr.size for arr in self._axes.values()) + (self._weights.size,)
+        """Shape of a fully-broadcast result array.
+
+        Returns ``(*PARAMETER, *ENSEMBLE)`` sizes in axis-layout order.
+        """
+        n_dims = len(self._axis_layout)
+        if n_dims == 0:
+            return ()
+        shape: list[int] = [0] * n_dims
+        for ax, pos in self._axis_layout.items():
+            shape[pos] = self._axis_sizes[ax]
+        return tuple(shape)
 
     def __getitem__(self, index: GenericIndex) -> np.ndarray:
-        """Return the raw result array for *index* (not yet broadcast to full shape)."""
-        return self._state.values[index.node]
+        """Return the result array for *index*."""
+        return np.asarray(self._state.values[index.node])
 
     def marginalize(self, index: GenericIndex) -> np.ndarray:
-        """Broadcast *index*'s result to :attr:`full_shape` then contract with weights.
+        """Contract ENSEMBLE axes using their weights and return the result.
 
-        Returns an array of shape ``(N_0, ..., N_k)`` — the scenario dimension
-        is contracted.  In 1-D mode (no axes) returns a scalar (or a timeseries
-        array of shape ``(T,)`` for timeseries indexes).
-
-        In 1-D mode the scenario dimension is axis 0; trailing size-1 dimensions
-        added by :class:`~.ensemble.DistributionEnsemble` (which wraps each
-        scalar sample as shape ``(1,)`` for timeseries broadcast compatibility)
-        are squeezed away so that the return value is a plain scalar.
+        Uses the explicit axis layout — no shape heuristics.
         """
         arr = np.asarray(self._state.values[index.node])
-        if not self._axes:
-            S = self._weights.size
-            # If the array has no scenario dimension (constant index, or an
-            # index whose evaluation did not broadcast over scenarios), inject
-            # a scenario dimension before contracting.
-            if arr.ndim == 0 or arr.shape[0] != S:
-                # Heuristic: if the leading dimension does not equal S, the
-                # array has no scenario dimension (constant node, or a sum
-                # projection that collapses T→1 regardless of scenarios).
-                # Inject a broadcast scenario dimension so the tensordot below
-                # can contract it.
-                #
-                # Known fragility: if S == T for a timeseries-shaped result
-                # this check would incorrectly treat the timeseries dimension
-                # as the scenario dimension.  This will be addressed when typed
-                # axes are introduced in v0.9.0 (see GitHub issue #142).
-                arr = np.broadcast_to(arr.reshape((1,) + arr.shape), (S,) + arr.shape)
-            # 1-D mode: scenario dimension is always axis 0.
-            # Contract directly; squeeze trailing size-1 dims so scalar indexes
-            # return a scalar rather than a (1,) array.
-            return np.tensordot(arr, self._weights, axes=([0], [0])).squeeze()
-        arr = np.broadcast_to(arr, self.full_shape)
-        return np.tensordot(arr, self._weights, axes=([-1], [0]))
+
+        ensemble_entries = sorted(
+            [(ax, pos) for ax, pos in self._axis_layout.items() if ax.role == ENSEMBLE],
+            key=lambda t: t[1],
+            reverse=True,
+        )
+
+        if not ensemble_entries:
+            return arr.squeeze()
+
+        for ax, pos in ensemble_entries:
+            weights = self._factorized_weights[ax]
+            S = self._axis_sizes[ax]
+            # Ensure the ENSEMBLE dimension exists at `pos` with size S.
+            # Constant or PARAMETER-only nodes may have fewer dims or size 1
+            # at `pos` — expand before contracting.
+            target = list(arr.shape)
+            while len(target) <= pos:
+                target.insert(0, 1)
+            if target[pos] != S:
+                target[pos] = S
+            arr = np.average(np.broadcast_to(arr, target), weights=weights, axis=pos)
+
+        return arr.squeeze()
 
 
 class Evaluation:
     """Bridge between a :class:`~dt_model.model.model.Model` and the engine.
 
-    Given a model and a list of weighted scenarios, :meth:`evaluate` builds
-    the engine substitution dict, runs :func:`executor.evaluate_nodes`, and
-    returns an :class:`EvaluationResult`.
+    Given a model and an ensemble, :meth:`evaluate` builds the engine
+    substitution dict, runs :func:`executor.evaluate_nodes`, and returns an
+    :class:`EvaluationResult`.
 
     This class knows nothing about grids, presence variables, sustainability,
     or constraints — all domain-specific logic lives in subclasses or
@@ -130,90 +221,155 @@ class Evaluation:
 
     def evaluate(
         self,
-        scenarios: Ensemble,
+        scenarios: AxisEnsemble | Ensemble | None = None,
         nodes_of_interest: list[GenericIndex] | None = None,
         *,
+        parameters: dict[GenericIndex, np.ndarray] | None = None,
         axes: dict[GenericIndex, np.ndarray] | None = None,
+        ensemble: AxisEnsemble | Ensemble | None = None,
         functions: dict[str, executor.Functor] | None = None,
     ) -> EvaluationResult:
-        """Evaluate *nodes_of_interest* over the given scenarios.
+        """Evaluate *nodes_of_interest* over the given ensemble.
 
         Parameters
         ----------
         scenarios:
-            An :class:`~dt_model.simulation.ensemble.Ensemble` (any iterable
-            of ``(weight, assignments)`` pairs).  Non-axis abstract indexes of
-            the model must appear in every ``assignments`` dict.
+            Deprecated positional name for the ensemble argument.  Use
+            ``ensemble=`` instead.  Only one of *scenarios* / *ensemble* may
+            be supplied per call.
         nodes_of_interest:
             Indexes to evaluate.  Transitive dependencies are resolved
             automatically via :func:`linearize.forest`.  Defaults to all
             indexes in the model when ``None``.
-        axes:
-            Optional grid axes for multi-dimensional evaluation.  Maps each
+        parameters:
+            PARAMETER axes for multi-dimensional evaluation.  Maps each
             axis :class:`~dt_model.model.index.GenericIndex` to a 1-D numpy
-            array of values.  When provided:
-
-            * Each axis index ``idx`` at position ``i`` contributes a
-              substitution array of shape ``(1, …, N_i, …, 1, 1)`` where
-              ``N_i = arr.size`` and the non-unit dimension is at position
-              ``i`` (zero-indexed).
-            * Each non-axis abstract index contributes a substitution derived
-              from the scenario assignments.
-            * Result arrays broadcast to shape ``(N_0, N_1, …, S)``; use
-              :meth:`EvaluationResult.marginalize` to contract the scenario
-              dimension.
+            array of values.  When provided, each axis index ``idx`` at
+            position ``i`` contributes a substitution array of shape
+            ``(1, …, N_i, …, 1, 1)`` where ``N_i = arr.size``.
+        axes:
+            Deprecated alias for *parameters*.  Use ``parameters=`` instead.
+        ensemble:
+            The ensemble to evaluate.  Must be an :class:`AxisEnsemble`
+            (canonical, batched) or a legacy ``Iterable[WeightedScenario]``
+            (deprecated, emits :class:`DeprecationWarning`).  Pass ``None``
+            for deterministic evaluation (no ENSEMBLE axes).
         functions:
-            Optional user-defined functions passed to the executor.  Keys are
-            the names referenced by :class:`~graph.function_call` nodes;
-            values are :class:`~executor.Functor` callables.
+            Optional user-defined functions passed to the executor.
 
         Returns
         -------
         EvaluationResult
-            Typed result wrapper.  Node values can be retrieved via
-            ``result[index]``; weighted expectations via
-            ``result.marginalize(index)``.
+            Typed result wrapper.
 
         Raises
         ------
+        TypeError
+            If both *scenarios* and *ensemble* are supplied, or both
+            *axes* and *parameters* are supplied.
         ValueError
-            If any non-axis abstract index is not resolved in a scenario.
+            If any non-parameter abstract index is not resolved in a scenario.
         """
-        abstract = self.model.abstract_indexes()
-        scenarios_list = list(scenarios)
-        axes = axes or {}
+        # --- resolve 'ensemble' from positional 'scenarios' arg ------------
+        if scenarios is not None and ensemble is not None:
+            raise TypeError("Cannot specify both 'scenarios' and 'ensemble'.")
+        if scenarios is not None:
+            warnings.warn(
+                "The positional 'scenarios' argument is deprecated; use 'ensemble=' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            ensemble = scenarios
+
+        # --- resolve 'parameters' from deprecated 'axes' arg ---------------
+        if axes is not None and parameters is not None:
+            raise TypeError("Cannot specify both 'axes' and 'parameters'.")
+        if axes is not None:
+            warnings.warn(
+                "'axes' is deprecated; use 'parameters=' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            parameters = axes
+
+        parameters = parameters or {}
 
         if nodes_of_interest is None:
             nodes_of_interest = list(self.model.indexes)
 
-        axis_set = set(axes.keys())
-        non_axis_abstract = [idx for idx in abstract if idx not in axis_set]
+        abstract = self.model.abstract_indexes()
+        param_set = set(parameters.keys())
+        non_param_abstract = [idx for idx in abstract if idx not in param_set]
 
-        _validate_scenarios(non_axis_abstract, scenarios_list)
+        # --- adapt legacy Iterable[WeightedScenario] to AxisEnsemble ------
+        if ensemble is not None and not isinstance(ensemble, AxisEnsemble):
+            warnings.warn(
+                "Passing an iterable of WeightedScenario to 'evaluate()' is deprecated. "
+                "Use an AxisEnsemble (e.g. DistributionEnsemble) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            scenarios_list = list(ensemble)
+            if scenarios_list:
+                _validate_scenarios(non_param_abstract, scenarios_list)
+                ensemble = _LegacyEnsembleAdapter(scenarios_list, non_param_abstract)
+            else:
+                ensemble = None  # empty list → deterministic
 
-        n_axes = len(axes)
-        S = len(scenarios_list)
+        n_params = len(parameters)
+        axis_layout: dict[Axis, int] = {}
+        axis_sizes: dict[Axis, int] = {}
+        factorized_weights: dict[Axis, np.ndarray] = {}
         c_subs: dict[graph.Node, np.ndarray] = {}
+        param_nodes: list[graph.Node] = []
 
-        # Axis indexes: shape (1, …, N_i, …, 1, 1) — N_i at position i.
-        for i, (idx, arr) in enumerate(axes.items()):
-            shape = [1] * (n_axes + 1)
+        # PARAMETER axes — positions 0..n_params-1.
+        for i, (idx, arr) in enumerate(parameters.items()):
+            ax = Axis(getattr(idx, "name", f"param_{i}"), PARAMETER)
+            axis_layout[ax] = i
+            axis_sizes[ax] = arr.size
+            shape = [1] * n_params
             shape[i] = arr.size
             c_subs[idx.node] = arr.reshape(shape)
+            param_nodes.append(idx.node)
 
-        # Non-axis abstract indexes: stack scenario values.
-        # In grid mode (n_axes > 0) reshape to (1, …, 1, S) so they broadcast
-        # against the axis dimensions.  In 1-D mode (n_axes == 0) preserve the
-        # stacked shape as-is (e.g. (S, T) for timeseries-shaped values).
-        for idx in non_axis_abstract:
-            values = [assignments[idx] for _, assignments in scenarios_list]
-            stacked = np.asarray(values)
-            if n_axes > 0:
-                stacked = stacked.reshape([1] * n_axes + [S])
-            c_subs[idx.node] = stacked
+        n_ensemble = 0
+        ens_subs: dict[graph.Node, np.ndarray] = {}
 
-        weights = np.array([w for w, _ in scenarios_list])
+        if ensemble is not None:
+            ens_assignments = ensemble.assignments()
+            n_ensemble = len(ensemble.ensemble_axes)
+            for j, (ax, w) in enumerate(zip(ensemble.ensemble_axes, ensemble.ensemble_weights)):
+                axis_layout[ax] = n_params + j
+                axis_sizes[ax] = w.size
+                factorized_weights[ax] = w
+            for idx, batched in ens_assignments.items():
+                # Prepend n_params PARAMETER singletons.
+                # In pure-ensemble mode (no PARAMETER axes), also append a
+                # trailing 1 for scalar assignments so they broadcast with
+                # timeseries (T,) nodes: (S,) → (S, 1) × (T,) → (S, T).
+                param_singletons = (1,) * n_params
+                target = param_singletons + batched.shape
+                if n_params == 0 and batched.ndim == n_ensemble:
+                    target = target + (1,)
+                ens_subs[idx.node] = np.reshape(batched, target)
+
+        # Extend PARAMETER subs with n_ensemble trailing singleton dims.
+        if n_ensemble > 0:
+            ens_singletons = (1,) * n_ensemble
+            for node in param_nodes:
+                c_subs[node] = c_subs[node].reshape(c_subs[node].shape + ens_singletons)
+
+        c_subs.update(ens_subs)
+
         actual_nodes = [idx.node for idx in nodes_of_interest]
         state = executor.State(c_subs, functions=functions or {})
         executor.evaluate_nodes(state, *linearize.forest(*actual_nodes))
-        return EvaluationResult(state, weights, axes)
+
+        return EvaluationResult(
+            state,
+            axis_layout,
+            parameters,
+            axis_sizes=axis_sizes,
+            factorized_weights=factorized_weights,
+        )

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -31,23 +31,23 @@ placeholder index whose value must be supplied externally before the
 model can be evaluated.  It is *instantiated* when all indexes are
 fully concrete.
 
-**WeightedScenario / Ensemble.** The bridge from abstract to instantiated
-is an *ensemble*: an iterable of *weighted scenarios*, each pairing a
-probability weight with a dictionary that maps every abstract index to a
-concrete value.  The `Ensemble` type is a structural Protocol — any
-iterable of `(float, dict)` pairs satisfies it.
+**AxisEnsemble.** The bridge from abstract to instantiated is an
+*ensemble*: a batched object that assigns concrete arrays to every abstract
+index.  `DistributionEnsemble` and `PartitionedEnsemble` implement the
+`AxisEnsemble` protocol, which exposes named ENSEMBLE axes with factorized
+weight vectors.
 
-**Evaluation.** `Evaluation(model).evaluate(scenarios)` consumes an
-ensemble, builds the engine substitution dictionary from the scenario
-assignments, runs `executor.evaluate_nodes`, and returns an
+**Evaluation.** `Evaluation(model).evaluate(ensemble=…, parameters=…)`
+consumes an ensemble, builds the engine substitution dictionary from the
+batched assignments, runs `executor.evaluate_nodes`, and returns an
 `EvaluationResult`.  The result provides typed access to node arrays and
-weighted marginalisation over the scenario dimension.
+weighted marginalisation over ENSEMBLE and PARAMETER axes.
 
-**Grid mode.** `evaluate(scenarios, axes={idx: array, …})` extends the
-1-D scenario mode to multi-dimensional grids.  Axis indexes are swept
-over a dense grid; non-axis abstract indexes are drawn from the ensemble.
-Result arrays broadcast to shape `(N₀, N₁, …, S)` where each `Nᵢ`
-corresponds to one grid axis and `S` is the scenario count.
+**Grid mode.** `evaluate(ensemble=…, parameters={idx: array, …})` extends
+ensemble evaluation to multi-dimensional parameter grids.  PARAMETER
+indexes are swept over a dense grid; abstract indexes are handled by the
+ensemble.  Result arrays have canonical shape `(*PARAMETER, *ENSEMBLE)`
+where each PARAMETER size is `Nᵢ` and the ENSEMBLE size is `S`.
 
 ## Index Types
 
@@ -389,47 +389,74 @@ class GoodModel(Model):
         )
 ```
 
-## Ensemble and WeightedScenario
+## Ensemble
 
 [`simulation/ensemble.py`](../../civic_digital_twins/dt_model/simulation/ensemble.py)
 
-```python
-WeightedScenario = tuple[float, dict[GenericIndex, Any]]
+The canonical ensemble type is `AxisEnsemble`:
 
-class Ensemble(Protocol):
-    def __iter__(self) -> Iterator[WeightedScenario]: ...
+```python
+class AxisEnsemble(Protocol):
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]: ...
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]: ...
+    def assignments(self) -> Mapping[GenericIndex, np.ndarray]: ...
 ```
 
-`WeightedScenario` is a `(weight, assignments)` pair where:
-- `weight` is a probability (all weights in an ensemble should sum to 1).
-- `assignments` maps every abstract index that is not an axis to a
-  concrete `np.ndarray` value.
+Each `Axis` in `ensemble_axes` names one ENSEMBLE dimension.
+`ensemble_weights` provides the per-axis weight vector (sums to 1).
+`assignments()` returns batched arrays — one array per abstract index,
+with ENSEMBLE dimensions at the positions declared by the axes.
 
-`Ensemble` is a `runtime_checkable` Protocol: any iterable of
-`WeightedScenario` tuples satisfies it without inheriting from a base
-class.
+> **Legacy API (deprecated):** `WeightedScenario = tuple[float, dict[GenericIndex, Any]]`
+> and the `Ensemble` iterable protocol are still accepted by `evaluate()` but emit a
+> `DeprecationWarning`.  Migrate to `AxisEnsemble` (e.g. `DistributionEnsemble`).
 
 ### DistributionEnsemble
 
 `DistributionEnsemble(model, size, rng=None)` is the standard ensemble
 for models whose abstract indexes are all distribution-backed.  It draws
-`size` independent samples from each distribution and yields
-`size` equally-weighted scenarios (weight `1/size` each).
+`size` independent samples from each distribution into a single ENSEMBLE
+axis with uniform weights (`1/size` each).
 
 ```python
 from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
 
 ensemble = DistributionEnsemble(model, size=100)
-scenarios = list(ensemble)
-# Each scenario: (0.01, {x: array([...]), y: array([...])})
+# ensemble.ensemble_axes   → (Axis("x", ENSEMBLE), …)
+# ensemble.ensemble_weights[0]  → array of 100 weights summing to 1
+assignments = ensemble.assignments()
+# assignments[x]  → shape (100,) array of sampled values
 ```
 
 `DistributionEnsemble` also handles `CategoricalIndex` abstract indexes automatically —
-each categorical index is sampled proportional to its outcome weights, yielding a `(1,)` string
-array per scenario.  
+each categorical index is sampled proportional to its outcome weights.
 
 A `ValueError` is raised at construction if any abstract index is neither
 distribution-backed nor a `CategoricalIndex`.
+
+### PartitionedEnsemble
+
+`PartitionedEnsemble(model, axes, default_axis=None, rng=None)` creates
+N independent ENSEMBLE axes, each covering a disjoint subset of the
+model's abstract indexes.  Each `EnsembleAxisSpec` names the axis and
+lists the indexes it covers:
+
+```python
+from civic_digital_twins.dt_model.simulation.ensemble import (
+    EnsembleAxisSpec, PartitionedEnsemble,
+)
+
+ens = PartitionedEnsemble(
+    model,
+    axes=[
+        EnsembleAxisSpec("demand", indexes=[demand_idx], size=50),
+        EnsembleAxisSpec("capacity", indexes=[cap_idx], size=20),
+    ],
+)
+# Result arrays have shape (*PARAMETER, 50, 20) — two independent ENSEMBLE dims.
+```
 
 ## Evaluation
 
@@ -441,57 +468,51 @@ class Evaluation:
 
     def evaluate(
         self,
-        scenarios: Ensemble,
+        ensemble: AxisEnsemble | None = None,
         nodes_of_interest: list[GenericIndex] | None = None,
         *,
-        axes: dict[GenericIndex, np.ndarray] | None = None,
+        parameters: dict[GenericIndex, np.ndarray] | None = None,
         functions: dict[str, executor.Functor] | None = None,
     ) -> EvaluationResult: ...
 ```
 
-### 1-D mode
+### Ensemble mode
 
-When `axes` is `None` (or an empty dict), `evaluate` operates in *1-D
-mode*: it stacks the per-scenario values for each abstract index into a
-single substitution array and evaluates the graph once.
+When `parameters` is `None`, `evaluate` operates in *ensemble mode*: the
+`AxisEnsemble.assignments()` arrays are used as ENSEMBLE substitutions and
+evaluated in a single batched pass.
 
-For a model with abstract indexes `[x, y]` and `S` scenarios:
+For a model with abstract indexes `[x, y]` and ENSEMBLE size `S`:
 
-1. For each abstract index `idx`, collect its values across all
-   scenarios: `values = [assignments[idx] for _, assignments in scenarios]`.
-2. Stack: `stacked = np.asarray(values)`, shape `(S, 1)` for scalars or
-   `(S, T)` for timeseries-shaped values (shape `(1,)` per scenario
-   → `(S, 1)` after stacking, which broadcasts with shape `(T,)`).
-3. Build the engine substitution dict: `{idx.node: stacked, …}`.
-4. Run `executor.evaluate_nodes`.
+1. `ensemble.assignments()` returns `{x: arr_x, y: arr_y}` where each
+   `arr` has shape `(S,)` (or `(S, T)` for timeseries-shaped values).
+2. Shapes are normalised to `(*PARAMETER, *ENSEMBLE)` canonical form.
+3. Run `executor.evaluate_nodes` once.
 
-Result arrays have shape `(S, 1)` for scalar formulas or `(S, T)` for
-timeseries formulas.  Use `result.marginalize(idx)` to compute the
-weighted mean over `S`.
+Result arrays have shape `(S,)` for scalar formulas (plus any trailing
+DOMAIN dims, e.g. `(S, T)` for timeseries).
 
 ### Grid mode
 
-When `axes={pv₀: arr₀, pv₁: arr₁, …}` is provided, `evaluate` operates
-in *grid mode*:
+When `parameters={pv₀: arr₀, pv₁: arr₁, …}` is provided alongside an
+ensemble, `evaluate` operates in *grid mode*:
 
-- Each axis index at position `i` contributes a substitution of shape
-  `(1, …, Nᵢ, …, 1, 1)` where `Nᵢ = arrᵢ.size` and the non-unit
-  dimension is at position `i`.
-- Each non-axis abstract index contributes a substitution of shape
-  `(1, …, 1, S)` — one sample per scenario, broadcast-compatible with
-  all axis dimensions.
-- Result arrays broadcast to shape `(N₀, N₁, …, S)`.
+- Each PARAMETER index at position `i` contributes a substitution of shape
+  `(1, …, Nᵢ, …, 1)` where `Nᵢ = arrᵢ.size`.
+- ENSEMBLE indexes get shapes `(1, …, 1, S, 1)` — broadcast-compatible
+  with all PARAMETER dimensions.
+- Result arrays have canonical shape `(*PARAMETER, *ENSEMBLE)`.
 
-Use `result.marginalize(idx)` to contract the `S` dimension:
+Use `result.marginalize(idx)` to contract all ENSEMBLE dimensions:
 
 ```python
-# shape (N₀, N₁, …, S) → (N₀, N₁, …)
+# shape (*PARAMETER, *ENSEMBLE) → (*PARAMETER)
 marginalised = result.marginalize(idx)
 ```
 
 Grid mode is the standard way to compute sustainability fields in
-overtourism models, where the two presence variables define the grid
-axes.
+overtourism models, where the two presence variables define the parameter
+grid.
 
 ### EvaluationResult
 
@@ -499,13 +520,13 @@ axes.
 
 | API | Description |
 | --- | ----------- |
-| `result[idx]` | Raw array for `idx` (not yet broadcast to `full_shape`). |
-| `result.marginalize(idx)` | Broadcast to `full_shape`, then `tensordot` with `weights`. |
-| `result.weights` | Scenario weights, shape `(S,)`. |
-| `result.axes` | The `axes` dict passed to `evaluate`. |
-| `result.full_shape` | `(N₀, …, Nₖ, S)` — shape of a fully-broadcast array. |
+| `result[idx]` | Raw array for `idx` in canonical `(*PARAMETER, *ENSEMBLE)` shape prefix. |
+| `result.marginalize(idx)` | Contract all ENSEMBLE axes using factorized weights; result shape is `(*PARAMETER, *DOMAIN)`. |
+| `result.weights` | Joint weight array (outer product of per-axis weights). |
+| `result.parameter_values` | The `parameters=` dict passed to `evaluate`. |
+| `result.full_shape` | `(*PARAMETER, *ENSEMBLE)` sizes in axis-layout order. |
 
-### End-to-End Example (1-D mode)
+### End-to-End Example
 
 ```python
 import numpy as np
@@ -631,8 +652,8 @@ tt = np.linspace(0, 50_000, 101)   # tourist presence axis
 ee = np.linspace(0, 50_000, 101)   # excursionist presence axis
 
 result = Evaluation(model).evaluate(
-    list(ensemble),
-    axes={PV_tourists: tt, PV_excursionists: ee},
+    ensemble,
+    parameters={PV_tourists: tt, PV_excursionists: ee},
 )
 
 # Compute sustainability field per constraint
@@ -673,12 +694,15 @@ instances at construction time — the selector is a plain string.  This
 keeps variant switching visible at the call site and avoids deep
 inheritance hierarchies.
 
-### Why a structural `Ensemble` Protocol?
+### Why a structural `AxisEnsemble` Protocol?
 
-Making `Ensemble` a structural `Protocol` (rather than a base class)
-means that any iterable of `(float, dict)` pairs satisfies the contract
-without inheritance.  A `list[WeightedScenario]`, a generator, or a
-domain-specific class all work transparently.
+Making `AxisEnsemble` a structural `Protocol` (rather than a base class)
+means that any class exposing `ensemble_axes`, `ensemble_weights`, and
+`assignments()` satisfies the contract without inheritance.
+`DistributionEnsemble`, `PartitionedEnsemble`, and domain-specific
+ensemble classes (e.g. `OvertourismEnsemble`) all work transparently.
+The legacy `Iterable[WeightedScenario]` path is still supported via a
+deprecation adapter.
 
 ### Why `GenericIndex.__hash__` is identity-based
 
@@ -707,17 +731,23 @@ evaluated.
 **Concrete index**: an `Index` whose `value` is a scalar constant or a
 `graph.Node` formula; it can be evaluated without external input.
 
-**Ensemble**: an iterable of `WeightedScenario` tuples that defines a
-discrete probability distribution over model instantiations.
+**AxisEnsemble**: the canonical batched ensemble protocol.  Exposes named
+ENSEMBLE `Axis` objects, per-axis weight vectors, and a batched
+`assignments()` mapping.  `DistributionEnsemble` and `PartitionedEnsemble`
+implement this protocol.
+
+**Ensemble (legacy)**: an iterable of `WeightedScenario` tuples.  Still
+accepted by `evaluate()` via a deprecation adapter; migrate to
+`AxisEnsemble`.
 
 **Expose**: optional inner `@dataclass` on a `Model` subclass that
 holds inspectable but non-contractual intermediate indexes.  `Expose`
 fields are intended for debugging and visualisation only; they MUST NOT
 be used to wire indexes between models.
 
-**Grid mode**: the `axes=` keyword of `Evaluation.evaluate`; sweeps
-axis indexes over a dense grid while the ensemble provides the
-non-axis abstract index values.
+**Grid mode**: the `parameters=` keyword of `Evaluation.evaluate`; sweeps
+PARAMETER indexes over a dense grid while the ensemble provides the
+ENSEMBLE abstract index values.
 
 **InputsContractWarning**: a `ModelContractWarning` emitted when a
 `GenericIndex` constructor parameter is absent from the declared
@@ -730,9 +760,9 @@ instances passed in from outside).
 **Instantiated model**: a model in which `is_instantiated()` returns
 `True` — all indexes are concrete.
 
-**Marginalize**: collapse the scenario dimension `S` by computing
-`tensordot(arr, weights, axes=([-1], [0]))`, returning the weighted
-expectation over scenarios.
+**Marginalize**: contract all ENSEMBLE axes by computing the weighted
+average over each ENSEMBLE dimension using the factorized per-axis weights.
+Result shape is `(*PARAMETER, *DOMAIN)`.
 
 **ModelVariant**: a transparent proxy that selects among pre-constructed
 `Model` instances sharing the same I/O contract (`Inputs` / `Outputs`
@@ -747,6 +777,7 @@ evaluation layer may read.
 composing domain-specific `Index` subclasses) to add domain semantics
 without modifying the core library.
 
-**WeightedScenario**: `tuple[float, dict[GenericIndex, Any]]` — a
-probability weight paired with an assignment of every non-axis abstract
-index to a concrete `np.ndarray` value.
+**WeightedScenario** (deprecated): `tuple[float, dict[GenericIndex, Any]]` — a
+probability weight paired with an assignment dict.  The legacy iterable
+protocol is still accepted but emits `DeprecationWarning`; use `AxisEnsemble`
+instead.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,8 +149,8 @@ result = Evaluation(co2_model).evaluate(ensemble)
 ```
 
 `result` is an `EvaluationResult`.  Use `result[idx]` for the raw array
-(shape `(S, 1)` here, one value per scenario) and `result.marginalize(idx)`
-for the weighted expectation:
+(shape `(S, 1)` here — `S` ENSEMBLE samples, trailing 1 from the DOMAIN
+placeholder) and `result.marginalize(idx)` for the weighted expectation:
 
 ```python
 # Distribution of CO2 across 1000 scenarios

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -262,7 +262,7 @@ def _demo_18_20_overtourism() -> None:
 
     result = Evaluation(model).evaluate(
         list(ensemble),
-        axes={PV_tourists: tt, PV_excursionists: ee},
+        parameters={PV_tourists: tt, PV_excursionists: ee},
     )
 
     # Compute sustainability field per constraint

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -135,11 +135,11 @@ def _demo_12_distribution_ensemble() -> None:
         model = Model("demo12", [x, y, z])
 
     ensemble = DistributionEnsemble(model, size=100)
-    scenarios = list(ensemble)
 
-    assert len(scenarios) == 100
-    weight, assignments = scenarios[0]
+    assert len(ensemble.ensemble_weights[0]) == 100
+    weight = ensemble.ensemble_weights[0][0]
     assert abs(weight - 0.01) < 1e-12
+    assignments = ensemble.assignments()
     assert x in assignments
     assert y in assignments
 
@@ -261,7 +261,7 @@ def _demo_18_20_overtourism() -> None:
     ee = np.linspace(0, 50_000, 101)   # excursionist presence axis
 
     result = Evaluation(model).evaluate(
-        list(ensemble),
+        ensemble,
         parameters={PV_tourists: tt, PV_excursionists: ee},
     )
 

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -131,7 +131,7 @@ visitors_axis = np.linspace(0, 20_000, 201)
 
 result = Evaluation(model).evaluate(
     scenarios,
-    axes={PV_visitors: visitors_axis},
+    parameters={PV_visitors: visitors_axis},
 )
 
 assert result.full_shape == (201, 6)

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -116,7 +116,7 @@ scenario: dict[ContextVariable, list] = {
 ensemble = OvertourismEnsemble(model, scenario, cv_ensemble_size=10)
 # 2 × 3 = 6 scenarios (cv_ensemble_size=10 >= support sizes 2 and 3,
 # so all CV values are enumerated rather than sampled randomly)
-assert len(list(ensemble)) == 6
+assert len(ensemble) == 6
 
 assert abs(ensemble.weights.sum() - 1.0) < 1e-10
 
@@ -128,7 +128,7 @@ assert abs(ensemble.weights.sum() - 1.0) < 1e-10
 visitors_axis = np.linspace(0, 20_000, 201)
 
 result = Evaluation(model).evaluate(
-    ensemble,
+    ensemble=ensemble,
     parameters={PV_visitors: visitors_axis},
 )
 

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -114,13 +114,11 @@ scenario: dict[ContextVariable, list] = {
 }
 
 ensemble = OvertourismEnsemble(model, scenario, cv_ensemble_size=10)
-scenarios = list(ensemble)
 # 2 × 3 = 6 scenarios (cv_ensemble_size=10 >= support sizes 2 and 3,
 # so all CV values are enumerated rather than sampled randomly)
-assert len(scenarios) == 6
+assert len(list(ensemble)) == 6
 
-weights = np.array([w for w, _ in scenarios])
-assert abs(weights.sum() - 1.0) < 1e-10
+assert abs(ensemble.weights.sum() - 1.0) < 1e-10
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +128,7 @@ assert abs(weights.sum() - 1.0) < 1e-10
 visitors_axis = np.linspace(0, 20_000, 201)
 
 result = Evaluation(model).evaluate(
-    scenarios,
+    ensemble,
     parameters={PV_visitors: visitors_axis},
 )
 

--- a/examples/mobility_bologna/mobility_bologna.py
+++ b/examples/mobility_bologna/mobility_bologna.py
@@ -757,7 +757,7 @@ def evaluate(model: BolognaModel, size: int = 1) -> EvaluationResult:
     """
     ensemble = DistributionEnsemble(model, size)
     return Evaluation(model).evaluate(
-        ensemble,
+        ensemble=ensemble,
         functions={"ts_solve": executor.LambdaAdapter(_ts_solve)},
     )
 
@@ -875,7 +875,7 @@ def _save_scenario_plots(label: str, m: BolognaModel, result: EvaluationResult, 
         vertical_label="Flow (vehicles/hour)",
         vertical_size=1600,
         vertical_formatter=mticker.FuncFormatter(lambda x, _: f"{int(x * 12)}"),
-        reference_line=result[m.expose.ts_inflow],
+        reference_line=result.marginalize(m.expose.ts_inflow),
     )
     fig.savefig(out / f"{label}_inflow.png", dpi=150)
     plt.close(fig)
@@ -885,7 +885,7 @@ def _save_scenario_plots(label: str, m: BolognaModel, result: EvaluationResult, 
         horizontal_label="Time",
         vertical_label="Traffic (circulating vehicles)",
         vertical_size=15000,
-        reference_line=result[m.expose.traffic],
+        reference_line=result.marginalize(m.expose.traffic),
     )
     fig.savefig(out / f"{label}_traffic.png", dpi=150)
     plt.close(fig)
@@ -896,7 +896,7 @@ def _save_scenario_plots(label: str, m: BolognaModel, result: EvaluationResult, 
         vertical_label="Emissions (NOx gr/h)",
         vertical_size=4000,
         vertical_formatter=mticker.FuncFormatter(lambda x, _: f"{int(x * 12)}"),
-        reference_line=result[m.expose.emissions],
+        reference_line=result.marginalize(m.expose.emissions),
     )
     fig.savefig(out / f"{label}_emissions.png", dpi=150)
     plt.close(fig)

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -167,7 +167,7 @@ from civic_digital_twins.dt_model import Evaluation
 visitors_axis = np.linspace(0, 20_000, 201)
 
 result = Evaluation(model).evaluate(
-    ensemble,
+    ensemble=ensemble,
     parameters={PV_visitors: visitors_axis},
 )
 # result.full_shape == (201, 6)

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -141,14 +141,14 @@ scenario: dict[ContextVariable, list] = {
 }
 
 ensemble = OvertourismEnsemble(model, scenario, cv_ensemble_size=10)
-scenarios = list(ensemble)
-# 2 × 3 = 6 weighted scenarios
+# 2 × 3 = 6 scenarios (all CV combinations enumerated)
 ```
 
-`OvertourismEnsemble` enumerates all combinations of CV values and yields
-one weighted scenario per combination — here 2 × 3 = 6 scenarios, one per
-(season, weather) pair.  Each scenario also includes one sample of every
-distribution-backed non-PV non-CV abstract index (here: `I_C_beach`).
+`OvertourismEnsemble` implements `AxisEnsemble`: it enumerates all
+combinations of CV values and materialises the results into a single batched
+ENSEMBLE axis — here 2 × 3 = 6 scenarios, one per (season, weather) pair.
+Each scenario also includes one sample of every distribution-backed
+non-PV non-CV abstract index (here: `I_C_beach`).
 
 The `cv_ensemble_size` parameter controls random sampling only when a CV's
 support is too large (or continuous) to enumerate fully.  For the small
@@ -167,10 +167,10 @@ from civic_digital_twins.dt_model import Evaluation
 visitors_axis = np.linspace(0, 20_000, 201)
 
 result = Evaluation(model).evaluate(
-    scenarios,
-    axes={PV_visitors: visitors_axis},
+    ensemble,
+    parameters={PV_visitors: visitors_axis},
 )
-# result.full_shape == (201, 60)
+# result.full_shape == (201, 6)
 ```
 
 ## 7 — Sustainability field

--- a/examples/overtourism_molveno/overtourism_metamodel.py
+++ b/examples/overtourism_molveno/overtourism_metamodel.py
@@ -32,6 +32,7 @@ from scipy import stats
 from scipy.stats import rv_continuous
 from scipy.stats._distn_infrastructure import rv_continuous_frozen
 
+from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
 from civic_digital_twins.dt_model.model.index import Distribution, GenericIndex, Index
 from civic_digital_twins.dt_model.model.model import Model
 
@@ -330,13 +331,15 @@ class OvertourismModel(Model):
 
 
 class OvertourismEnsemble:
-    """Iterable that yields weighted scenarios for an :class:`OvertourismModel`.
+    """Batched ensemble for an :class:`OvertourismModel`.
 
-    Each iteration produces a :data:`~dt_model.simulation.evaluation.WeightedScenario`
-    assigning a concrete value to every context variable and every
-    distribution-backed (non-PV, non-CV) abstract index in the model.
-    Presence variables are *not* included — they are provided as grid axes
-    to :meth:`~dt_model.simulation.evaluation.Evaluation.evaluate`.
+    Implements :class:`~dt_model.simulation.ensemble.AxisEnsemble`.
+
+    Enumerates all combinations of CV values and pre-samples
+    distribution-backed indexes, materialising the results into a single
+    batched ENSEMBLE axis.  Presence variables are *not* included — they
+    are provided as PARAMETER axes to
+    :meth:`~dt_model.simulation.evaluation.Evaluation.evaluate`.
 
     Parameters
     ----------
@@ -358,21 +361,22 @@ class OvertourismEnsemble:
         self.model = model
 
         # Build per-CV list of (prob, value) pairs.
-        self._cv_samples: dict[ContextVariable, list] = {}
+        cv_samples: dict[ContextVariable, list] = {}
         for cv in model.cvs:
             if cv in scenario:
                 subset = scenario[cv]
                 if len(subset) == 1:
-                    self._cv_samples[cv] = [(1.0, subset[0])]
+                    cv_samples[cv] = [(1.0, subset[0])]
                 else:
-                    self._cv_samples[cv] = cv.sample(cv_ensemble_size, subset=subset)
+                    cv_samples[cv] = cv.sample(cv_ensemble_size, subset=subset)
             else:
-                self._cv_samples[cv] = cv.sample(cv_ensemble_size)
+                cv_samples[cv] = cv.sample(cv_ensemble_size)
 
         # Total number of scenarios = product of all per-CV sample sizes.
-        self.size = 1
-        for samples in self._cv_samples.values():
-            self.size *= len(samples)
+        S = 1
+        for samples in cv_samples.values():
+            S *= len(samples)
+        self.size = S
 
         # Distribution-backed non-PV non-CV abstract indexes (e.g. capacities
         # and distribution-backed conversion factors).
@@ -380,7 +384,7 @@ class OvertourismEnsemble:
         # GenericIndex.__eq__ returns a graph.Node (always truthy), making
         # the list `in` operator unreliable for these objects.
         pv_ids = {id(pv) for pv in model.pvs}
-        self._dist_indexes: list[Index] = [
+        dist_indexes: list[Index] = [
             idx  # type: ignore[misc]
             for idx in model.abstract_indexes()
             if not isinstance(idx, ContextVariable)
@@ -389,31 +393,39 @@ class OvertourismEnsemble:
             and isinstance(idx.value, Distribution)
         ]
 
-        # Pre-sample S values for each distribution-backed index.
-        S = max(self.size, 1)
-        self._dist_samples: dict[Index, object] = {
-            idx: idx.value.rvs(size=S)  # type: ignore[union-attr]
-            for idx in self._dist_indexes
-        }
+        # Materialise all scenario combinations into batched arrays.
+        cvs = list(cv_samples.keys())
+        cv_sample_lists = [cv_samples[cv] for cv in cvs]
 
-    def __iter__(self):
-        """Iterate over all CV combinations, yielding one WeightedScenario each."""
-        cvs = list(self._cv_samples.keys())
-        cv_sample_lists = [self._cv_samples[cv] for cv in cvs]
-
+        weights = np.ones(S)
+        cv_batched: dict[ContextVariable, list] = {cv: [] for cv in cvs}
         for i, combo in enumerate(itertools.product(*cv_sample_lists)):
-            weight = 1.0
-            assignments: dict = {}
-
             for cv, (prob, val) in zip(cvs, combo):
-                weight *= prob
-                assignments[cv] = val
+                weights[i] *= prob
+                cv_batched[cv].append(val)
 
-            # Include pre-sampled values for distribution-backed indexes.
-            for idx in self._dist_indexes:
-                assignments[idx] = self._dist_samples[idx][i]  # type: ignore[index]
+        self._axis = Axis("_overtourism", ENSEMBLE)
+        self._weights = weights
+        self._assignments: dict[GenericIndex, np.ndarray] = {cv: np.asarray(cv_batched[cv]) for cv in cvs}
+        # Pre-sample S values for each distribution-backed index.
+        for idx in dist_indexes:
+            self._assignments[idx] = idx.value.rvs(size=S)  # type: ignore[union-attr]
 
-            yield weight, assignments
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]:
+        return (self._axis,)
+
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        return (self._weights,)
+
+    @property
+    def weights(self) -> np.ndarray:
+        """Joint weight array (alias for the single ENSEMBLE axis weights)."""
+        return self._weights
+
+    def assignments(self) -> dict[GenericIndex, np.ndarray]:
+        return self._assignments
 
     def __len__(self) -> int:
         """Return the total number of scenarios."""

--- a/examples/overtourism_molveno/overtourism_metamodel.py
+++ b/examples/overtourism_molveno/overtourism_metamodel.py
@@ -174,7 +174,7 @@ class ContinuousContextVariable(ContextVariable):
         """Sample from the continuous context variable."""
         if force_sample or subset is None or nr < len(subset):
             assert nr > 0
-            return [(1 / nr, r) for r in list(self.rvc.rvs(size=nr))]
+            return [(1 / nr, r) for r in list(self.rvc.rvs(size=nr))]  # type: ignore[arg-type]
 
         subset_probability = list(self.rvc.pdf(subset))
         subset_probability_sum = sum(subset_probability)
@@ -413,10 +413,12 @@ class OvertourismEnsemble:
 
     @property
     def ensemble_axes(self) -> tuple[Axis, ...]:
+        """Return the single ENSEMBLE axis for this ensemble."""
         return (self._axis,)
 
     @property
     def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        """Return the weight array for the single ENSEMBLE axis."""
         return (self._weights,)
 
     @property
@@ -425,6 +427,7 @@ class OvertourismEnsemble:
         return self._weights
 
     def assignments(self) -> dict[GenericIndex, np.ndarray]:
+        """Return batched assignments for all CVs and distribution-backed indexes."""
         return self._assignments
 
     def __len__(self) -> int:

--- a/examples/overtourism_molveno/overtourism_molveno.py
+++ b/examples/overtourism_molveno/overtourism_molveno.py
@@ -185,7 +185,7 @@ def evaluate_scenario(model, situation) -> tuple:
     scenarios: list[WeightedScenario] = list(OvertourismEnsemble(model, situation, cv_ensemble_size=ensemble_size))
     tt = np.linspace(0, t_max, t_sample + 1)
     ee = np.linspace(0, e_max, e_sample + 1)
-    result = Evaluation(model).evaluate(scenarios, axes={PV_tourists: tt, PV_excursionists: ee})
+    result = Evaluation(model).evaluate(scenarios, parameters={PV_tourists: tt, PV_excursionists: ee})
     return result, scenarios
 
 
@@ -207,8 +207,8 @@ def plot_scenario(ax, model, result, scenarios, title):
     title:
         Plot title prefix.
     """
-    tt = result.axes[PV_tourists]
-    ee = result.axes[PV_excursionists]
+    tt = result.parameter_values[PV_tourists]
+    ee = result.parameter_values[PV_excursionists]
 
     # Compute sustainability field.
     # field[t_idx, e_idx] = P(all constraints satisfied | tourists=tt[t_idx], excursionists=ee[e_idx])

--- a/examples/overtourism_molveno/overtourism_molveno.py
+++ b/examples/overtourism_molveno/overtourism_molveno.py
@@ -16,7 +16,6 @@ from scipy import interpolate, ndimage, stats
 
 from civic_digital_twins.dt_model import Evaluation
 from civic_digital_twins.dt_model.model.index import Distribution
-from civic_digital_twins.dt_model.simulation.ensemble import WeightedScenario
 
 try:
     from overtourism_molveno.molveno_model import (
@@ -177,16 +176,16 @@ def threshold(p, t):
 def evaluate_scenario(model, situation) -> tuple:
     """Evaluate the sustainability field for *situation*.
 
-    Returns ``(result, scenarios)`` where *result* is an
-    :class:`~dt_model.simulation.evaluation.EvaluationResult` and *scenarios*
-    is the list of :data:`~dt_model.simulation.evaluation.WeightedScenario`
-    used (needed downstream for presence-sample generation).
+    Returns ``(result, ensemble)`` where *result* is an
+    :class:`~dt_model.simulation.evaluation.EvaluationResult` and *ensemble*
+    is the :class:`~overtourism_molveno.OvertourismEnsemble` used (needed
+    downstream for presence-sample generation).
     """
-    scenarios: list[WeightedScenario] = list(OvertourismEnsemble(model, situation, cv_ensemble_size=ensemble_size))
+    ensemble = OvertourismEnsemble(model, situation, cv_ensemble_size=ensemble_size)
     tt = np.linspace(0, t_max, t_sample + 1)
     ee = np.linspace(0, e_max, e_sample + 1)
-    result = Evaluation(model).evaluate(scenarios, parameters={PV_tourists: tt, PV_excursionists: ee})
-    return result, scenarios
+    result = Evaluation(model).evaluate(ensemble, parameters={PV_tourists: tt, PV_excursionists: ee})
+    return result, ensemble
 
 
 def plot_scenario(ax, model, result, scenarios, title):
@@ -235,15 +234,25 @@ def plot_scenario(ax, model, result, scenarios, title):
     rf_e = float(np.mean(result[I_P_excursionists_reduction_factor]))
     sl_e = float(np.mean(result[I_P_excursionists_saturation_level]))
 
+    ens_weights = scenarios.weights
+    ens_assignments = scenarios.assignments()
+    # Iterate scenario-by-scenario: zip per-index arrays into per-scenario dicts.
+    scenario_keys = list(ens_assignments.keys())
     sample_tourists = [
         presence_transformation(sample, rf_t, sl_t)
-        for w, assignments in scenarios
-        for sample in PV_tourists.sample(cvs=assignments, nr=max(1, round(w * target_presence_samples)))
+        for i, w in enumerate(ens_weights)
+        for sample in PV_tourists.sample(
+            cvs={k: ens_assignments[k][i] for k in scenario_keys},
+            nr=max(1, round(w * target_presence_samples)),
+        )
     ]
     sample_excursionists = [
         presence_transformation(sample, rf_e, sl_e)
-        for w, assignments in scenarios
-        for sample in PV_excursionists.sample(cvs=assignments, nr=max(1, round(w * target_presence_samples)))
+        for i, w in enumerate(ens_weights)
+        for sample in PV_excursionists.sample(
+            cvs={k: ens_assignments[k][i] for k in scenario_keys},
+            nr=max(1, round(w * target_presence_samples)),
+        )
     ]
 
     axes_dict = {PV_tourists: tt, PV_excursionists: ee}

--- a/examples/overtourism_molveno/overtourism_molveno.py
+++ b/examples/overtourism_molveno/overtourism_molveno.py
@@ -184,7 +184,7 @@ def evaluate_scenario(model, situation) -> tuple:
     ensemble = OvertourismEnsemble(model, situation, cv_ensemble_size=ensemble_size)
     tt = np.linspace(0, t_max, t_sample + 1)
     ee = np.linspace(0, e_max, e_sample + 1)
-    result = Evaluation(model).evaluate(ensemble, parameters={PV_tourists: tt, PV_excursionists: ee})
+    result = Evaluation(model).evaluate(ensemble=ensemble, parameters={PV_tourists: tt, PV_excursionists: ee})
     return result, ensemble
 
 

--- a/tests/dt_model/examples/test_overtourism_molveno.py
+++ b/tests/dt_model/examples/test_overtourism_molveno.py
@@ -41,15 +41,15 @@ from civic_digital_twins.dt_model.model.index import Distribution, DistributionI
 # ---------------------------------------------------------------------------
 
 
-def compute_field(model, scenarios, tt, ee):
-    """Evaluate the sustainability field using Evaluation.evaluate(axes=...).
+def compute_field(model, ensemble, tt, ee):
+    """Evaluate the sustainability field using Evaluation.evaluate(parameters=...).
 
     Returns ``(field, field_elements, result)`` where:
     - ``field`` has shape ``(tt.size, ee.size)``
     - ``field_elements`` maps each Constraint to a ``(tt.size, ee.size)`` array
     - ``result`` is the :class:`~dt_model.simulation.evaluation.EvaluationResult`
     """
-    result = Evaluation(model).evaluate(scenarios, parameters={PV_tourists: tt, PV_excursionists: ee})
+    result = Evaluation(model).evaluate(ensemble, parameters={PV_tourists: tt, PV_excursionists: ee})
 
     field = np.ones((tt.size, ee.size))
     field_elements = {}
@@ -128,18 +128,16 @@ def excursionists():
 
 @pytest.fixture
 def good_weather_scenarios():
-    """Single-member scenario list: good weather, monday, high season."""
+    """Single-member ensemble: good weather, monday, high season."""
     np.random.seed(0)
     random.seed(0)
-    return list(
-        OvertourismEnsemble(
-            M_Base,
-            {
-                CV_weekday: ["monday"],
-                CV_season: ["high"],
-                CV_weather: ["good"],
-            },
-        )
+    return OvertourismEnsemble(
+        M_Base,
+        {
+            CV_weekday: ["monday"],
+            CV_season: ["high"],
+            CV_weather: ["good"],
+        },
     )
 
 
@@ -189,9 +187,8 @@ def test_ensemble_based_evaluation(tourists, excursionists):
     random.seed(42)
     scenario: dict[ContextVariable, list] = {CV_weather: ["good", "bad"]}
     ensemble = OvertourismEnsemble(M_Base, scenario, cv_ensemble_size=5)
-    scenarios = list(ensemble)
 
-    field, field_elements, _ = compute_field(M_Base, scenarios, tourists, excursionists)
+    field, field_elements, _ = compute_field(M_Base, ensemble, tourists, excursionists)
 
     assert field.shape == (tourists.size, excursionists.size)
     assert np.all(field >= 0.0)
@@ -223,9 +220,7 @@ def test_fixed_ensemble():
             CV_weather: ["good"],
         },
     )
-    scenarios = list(ensemble)
-
-    _, got, _ = compute_field(M_Base, scenarios, tourists, excursionists)
+    _, got, _ = compute_field(M_Base, ensemble, tourists, excursionists)
 
     # Expected: field_elements[t_idx, e_idx] — tourists on axis 0, excursionists on axis 1.
     # Parking: mostly excursionist-dominated; parking violated when excursionists > ~2000.
@@ -285,12 +280,10 @@ def test_multiple_ensemble_members():
     random.seed(0)
     scenario: dict[ContextVariable, list] = {CV_weather: ["good", "bad"]}
     ens = OvertourismEnsemble(M_Base, scenario, cv_ensemble_size=10)
-    scenarios = list(ens)
-
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])
 
-    field, field_elements, _ = compute_field(M_Base, scenarios, tourists, excursionists)
+    field, field_elements, _ = compute_field(M_Base, ens, tourists, excursionists)
 
     assert field is not None
     assert field_elements is not None
@@ -614,12 +607,11 @@ def test_bug_37():
     random.seed(0)
     situation: dict[ContextVariable, list] = {CV_weather: ["good", "unsettled", "bad"]}
     ensemble = OvertourismEnsemble(M_Base, situation, cv_ensemble_size=20)
-    scenarios = list(ensemble)
 
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])
 
-    field, field_elements, _ = compute_field(M_Base, scenarios, tourists, excursionists)
+    field, field_elements, _ = compute_field(M_Base, ensemble, tourists, excursionists)
 
     assert field is not None
     assert field_elements is not None

--- a/tests/dt_model/examples/test_overtourism_molveno.py
+++ b/tests/dt_model/examples/test_overtourism_molveno.py
@@ -49,7 +49,7 @@ def compute_field(model, scenarios, tt, ee):
     - ``field_elements`` maps each Constraint to a ``(tt.size, ee.size)`` array
     - ``result`` is the :class:`~dt_model.simulation.evaluation.EvaluationResult`
     """
-    result = Evaluation(model).evaluate(scenarios, axes={PV_tourists: tt, PV_excursionists: ee})
+    result = Evaluation(model).evaluate(scenarios, parameters={PV_tourists: tt, PV_excursionists: ee})
 
     field = np.ones((tt.size, ee.size))
     field_elements = {}

--- a/tests/dt_model/simulation/test_acceptance_typed_axes.py
+++ b/tests/dt_model/simulation/test_acceptance_typed_axes.py
@@ -52,8 +52,8 @@ def test_parameter_then_ensemble_then_domain_order():
     only abstract index (sampled by DistributionEnsemble → ENSEMBLE dim).
     Expected shape: (3, 5) — PARAMETER first, ENSEMBLE second.
     """
-    i_x = _dist_index("x")     # abstract: sampled by ensemble → ENSEMBLE dim
-    i_p = Index("p", 1.0)      # concrete default, swept via parameters= → PARAMETER dim
+    i_x = _dist_index("x")  # abstract: sampled by ensemble → ENSEMBLE dim
+    i_p = Index("p", 1.0)  # concrete default, swept via parameters= → PARAMETER dim
     i_result = Index("result", i_p.node * i_x.node)
     model = _make_model(i_x, i_p, i_result)
 
@@ -69,7 +69,7 @@ def test_parameter_then_ensemble_then_domain_order():
 def test_no_shape_heuristic_constant_node():
     """A constant node marginalizes to a scalar regardless of ENSEMBLE size."""
     i_c = Index("c", 42.0)
-    i_x = _dist_index("x")   # gives DistributionEnsemble something to sample
+    i_x = _dist_index("x")  # gives DistributionEnsemble something to sample
     model = _make_model(i_c, i_x)
 
     ens = DistributionEnsemble(model, size=4, rng=np.random.default_rng(0))

--- a/tests/dt_model/simulation/test_acceptance_typed_axes.py
+++ b/tests/dt_model/simulation/test_acceptance_typed_axes.py
@@ -1,0 +1,237 @@
+"""Acceptance tests for typed-axes milestone (#142, #134).
+
+Covers the checklist in docs/design/sessions/typed-axes.md §7:
+- Canonical shape contract
+- S == T regression (historical #142 failure mode)
+- Broadcasting correctness (scalar ↔ timeseries)
+- Multi-axis ensemble (factorized weights)
+- Backward compatibility (deprecation window)
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from civic_digital_twins.dt_model.model.index import DistributionIndex, Index, TimeseriesIndex
+from civic_digital_twins.dt_model.model.model import Model
+from civic_digital_twins.dt_model.simulation.ensemble import (
+    DistributionEnsemble,
+    EnsembleAxisSpec,
+    PartitionedEnsemble,
+    WeightedScenario,
+)
+from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dist_index(name: str, lo: float = 0.0, hi: float = 1.0) -> Index:
+    return DistributionIndex(name, stats.uniform, {"loc": lo, "scale": hi - lo})
+
+
+def _make_model(*indexes) -> Model:
+    return Model("test", list(indexes))
+
+
+# ---------------------------------------------------------------------------
+# Canonical shape contract
+# ---------------------------------------------------------------------------
+
+
+def test_parameter_then_ensemble_then_domain_order():
+    """result[idx] shape follows (*PARAMETER, *ENSEMBLE) order for scalar nodes.
+
+    1 PARAMETER axis (size 3), 1 ENSEMBLE axis (S=5, from DistributionEnsemble).
+    i_p has a concrete default value and is swept via parameters=; i_x is the
+    only abstract index (sampled by DistributionEnsemble → ENSEMBLE dim).
+    Expected shape: (3, 5) — PARAMETER first, ENSEMBLE second.
+    """
+    i_x = _dist_index("x")     # abstract: sampled by ensemble → ENSEMBLE dim
+    i_p = Index("p", 1.0)      # concrete default, swept via parameters= → PARAMETER dim
+    i_result = Index("result", i_p.node * i_x.node)
+    model = _make_model(i_x, i_p, i_result)
+
+    pp = np.array([1.0, 2.0, 3.0])
+    ens = DistributionEnsemble(model, size=5, rng=np.random.default_rng(0))
+
+    result = Evaluation(model).evaluate(ensemble=ens, parameters={i_p: pp})
+    arr = result[i_result]
+    # Shape: (N_p=3, S=5) — PARAMETER first, ENSEMBLE second
+    assert arr.shape == (3, 5)
+
+
+def test_no_shape_heuristic_constant_node():
+    """A constant node marginalizes to a scalar regardless of ENSEMBLE size."""
+    i_c = Index("c", 42.0)
+    i_x = _dist_index("x")   # gives DistributionEnsemble something to sample
+    model = _make_model(i_c, i_x)
+
+    ens = DistributionEnsemble(model, size=4, rng=np.random.default_rng(0))
+    result = Evaluation(model).evaluate(ensemble=ens)
+
+    marginalised = result.marginalize(i_c)
+    # Constant node: marginalize over ENSEMBLE should give scalar 42.0
+    assert float(marginalised) == pytest.approx(42.0)
+
+
+# ---------------------------------------------------------------------------
+# S == T regression (#142)
+# ---------------------------------------------------------------------------
+
+
+def test_s_equals_t_ensemble_contracted_not_time():
+    """S == T: ENSEMBLE axis contracted, time axis preserved — shape (T,).
+
+    Uses a timeseries constant (T=5 steps) and ensemble size S=5.
+    The historical bug would confuse which axis to contract.
+    """
+    T = 5
+    S = 5
+    ts = TimeseriesIndex("ts", np.arange(float(T)))  # shape (T,) = (5,)
+    i_x = _dist_index("x")
+    model = _make_model(ts, i_x)
+
+    ens = DistributionEnsemble(model, size=S, rng=np.random.default_rng(0))
+    result = Evaluation(model).evaluate(ensemble=ens)
+
+    # ts is a constant timeseries — marginalize over ENSEMBLE should preserve (T,)
+    marginalised = result.marginalize(ts)
+    assert marginalised.shape == (T,)
+    assert np.allclose(marginalised, np.arange(float(T)))
+
+
+def test_deterministic_timeseries_no_ensemble_contraction():
+    """Deterministic (ensemble=None) timeseries: no ENSEMBLE axis; shape stays (T,)."""
+    T = 24
+    ts = TimeseriesIndex("ts", np.ones(T))
+    model = _make_model(ts)
+
+    result = Evaluation(model).evaluate(ensemble=None)
+    marginalised = result.marginalize(ts)
+    assert marginalised.shape == (T,)
+    assert np.allclose(marginalised, np.ones(T))
+
+
+def test_two_ensemble_axes_one_equals_t():
+    """Two ENSEMBLE axes where S1 == T: both ENSEMBLE axes contracted, time preserved.
+
+    Setup: timeseries constant (T=24), PartitionedEnsemble with axes of sizes
+    S0=10 and S1=24.  marginalize() must contract S0 and S1, not time.
+    """
+    T = 24
+    S0 = 10
+    S1 = T  # deliberately equal to T
+    ts = TimeseriesIndex("ts", np.arange(float(T)))
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(ts, i_a, i_b)
+
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=S0),
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=S1),
+        ],
+        rng=np.random.default_rng(0),
+    )
+    result = Evaluation(model).evaluate(ensemble=ens)
+
+    # ts is constant — marginalize over both ENSEMBLE axes → shape (T,)
+    marginalised = result.marginalize(ts)
+    assert marginalised.shape == (T,)
+    assert np.allclose(marginalised, np.arange(float(T)))
+
+
+# ---------------------------------------------------------------------------
+# Broadcasting correctness (scalar ↔ timeseries)
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_ensemble_broadcasts_with_timeseries():
+    """Scalar abstract index (S,) broadcasts with timeseries (T,) → (S, T)."""
+    T = 6
+    S = 4
+    ts = TimeseriesIndex("ts", np.ones(T))
+    i_x = _dist_index("x")
+    i_result = Index("result", i_x.node * ts.node)
+    model = _make_model(ts, i_x, i_result)
+
+    ens = DistributionEnsemble(model, size=S, rng=np.random.default_rng(0))
+    result = Evaluation(model).evaluate(ensemble=ens)
+
+    arr = result[i_result]
+    # Shape should be (S, T) = (4, 6) — ENSEMBLE then DOMAIN
+    assert arr.shape == (S, T)
+
+
+def test_index_sum_axis_minus1_over_timeseries_with_ensemble():
+    """Index.sum(axis=-1) on timeseries+ensemble: time reduced, shape (*ENSEMBLE, 1)."""
+    T = 6
+    S = 4
+    ts = TimeseriesIndex("ts", np.arange(1.0, T + 1))
+    i_x = _dist_index("x")
+    i_prod = Index("prod", i_x.node * ts.node)
+    i_sum = Index("sum", i_prod.sum(axis=-1))  # keepdims=True by convention
+    model = _make_model(ts, i_x, i_prod, i_sum)
+
+    ens = DistributionEnsemble(model, size=S, rng=np.random.default_rng(0))
+    result = Evaluation(model).evaluate(ensemble=ens)
+
+    arr = result[i_sum]
+    # sum(axis=-1) reduces T → 1 (keepdims): shape (S, 1)
+    assert arr.shape == (S, 1)
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility (deprecation window)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_iterable_emits_deprecation_warning():
+    """Passing Iterable[WeightedScenario] emits DeprecationWarning."""
+    i_x = _dist_index("x")
+    model = _make_model(i_x)
+    scenarios: list[WeightedScenario] = [(1.0, {i_x: 0.5})]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Evaluation(model).evaluate(scenarios)
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any("WeightedScenario" in str(w.message) for w in deprecations)
+
+
+def test_legacy_iterable_gives_correct_results():
+    """Legacy Iterable[WeightedScenario] adapter yields correct marginalised values."""
+    i_x = Index("x", None)
+    i_result = Index("result", i_x.node * 2.0)
+    model = _make_model(i_x, i_result)
+
+    scenarios: list[WeightedScenario] = [(0.5, {i_x: 1.0}), (0.5, {i_x: 3.0})]
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        result = Evaluation(model).evaluate(scenarios)
+
+    # E[result] = 0.5*(1*2) + 0.5*(3*2) = 0.5*2 + 0.5*6 = 4.0
+    assert float(result.marginalize(i_result)) == pytest.approx(4.0)
+
+
+def test_empty_scenario_list_is_deterministic():
+    """Passing [] emits DeprecationWarning and evaluates deterministically."""
+    i_c = Index("c", 7.0)
+    model = _make_model(i_c)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = Evaluation(model).evaluate([])
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations  # at least one deprecation warning
+    assert float(result.marginalize(i_c)) == pytest.approx(7.0)

--- a/tests/dt_model/simulation/test_acceptance_typed_axes.py
+++ b/tests/dt_model/simulation/test_acceptance_typed_axes.py
@@ -26,7 +26,6 @@ from civic_digital_twins.dt_model.simulation.ensemble import (
 )
 from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -97,7 +97,7 @@ def test_axes_single_axis_result_shape():
     model = _make_model(I_x)
     xs = np.array([1.0, 2.0, 3.0])
 
-    result = Evaluation(model).evaluate([(1.0, {})], axes={I_x: xs})
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={I_x: xs})
     assert result[I_x].shape == (3, 1)
 
 
@@ -109,7 +109,7 @@ def test_axes_two_axes_result_shape():
     xs = np.array([1.0, 2.0])
     ys = np.array([10.0, 20.0, 30.0])
 
-    result = Evaluation(model).evaluate([(1.0, {})], axes={I_x: xs, I_y: ys})
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={I_x: xs, I_y: ys})
     assert result[I_x].shape == (2, 1, 1)
     assert result[I_y].shape == (1, 3, 1)
 
@@ -124,7 +124,7 @@ def test_axes_non_axis_abstract_has_shape_1_1_s():
     a0: dict[GenericIndex, Any] = {I_factor: 1.0}
     a1: dict[GenericIndex, Any] = {I_factor: 2.0}
     scenarios: list[WeightedScenario] = [(0.5, a0), (0.5, a1)]
-    result = Evaluation(model).evaluate(scenarios, axes={I_x: xs})
+    result = Evaluation(model).evaluate(scenarios, parameters={I_x: xs})
     # Non-axis abstract: shape (1, S) = (1, 2)
     assert result[I_factor].shape == (1, 2)
 
@@ -142,7 +142,7 @@ def test_axes_single_axis_formula_values():
     model = _make_model(I_x, I_scale, I_result)
     xs = np.array([1.0, 2.0, 4.0])
 
-    result = Evaluation(model).evaluate([(1.0, {})], axes={I_x: xs})
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={I_x: xs})
     # shape (3, 1); marginalize: tensordot(..., [1.0], axes=([-1],[0])) → (3,)
     marginalised = result.marginalize(I_result)
     assert np.allclose(marginalised, [3.0, 6.0, 12.0])
@@ -157,7 +157,7 @@ def test_axes_two_axes_additive_formula():
     xs = np.array([1.0, 2.0])
     ys = np.array([10.0, 20.0, 30.0])
 
-    result = Evaluation(model).evaluate([(1.0, {})], axes={I_x: xs, I_y: ys})
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={I_x: xs, I_y: ys})
     marginalised = result.marginalize(I_result)
     # result[i, j] = xs[i] + ys[j]
     expected = xs[:, None] + ys[None, :]
@@ -176,7 +176,7 @@ def test_axes_non_axis_factor_marginalised_correctly():
     a1: dict[GenericIndex, Any] = {I_factor: 3.0}
     scenarios: list[WeightedScenario] = [(0.5, a0), (0.5, a1)]
 
-    result = Evaluation(model).evaluate(scenarios, axes={I_x: xs})
+    result = Evaluation(model).evaluate(scenarios, parameters={I_x: xs})
     marginalised = result.marginalize(I_result)
     # result[i] = xs[i] * mean_factor = xs[i] * 2
     assert np.allclose(marginalised, [2.0, 4.0, 6.0])
@@ -194,7 +194,7 @@ def test_axes_raises_on_unresolved_non_axis_abstract():
     model = _make_model(I_x, I_missing)
 
     with pytest.raises(ValueError, match="abstract index"):
-        Evaluation(model).evaluate([(1.0, {})], axes={I_x: np.array([1.0])})
+        Evaluation(model).evaluate([(1.0, {})], parameters={I_x: np.array([1.0])})
 
 
 def test_axes_axis_index_not_required_in_scenario():
@@ -203,7 +203,7 @@ def test_axes_axis_index_not_required_in_scenario():
     model = _make_model(I_x)
 
     # Should not raise — I_x is an axis, not required in scenario dict.
-    result = Evaluation(model).evaluate([(1.0, {})], axes={I_x: np.array([5.0, 10.0])})
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={I_x: np.array([5.0, 10.0])})
     assert result[I_x].shape == (2, 1)
 
 
@@ -228,25 +228,25 @@ def test_evaluation_result_weights_property():
     assert np.isclose(weights[1], 0.7)
 
 
-def test_evaluation_result_axes_property():
-    """EvaluationResult.axes returns the dict passed to evaluate()."""
+def test_evaluation_result_parameter_values_property():
+    """EvaluationResult.parameter_values returns the dict passed to evaluate()."""
     I_x = Index("x", None)
     model = _make_model(I_x)
     xs = np.array([1.0, 2.0, 3.0])
 
-    result = Evaluation(model).evaluate([(1.0, {})], axes={I_x: xs})
-    axes = result.axes
-    assert I_x in axes
-    assert np.array_equal(axes[I_x], xs)
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={I_x: xs})
+    pv = result.parameter_values
+    assert I_x in pv
+    assert np.array_equal(pv[I_x], xs)
 
 
-def test_evaluation_result_axes_property_empty_in_1d_mode():
-    """EvaluationResult.axes is empty when no axes are passed."""
+def test_evaluation_result_parameter_values_empty_in_1d_mode():
+    """EvaluationResult.parameter_values is empty when no parameters are passed."""
     I_x = Index("x", 1.0)
     model = _make_model(I_x)
 
     result = Evaluation(model).evaluate([])
-    assert result.axes == {}
+    assert result.parameter_values == {}
 
 
 def test_marginalize_constant_index():

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -55,8 +55,8 @@ def test_1d_single_scenario_placeholder():
     a: dict[GenericIndex, Any] = {I_x: 5.0}
     scenarios: list[WeightedScenario] = [(1.0, a)]
     result = Evaluation(model).evaluate(scenarios)
-    # Batch dim: shape (1,); value = 2 * 5 = 10
-    assert result[I_result].shape == (1,)
+    # Shape (S, 1): S=1 scenario, trailing 1 from DOMAIN placeholder; value = 2 * 5 = 10
+    assert result[I_result].shape == (1, 1)
     assert np.isclose(result[I_result][0], 10.0)
 
 
@@ -70,7 +70,7 @@ def test_1d_multiple_scenarios():
     a1: dict[GenericIndex, Any] = {I_x: 3.0}
     scenarios: list[WeightedScenario] = [(0.5, a0), (0.5, a1)]
     result = Evaluation(model).evaluate(scenarios)
-    assert result[I_result].shape == (2,)
+    assert result[I_result].shape == (2, 1)
     assert np.isclose(result[I_result][0], 4.0)
     assert np.isclose(result[I_result][1], 9.0)
 

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -281,6 +281,99 @@ def test_marginalize_1d_squeeze_scalar():
 # ---------------------------------------------------------------------------
 
 
+def test_result_axes_deprecated_property():
+    """EvaluationResult.axes emits DeprecationWarning and returns parameter_values."""
+    import warnings
+
+    I_x = Index("x", None)
+    model = _make_model(I_x)
+    xs = np.array([1.0, 2.0])
+
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={I_x: xs})
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        axes = result.axes
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any("result.axes" in str(w.message) for w in deprecations)
+    assert I_x in axes
+
+
+def test_result_parameter_values_for():
+    """EvaluationResult.parameter_values_for() returns the array for a given index."""
+    I_x = Index("x", None)
+    model = _make_model(I_x)
+    xs = np.array([1.0, 2.0, 3.0])
+
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={I_x: xs})
+    assert np.array_equal(result.parameter_values_for(I_x), xs)
+
+
+def test_result_full_shape_no_axes():
+    """EvaluationResult.full_shape is () when there are no axes at all."""
+    I_c = Index("c", 5.0)
+    model = _make_model(I_c)
+
+    result = Evaluation(model).evaluate(ensemble=None)
+    assert result.full_shape == ()
+
+
+def test_result_weights_no_ensemble():
+    """EvaluationResult.weights returns empty array when there are no ENSEMBLE axes."""
+    I_c = Index("c", 5.0)
+    model = _make_model(I_c)
+
+    result = Evaluation(model).evaluate(ensemble=None)
+    assert result.weights.shape == (0,)
+
+
+def test_evaluate_raises_when_both_scenarios_and_ensemble():
+    """TypeError when both 'scenarios' and 'ensemble=' are supplied."""
+    from scipy import stats
+
+    from civic_digital_twins.dt_model.model.index import DistributionIndex
+    from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
+
+    I_x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 1.0})
+    model = _make_model(I_x)
+    ens = DistributionEnsemble(model, size=3)
+
+    scenario: dict[GenericIndex, Any] = {I_x: 0.5}
+    legacy: list[WeightedScenario] = [(1.0, scenario)]
+    with pytest.raises(TypeError, match="both"):
+        Evaluation(model).evaluate(legacy, ensemble=ens)
+
+
+def test_evaluate_raises_when_both_axes_and_parameters():
+    """TypeError when both 'axes=' and 'parameters=' are supplied."""
+    import warnings
+
+    I_x = Index("x", None)
+    model = _make_model(I_x)
+    xs = np.array([1.0, 2.0])
+
+    with pytest.raises(TypeError, match="both"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            Evaluation(model).evaluate([(1.0, {})], axes={I_x: xs}, parameters={I_x: xs})
+
+
+def test_evaluate_deprecated_axes_kwarg():
+    """Passing axes= emits DeprecationWarning and is equivalent to parameters=."""
+    import warnings
+
+    I_x = Index("x", None)
+    model = _make_model(I_x)
+    xs = np.array([1.0, 2.0])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = Evaluation(model).evaluate([(1.0, {})], axes={I_x: xs})
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any("axes" in str(w.message) for w in deprecations)
+    assert result[I_x].shape[0] == 2
+
+
 def test_distribution_ensemble_raises_for_non_distribution_abstract():
     """DistributionEnsemble raises ValueError when an abstract index has no distribution."""
     from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
@@ -290,6 +383,23 @@ def test_distribution_ensemble_raises_for_non_distribution_abstract():
 
     with pytest.raises(ValueError, match="unsupported indexes"):
         DistributionEnsemble(model, size=10)
+
+
+def test_distribution_ensemble_iteration_without_rng():
+    """DistributionEnsemble.__iter__ works without an explicit rng (rng=None path)."""
+    from scipy import stats
+
+    from civic_digital_twins.dt_model.model.index import DistributionIndex
+    from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
+
+    I_x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 1.0})
+    model = _make_model(I_x)
+
+    scenarios = list(DistributionEnsemble(model, size=5))
+    assert len(scenarios) == 5
+    w, a = scenarios[0]
+    assert np.isclose(w, 1.0 / 5)
+    assert I_x in a
 
 
 def test_distribution_ensemble_with_rng_is_reproducible():

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -259,7 +259,7 @@ def test_marginalize_constant_index():
 
 
 def test_marginalize_1d_squeeze_scalar():
-    """Marginalize squeezes the trailing size-1 dim added by DistributionEnsemble."""
+    """Marginalize of a pure-ENSEMBLE scalar result is a 0-d scalar array."""
     from scipy import stats
 
     from civic_digital_twins.dt_model.model.index import DistributionIndex
@@ -272,7 +272,7 @@ def test_marginalize_1d_squeeze_scalar():
     ensemble = DistributionEnsemble(model, size=50)
     result = Evaluation(model).evaluate(ensemble)
     marginalised = result.marginalize(I_result)
-    # Should be a plain scalar (0-d array), not shape (1,).
+    # ENSEMBLE axis contracted, DOMAIN placeholder squeezed → 0-d scalar.
     assert np.ndim(marginalised) == 0
 
 

--- a/tests/dt_model/simulation/test_model_variant_evaluation.py
+++ b/tests/dt_model/simulation/test_model_variant_evaluation.py
@@ -220,7 +220,7 @@ def test_grid_mode_categorical_selector_all_bike():
 
     # mode is a non-axis abstract; presence is the axis → single scenario needs mode assignment.
     manual_scenarios: list[WeightedScenario] = [(1.0, {mode: np.array(["bike"])})]
-    result = Evaluation(mv).evaluate(manual_scenarios, [mv.outputs.throughput], axes={presence: xs})
+    result = Evaluation(mv).evaluate(manual_scenarios, [mv.outputs.throughput], parameters={presence: xs})
 
     assert np.allclose(result.marginalize(mv.outputs.throughput), xs * 1.0)
 
@@ -232,7 +232,7 @@ def test_grid_mode_categorical_selector_all_train():
     xs = np.array([100.0, 200.0, 300.0])
 
     manual_scenarios: list[WeightedScenario] = [(1.0, {mode: np.array(["train"])})]
-    result = Evaluation(mv).evaluate(manual_scenarios, [mv.outputs.throughput], axes={presence: xs})
+    result = Evaluation(mv).evaluate(manual_scenarios, [mv.outputs.throughput], parameters={presence: xs})
 
     assert np.allclose(result.marginalize(mv.outputs.throughput), xs * 10.0)
 
@@ -250,7 +250,7 @@ def test_grid_mode_categorical_selector_mixed_scenarios():
         (0.5, {mode: np.array(["bike"])}),
         (0.5, {mode: np.array(["train"])}),
     ]
-    result = Evaluation(mv).evaluate(manual_scenarios, [mv.outputs.throughput], axes={presence: xs})
+    result = Evaluation(mv).evaluate(manual_scenarios, [mv.outputs.throughput], parameters={presence: xs})
 
     assert np.allclose(result.marginalize(mv.outputs.throughput), xs * 5.5)
 
@@ -276,7 +276,7 @@ def test_grid_mode_node_selector_from_axis():
     xs = np.array([100.0, 200.0, 300.0])
 
     # presence is the only abstract index and it is the axis → no assignments needed.
-    result = Evaluation(mv).evaluate([(1.0, {})], [mv.outputs.throughput], axes={presence: xs})
+    result = Evaluation(mv).evaluate([(1.0, {})], [mv.outputs.throughput], parameters={presence: xs})
 
     # presence=100 → bike → 100*1=100
     # presence=200 → train → 200*10=2000

--- a/tests/dt_model/simulation/test_partitioned_ensemble.py
+++ b/tests/dt_model/simulation/test_partitioned_ensemble.py
@@ -1,0 +1,282 @@
+"""Tests for PartitionedEnsemble — multi-axis batched ensemble."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from civic_digital_twins.dt_model.model.axis import ENSEMBLE
+from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+from civic_digital_twins.dt_model.model.model import Model
+from civic_digital_twins.dt_model.simulation.ensemble import EnsembleAxisSpec, PartitionedEnsemble
+from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dist_index(name: str, lo: float = 0.0, hi: float = 1.0) -> Index:
+    return DistributionIndex(name, stats.uniform, {"loc": lo, "scale": hi - lo})
+
+
+def _make_model(*indexes) -> Model:
+    return Model("test", list(indexes))
+
+
+# ---------------------------------------------------------------------------
+# Construction and validation
+# ---------------------------------------------------------------------------
+
+
+def test_construction_single_axis():
+    """PartitionedEnsemble with one axis wraps all abstract indexes."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+
+    ens = PartitionedEnsemble(model, axes=[EnsembleAxisSpec("unc", indexes=[i_a, i_b], size=10)])
+    assert len(ens.ensemble_axes) == 1
+    assert ens.ensemble_axes[0].name == "unc"
+    assert ens.ensemble_axes[0].role == ENSEMBLE
+    assert ens.ensemble_weights[0].shape == (10,)
+    assert np.isclose(ens.ensemble_weights[0].sum(), 1.0)
+
+
+def test_construction_two_axes():
+    """Two specs produce two ENSEMBLE axes with independent sizes."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=30),
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=50),
+        ],
+    )
+    assert len(ens.ensemble_axes) == 2
+    assert ens.ensemble_axes[0].name == "ax0"
+    assert ens.ensemble_axes[1].name == "ax1"
+    assert ens.ensemble_weights[0].shape == (30,)
+    assert ens.ensemble_weights[1].shape == (50,)
+
+
+def test_raises_on_uncovered_index_without_default():
+    """ValueError when an abstract index is not in any spec and default_axis is None."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+
+    with pytest.raises(ValueError, match="not covered"):
+        PartitionedEnsemble(model, axes=[EnsembleAxisSpec("ax0", indexes=[i_a], size=10)])
+
+
+def test_raises_on_non_abstract_index_in_spec():
+    """ValueError when a spec lists an index that is not abstract in the model."""
+    i_a = _dist_index("a")
+    i_outside = _dist_index("outside")
+    model = _make_model(i_a)
+
+    with pytest.raises(ValueError, match="not an abstract index"):
+        PartitionedEnsemble(model, axes=[EnsembleAxisSpec("ax", indexes=[i_a, i_outside], size=5)])
+
+
+def test_raises_on_duplicate_index_across_specs():
+    """ValueError when the same index appears in two specs."""
+    i_a = _dist_index("a")
+    model = _make_model(i_a)
+
+    with pytest.raises(ValueError, match="more than one"):
+        PartitionedEnsemble(
+            model,
+            axes=[
+                EnsembleAxisSpec("ax0", indexes=[i_a], size=5),
+                EnsembleAxisSpec("ax1", indexes=[i_a], size=5),
+            ],
+        )
+
+
+def test_raises_on_duplicate_spec_names():
+    """ValueError when two specs (or a spec and default_axis) share a name."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+
+    with pytest.raises(ValueError, match="Duplicate"):
+        PartitionedEnsemble(
+            model,
+            axes=[
+                EnsembleAxisSpec("unc", indexes=[i_a], size=5),
+                EnsembleAxisSpec("unc", indexes=[i_b], size=5),
+            ],
+        )
+
+
+def test_raises_on_duplicate_name_with_default_axis():
+    """ValueError when default_axis name clashes with an explicit spec name."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+
+    with pytest.raises(ValueError, match="Duplicate"):
+        PartitionedEnsemble(
+            model,
+            axes=[EnsembleAxisSpec("unc", indexes=[i_a], size=5)],
+            default_axis=EnsembleAxisSpec("unc", indexes=[], size=5),
+        )
+
+
+def test_default_axis_absorbs_unassigned():
+    """Unassigned abstract indexes are routed to the default_axis."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+
+    ens = PartitionedEnsemble(
+        model,
+        axes=[EnsembleAxisSpec("ax0", indexes=[i_a], size=10)],
+        default_axis=EnsembleAxisSpec("default", indexes=[], size=20),
+    )
+    assert len(ens.ensemble_axes) == 2
+    assert ens.ensemble_axes[1].name == "default"
+    assert ens.ensemble_weights[1].shape == (20,)
+
+
+# ---------------------------------------------------------------------------
+# assignments() shape contract
+# ---------------------------------------------------------------------------
+
+
+def test_assignments_shape_single_axis():
+    """Single-axis: each assignment has shape (S,)."""
+    i_a = _dist_index("a")
+    model = _make_model(i_a)
+    ens = PartitionedEnsemble(
+        model,
+        axes=[EnsembleAxisSpec("unc", indexes=[i_a], size=7)],
+        rng=np.random.default_rng(0),
+    )
+    asgn = ens.assignments()
+    assert i_a in asgn
+    assert asgn[i_a].shape == (7,)
+
+
+def test_assignments_shape_two_axes():
+    """Two-axis: index on axis-0 has shape (S0, 1); index on axis-1 has shape (1, S1)."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=30),
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=50),
+        ],
+        rng=np.random.default_rng(1),
+    )
+    asgn = ens.assignments()
+    assert asgn[i_a].shape == (30, 1)
+    assert asgn[i_b].shape == (1, 50)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation with PartitionedEnsemble
+# ---------------------------------------------------------------------------
+
+
+def test_evaluation_result_shape_two_axes():
+    """evaluate() with two ENSEMBLE axes gives result shape (S0, S1, 1)."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    i_result = Index("result", i_a.node + i_b.node)
+    model = _make_model(i_a, i_b, i_result)
+
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=10),
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=5),
+        ],
+        rng=np.random.default_rng(0),
+    )
+    result = Evaluation(model).evaluate(ensemble=ens)
+    arr = result[i_result]
+    # Shape: (S0=10, S1=5, 1) — trailing 1 from domain placeholder
+    assert arr.shape == (10, 5, 1)
+
+
+def test_marginalize_contracts_both_ensemble_axes():
+    """marginalize() contracts both ENSEMBLE axes; result is a scalar."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    i_result = Index("result", i_a.node + i_b.node)
+    model = _make_model(i_a, i_b, i_result)
+
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=200),
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=200),
+        ],
+        rng=np.random.default_rng(42),
+    )
+    result = Evaluation(model).evaluate(ensemble=ens)
+    marginalised = result.marginalize(i_result)
+    # Both a and b ~ Uniform(0,1); E[a+b] = 1.0
+    assert marginalised.shape == ()
+    assert float(marginalised) == pytest.approx(1.0, abs=0.1)
+
+
+def test_marginalize_order_independence():
+    """marginalize() result is the same regardless of ENSEMBLE axis order.
+
+    Reverses the spec order and checks the marginalised value is unchanged.
+    """
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    i_result = Index("result", i_a.node + i_b.node)
+    model = _make_model(i_a, i_b, i_result)
+
+    rng0 = np.random.default_rng(7)
+    ens_fwd = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=100),
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=100),
+        ],
+        rng=rng0,
+    )
+    rng1 = np.random.default_rng(7)
+    ens_rev = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=100),
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=100),
+        ],
+        rng=rng1,
+    )
+    m_fwd = float(Evaluation(model).evaluate(ensemble=ens_fwd).marginalize(i_result))
+    m_rev = float(Evaluation(model).evaluate(ensemble=ens_rev).marginalize(i_result))
+    assert m_fwd == pytest.approx(m_rev, rel=0.05)
+
+
+def test_factorized_weights_are_uniform():
+    """PartitionedEnsemble uses uniform weights per axis."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=4),
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=6),
+        ],
+        rng=np.random.default_rng(0),
+    )
+    w0, w1 = ens.ensemble_weights
+    assert np.allclose(w0, np.full(4, 0.25))
+    assert np.allclose(w1, np.full(6, 1.0 / 6))

--- a/tests/dt_model/simulation/test_partitioned_ensemble.py
+++ b/tests/dt_model/simulation/test_partitioned_ensemble.py
@@ -6,12 +6,11 @@ import numpy as np
 import pytest
 from scipy import stats
 
-from civic_digital_twins.dt_model.model.axis import ENSEMBLE
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
+from civic_digital_twins.dt_model.model.index import CategoricalIndex, DistributionIndex, Index
 from civic_digital_twins.dt_model.model.model import Model
 from civic_digital_twins.dt_model.simulation.ensemble import EnsembleAxisSpec, PartitionedEnsemble
 from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -262,6 +261,70 @@ def test_marginalize_order_independence():
     m_fwd = float(Evaluation(model).evaluate(ensemble=ens_fwd).marginalize(i_result))
     m_rev = float(Evaluation(model).evaluate(ensemble=ens_rev).marginalize(i_result))
     assert m_fwd == pytest.approx(m_rev, rel=0.05)
+
+
+def test_axis_repr():
+    """Axis.__repr__ returns a concise human-readable string."""
+    ax = Axis("my_axis", ENSEMBLE)
+    assert repr(ax) == "Axis('my_axis', role='ENSEMBLE')"
+
+
+def test_categorical_index_in_partitioned_ensemble():
+    """CategoricalIndex is sampled via its sample() in PartitionedEnsemble."""
+    i_cat = CategoricalIndex("mode", {"bike": 0.6, "train": 0.4})
+    model = _make_model(i_cat)
+
+    ens = PartitionedEnsemble(
+        model,
+        axes=[EnsembleAxisSpec("unc", indexes=[i_cat], size=10)],
+        rng=np.random.default_rng(0),
+    )
+    asgn = ens.assignments()
+    assert i_cat in asgn
+    assert asgn[i_cat].shape == (10,)
+    assert all(v in ("bike", "train") for v in asgn[i_cat])
+
+
+def test_partitioned_ensemble_without_rng():
+    """PartitionedEnsemble works without an explicit rng (rng=None path)."""
+    i_a = _dist_index("a")
+    model = _make_model(i_a)
+
+    ens = PartitionedEnsemble(model, axes=[EnsembleAxisSpec("unc", indexes=[i_a], size=5)])
+    asgn = ens.assignments()
+    assert i_a in asgn
+    assert asgn[i_a].shape == (5,)
+
+
+def test_result_weights_with_two_ensemble_axes():
+    """EvaluationResult.weights returns the joint weight array for two ENSEMBLE axes."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("ax0", indexes=[i_a], size=3),
+            EnsembleAxisSpec("ax1", indexes=[i_b], size=4),
+        ],
+        rng=np.random.default_rng(0),
+    )
+    result = Evaluation(model).evaluate(ensemble=ens)
+    w = result.weights
+    # Joint weight = outer product of (3,) and (4,) uniform weights → (3, 4)
+    assert w.shape == (3, 4)
+    assert np.isclose(w.sum(), 1.0)
+
+
+def test_raises_on_non_samplable_index_in_spec():
+    """ValueError when assignments() is called with a plain abstract index (no distribution)."""
+    I_plain = Index("plain", None)  # abstract but no distribution
+    model = _make_model(I_plain)
+
+    ens = PartitionedEnsemble(model, axes=[EnsembleAxisSpec("unc", indexes=[I_plain], size=5)])
+    with pytest.raises(ValueError, match="not Distribution-backed"):
+        ens.assignments()
 
 
 def test_factorized_weights_are_uniform():


### PR DESCRIPTION
## Summary

- Introduces `Axis`, `AxisRole`, `AxisEnsemble`, and `EnsembleAxisSpec` as first-class types; `DistributionEnsemble` and the new `PartitionedEnsemble` implement the `AxisEnsemble` protocol
- `Evaluation.evaluate()` accepts `AxisEnsemble` directly; result shape is canonically `(*PARAMETER, *ENSEMBLE, *DOMAIN)` with post-evaluation BFS canonicalization fixing the historical S==T ambiguity (#142)
- `OvertourismEnsemble` migrated from `Iterable[WeightedScenario]` to `AxisEnsemble`; legacy `scenarios=` / `axes=` kwargs and `result.axes` deprecated with warnings
- 100% branch coverage on `simulation/` package; all examples and doc-sync verified clean

Closes #142