### PR TITLE
fix(evaluation): enforce all-axes invariant (#155, #156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,11 +59,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `EvaluationResult.marginalize()` contracted the wrong axis when the ENSEMBLE size
-  equalled the timeseries length (`S == T`, #142).  The fix injects explicit ENSEMBLE
-  singleton dims post-evaluation so `marginalize()` always contracts the correct axis.
-- `marginalize()` no longer calls `squeeze()` on the result: only ENSEMBLE axes are
-  contracted; PARAMETER dims and non-trivial DOMAIN dims are preserved.
+- `EvaluationResult.marginalize()` raised `IndexError` on constant nodes in
+  grid+ensemble mode (two or more PARAMETER axes plus at least one ENSEMBLE axis)
+  (#155).
+- `Evaluation.evaluate()` raised `ValueError` (numpy broadcast failure) in
+  grid+ensemble+timeseries mode when the ENSEMBLE size differed from the timeseries
+  length (#156).  Also fixed for pure-PARAMETER+timeseries mode (no ensemble).
+- The all-axes invariant (`*PARAMETER, *ENSEMBLE, *domain` shape on every result
+  array) is now enforced for all axis combinations, including pure-PARAMETER mode.
+  Post-normalisation assertions verify the invariant at debug time.
+- **Breaking shape change (scalar ENSEMBLE results, no timeseries)** — in
+  pure-ENSEMBLE mode with no PARAMETER axes and no timeseries nodes, scalar
+  result arrays now have shape `(S,)` instead of `(S, 1)`.  `marginalize()`
+  output is identical; only direct `result[idx].shape` comparisons are affected.
+- `EvaluationResult.marginalize()` contracted the wrong axis when `S == T` (#142);
+  PARAMETER dims and non-trivial DOMAIN dims are now preserved.
 - Dependabot vulnerability alerts resolved: `fonttools` bumped to `>=4.60.2`
   (moderate) and `pillow` to `>=12.1.1` (high) via lockfile regeneration. (#132)
 

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -333,6 +333,14 @@ class Evaluation:
             else:
                 ensemble = None  # empty list → deterministic
 
+        # Pre-compute linearization and timeseries detection once.
+        # These are reused for executor.evaluate_nodes() and BFS normalisation below.
+        actual_nodes = [idx.node for idx in nodes_of_interest]
+        linearized_nodes = linearize.forest(*actual_nodes)
+        _has_timeseries = any(
+            isinstance(node, (graph.timeseries_constant, graph.timeseries_placeholder)) for node in linearized_nodes
+        )
+
         n_params = len(parameters)
         axis_layout: dict[Axis, int] = {}
         axis_sizes: dict[Axis, int] = {}
@@ -362,61 +370,96 @@ class Evaluation:
                 factorized_weights[ax] = w
             for idx, batched in ens_assignments.items():
                 # Prepend n_params PARAMETER singletons.
-                # In pure-ensemble mode (no PARAMETER axes), also append a
-                # trailing 1 for scalar assignments so they broadcast with
-                # timeseries (T,) nodes: (S,) → (S, 1) × (T,) → (S, T).
+                # When the model contains timeseries nodes, also append a
+                # trailing 1 for scalar (non-timeseries) assignments so they
+                # broadcast with timeseries (T,) nodes:
+                # (S, 1) × (T,) → (S, T).
                 param_singletons = (1,) * n_params
                 target = param_singletons + batched.shape
-                if n_params == 0 and batched.ndim == n_ensemble:
+                if _has_timeseries and batched.ndim == n_ensemble:
                     target = target + (1,)
                 ens_subs[idx.node] = np.reshape(batched, target)
 
-        # Extend PARAMETER subs with n_ensemble trailing singleton dims.
-        if n_ensemble > 0:
-            ens_singletons = (1,) * n_ensemble
+        # Extend PARAMETER subs with trailing singleton dims:
+        # - one per ENSEMBLE axis (so PARAMETER arrays broadcast against ENSEMBLE arrays),
+        # - plus one extra timeseries placeholder when the graph has timeseries nodes
+        #   (so (N, …, 1) broadcasts against a bare (T,) timeseries).
+        extra_ts = 1 if _has_timeseries else 0
+        trailing_singletons = (1,) * (n_ensemble + extra_ts)
+        if trailing_singletons:
             for node in param_nodes:
-                c_subs[node] = c_subs[node].reshape(c_subs[node].shape + ens_singletons)
+                c_subs[node] = c_subs[node].reshape(c_subs[node].shape + trailing_singletons)
 
         c_subs.update(ens_subs)
 
-        actual_nodes = [idx.node for idx in nodes_of_interest]
-        state = executor.State(c_subs, functions=functions or {})
-        executor.evaluate_nodes(state, *linearize.forest(*actual_nodes))
+        # Snapshot the substituted node keys before the executor mutates state.values
+        # (executor.State takes c_subs by reference and adds all computed nodes into it).
+        substituted_nodes: set[graph.Node] = set(c_subs)
 
-        # Normalize result arrays: inject an explicit ENSEMBLE singleton dim at
-        # every ENSEMBLE axis position for nodes that did NOT receive any ENSEMBLE
-        # substitution (directly or transitively).  Without this, a constant
-        # timeseries node (T,) is indistinguishable from an ENSEMBLE result (S,)
-        # when S == T, causing marginalize() to erroneously contract the time axis.
-        if n_ensemble > 0:
-            ensemble_positions: list[tuple[int, int]] = [
-                (n_params + j, axis_sizes[ax])
-                for j, ax in enumerate(ensemble.ensemble_axes)  # type: ignore[union-attr]
-            ]
-            # Build the set of nodes that are downstream of ENSEMBLE substitutions
-            # (i.e., touched by ENSEMBLE data) via forward BFS through the graph.
-            ens_touched: set[graph.Node] = set(ens_subs)
-            for node in linearize.forest(*actual_nodes):
-                if node in ens_touched:
+        state = executor.State(c_subs, functions=functions or {})
+        executor.evaluate_nodes(state, *linearized_nodes)
+
+        # Normalise result arrays: every actual node must have shape
+        # (*PARAMETER, *ENSEMBLE, *domain) with explicit singletons where
+        # the node does not vary along an axis.
+        #
+        # All-or-nothing property: a node is either
+        #   (a) downstream of some substitution → executor already produced
+        #       the correct shape via numpy broadcasting; or
+        #   (b) not downstream of any substitution → natural shape with zero
+        #       leading dims (scalar () or bare timeseries (T,)).
+        #
+        # A single reshape prepending (n_total - arr.ndim) singletons handles
+        # both subcases of (b), eliminating the need for a per-axis loop.
+        n_full = n_params + n_ensemble
+        n_total = n_full + extra_ts
+
+        if n_total > 0:
+            # all_touched: nodes transitively downstream of any substitution.
+            # Use the pre-executor snapshot so that constant nodes evaluated by
+            # the executor don't accidentally appear as "substituted".
+            all_touched: set[graph.Node] = set(substituted_nodes)
+            for node in linearized_nodes:
+                if node in all_touched:
                     continue
-                if any(dep in ens_touched for dep in linearize._get_dependencies(node)):
-                    ens_touched.add(node)
+                if any(dep in all_touched for dep in linearize._get_dependencies(node)):
+                    all_touched.add(node)
 
             for node in actual_nodes:
-                if node in ens_touched or node not in state.values:
-                    continue  # already has correct ENSEMBLE dims
+                if node in all_touched or node not in state.values:
+                    continue  # already has correct shape via substitution/broadcasting
                 arr = np.asarray(state.values[node])
-                modified = False
-                for pos, _ in ensemble_positions:
-                    # Insert singleton at pos: node has no ENSEMBLE data there.
-                    # Clamp insertion point to arr.ndim (appending at end for
-                    # arrays shorter than pos, e.g. scalars or 1-D constants).
-                    insert_at = min(pos, arr.ndim)
-                    if arr.ndim <= pos or arr.shape[pos] != 1:
-                        arr = np.expand_dims(arr, axis=insert_at)
-                        modified = True
-                if modified:
-                    state.values[node] = arr
+                # All-or-nothing invariant: untouched nodes must have natural
+                # shape (zero leading dims: scalar or bare timeseries).
+                assert arr.ndim in ({0, 1} if _has_timeseries else {0}), (
+                    f"Untouched node {getattr(node, 'name', repr(node))!r}: "
+                    f"unexpected ndim={arr.ndim} (has_timeseries={_has_timeseries})"
+                )
+                # Inject (n_total - arr.ndim) leading singletons.
+                # Scalars get the full n_total prefix (including the timeseries
+                # placeholder when _has_timeseries); timeseries nodes get n_full
+                # singletons and keep their trailing (T,) dimension.
+                n_inject = n_total - arr.ndim
+                state.values[node] = arr.reshape((1,) * n_inject + arr.shape)
+
+        # Post-normalisation invariant: every actual node must carry the
+        # correct number of leading axis dims and valid sizes at each
+        # axis position.  Guarded by __debug__ to avoid the loop overhead
+        # when running with python -O.
+        if __debug__:
+            for node in actual_nodes:
+                if node not in state.values:
+                    continue
+                arr = np.asarray(state.values[node])
+                assert arr.ndim == n_total, (
+                    f"Post-norm: node {getattr(node, 'name', repr(node))!r} ndim={arr.ndim}, expected {n_total}"
+                )
+                for ax, pos in axis_layout.items():
+                    assert arr.shape[pos] in {1, axis_sizes[ax]}, (
+                        f"Post-norm: node {getattr(node, 'name', repr(node))!r} "
+                        f"axis {ax.name!r} at pos {pos}: shape[{pos}]={arr.shape[pos]}, "
+                        f"expected 1 or {axis_sizes[ax]}"
+                    )
 
         return EvaluationResult(
             state,

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -209,6 +209,24 @@ class EvaluationResult:
         size 1.  Trailing size-1 DOMAIN placeholder dims are removed so
         that pure-scalar results are returned as 0-d arrays rather than
         shape ``(1,)`` arrays.
+
+        Known limitation — T=1 timeseries
+        ----------------------------------
+        When a model contains timeseries nodes, ``evaluate()`` appends a
+        trailing size-1 placeholder dimension to every scalar substitution
+        so that scalars broadcast correctly against ``(T,)`` arrays.  After
+        ENSEMBLE contraction in :meth:`marginalize`, this placeholder is
+        indistinguishable from a genuine length-1 timeseries trailing dim,
+        and both are squeezed away here.  As a result,
+        ``marginalize(ts)`` for a ``TimeseriesIndex`` of length 1 returns a
+        0-d scalar rather than a shape-``(1,)`` array — the time axis is
+        silently dropped.
+
+        The root cause is the absence of explicit DOMAIN axis tracking: the
+        engine has no way to tag "this dimension is the time axis" vs "this
+        dimension is an internal broadcast placeholder".  A proper fix
+        requires first-class DOMAIN axis support (see issue #157 and the
+        D12/D13 design sprint).
         """
         domain_dims = tuple(i for i in range(n_params, arr.ndim) if arr.shape[i] == 1)
         if domain_dims:

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -466,8 +466,10 @@ class Evaluation:
         # when running with python -O.
         if __debug__:
             for node in actual_nodes:
-                if node not in state.values:
-                    continue
+                assert node in state.values, (
+                    f"Post-norm: node {getattr(node, 'name', repr(node))!r} missing from "
+                    f"state after evaluate_nodes — this is a bug in the executor"
+                )
                 arr = np.asarray(state.values[node])
                 assert arr.ndim == n_total, (
                     f"Post-norm: node {getattr(node, 'name', repr(node))!r} ndim={arr.ndim}, expected {n_total}"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,12 +149,12 @@ result = Evaluation(co2_model).evaluate(ensemble)
 ```
 
 `result` is an `EvaluationResult`.  Use `result[idx]` for the raw array
-(shape `(S, 1)` here — `S` ENSEMBLE samples, trailing 1 from the DOMAIN
-placeholder) and `result.marginalize(idx)` for the weighted expectation:
+(shape `(S,)` here — `S` ENSEMBLE samples) and `result.marginalize(idx)`
+for the weighted expectation:
 
 ```python
 # Distribution of CO2 across 1000 scenarios
-co2_samples = result[co2]          # np.ndarray, shape (1000, 1)
+co2_samples = result[co2]          # np.ndarray, shape (1000,)
 
 # Expected (mean) CO2
 co2_mean = result.marginalize(co2) # scalar

--- a/examples/doc/doc_getting_started.py
+++ b/examples/doc/doc_getting_started.py
@@ -102,10 +102,10 @@ ensemble = DistributionEnsemble(co2_model, size=1000)
 result = Evaluation(co2_model).evaluate(ensemble)
 
 co2 = co2_model.outputs.co2   # access via contractual output
-co2_samples = result[co2]            # np.ndarray, shape (1000, 1)
+co2_samples = result[co2]            # np.ndarray, shape (1000,)
 co2_mean = result.marginalize(co2)   # scalar
 
-assert co2_samples.shape == (1000, 1)
+assert co2_samples.shape == (1000,)
 # E[CO2] = E[distance / fuel_efficiency * 2.31]
 # distance ~ U(50,80), fuel_efficiency ~ U(10,15)  → reasonable range
 assert 0 < co2_mean < 200, f"Unexpected CO2 mean: {co2_mean:.1f}"

--- a/tests/dt_model/simulation/test_acceptance_typed_axes.py
+++ b/tests/dt_model/simulation/test_acceptance_typed_axes.py
@@ -189,6 +189,120 @@ def test_index_sum_axis_minus1_over_timeseries_with_ensemble():
 
 
 # ---------------------------------------------------------------------------
+# Known gap — PARAMETER + timeseries, no ensemble (#157)
+# ---------------------------------------------------------------------------
+
+
+def test_parameter_timeseries_no_ensemble_broadcast():
+    """PARAMETER sweep × timeseries with no ensemble broadcasts correctly.
+
+    With n_ensemble=0, PARAMETER substitutions get a trailing timeseries
+    placeholder so (N, 1) × (T,) → (N, T).
+    """
+    T = 6
+    N = 3  # deliberately different from T
+    assert N != T
+
+    ts = TimeseriesIndex("ts", np.ones(T))
+    i_p = Index("p", 1.0)
+    i_result = Index("result", i_p.node * ts.node)
+    model = _make_model(ts, i_p, i_result)
+
+    pp = np.array([1.0, 2.0, 3.0])
+    assert pp.size == N
+
+    # No ensemble — pure PARAMETER sweep.  Expected shape: (N, T) = (3, 6).
+    result = Evaluation(model).evaluate(ensemble=None, parameters={i_p: pp})
+    arr = result[i_result]
+    assert arr.shape == (N, T)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — all-axes invariant bugs (#155, #156)
+# ---------------------------------------------------------------------------
+
+
+def test_grid_ensemble_constant_no_indexerror():
+    """grid+ensemble: constant node marginalises correctly without IndexError (#155).
+
+    Bug: with 2 PARAMETER axes and 1 ENSEMBLE axis the old per-axis singleton
+    insertion clamped to position 0 for a scalar constant, producing shape (1,)
+    instead of (1, 1, 1).  marginalize() then tried arr.shape[2] → IndexError.
+    """
+    i_x = Index("x", None)
+    i_y = Index("y", None)
+    i_c = Index("c", 42.0)
+    model = _make_model(i_x, i_y, i_c)
+
+    xs = np.array([1.0, 2.0])
+    ys = np.array([10.0, 20.0, 30.0])
+
+    result = Evaluation(model).evaluate([(1.0, {})], parameters={i_x: xs, i_y: ys})
+    # Must not raise IndexError.  The constant has PARAMETER singleton dims
+    # preserved (shape (1, 1)) so we test all values equal 42.0.
+    marginalised = result.marginalize(i_c)
+    assert np.all(np.isclose(marginalised, 42.0))
+
+
+def test_grid_ensemble_timeseries_broadcast_no_valueerror():
+    """grid+ensemble+timeseries: PARAMETER sub broadcasts with timeseries (#156).
+
+    Bug: with at least one PARAMETER axis the `n_params == 0` guard suppressed
+    the trailing-1 appended to ENSEMBLE substitutions, so an ENSEMBLE scalar
+    assignment got shape (S,) instead of (S, 1).  A formula that multiplied a
+    PARAMETER result (N, S) by a timeseries (T,) then tried to broadcast (N, S)
+    against T → ValueError when S != T.
+    """
+    T = 7
+    S = 4
+    ts = TimeseriesIndex("ts", np.ones(T))
+    i_x = _dist_index("x")
+    i_p = Index("p", 1.0)
+    i_result = Index("result", i_p.node * i_x.node * ts.node)
+    model = _make_model(ts, i_x, i_p, i_result)
+
+    pp = np.array([1.0, 2.0, 3.0])
+    ens = DistributionEnsemble(model, size=S, rng=np.random.default_rng(0))
+
+    # Must not raise ValueError during evaluate().
+    result = Evaluation(model).evaluate(ensemble=ens, parameters={i_p: pp})
+    arr = result[i_result]
+    # Shape: (N_p=3, S=4, T=7)
+    assert arr.shape == (3, S, T)
+
+
+def test_grid_ensemble_constant_and_timeseries_both_normalised():
+    """grid+ensemble+timeseries: constant AND timeseries nodes both get correct shape.
+
+    Combines #155 and #156 in one model: 1 PARAMETER axis, 1 ENSEMBLE axis,
+    1 timeseries constant, 1 scalar constant — both must be injectable as
+    singleton dims at all n_full positions.
+    """
+    T = 5
+    S = 3
+    N = 2
+    ts = TimeseriesIndex("ts", np.arange(float(T)))
+    i_c = Index("c", 10.0)
+    i_x = _dist_index("x")
+    i_p = Index("p", 1.0)
+    model = _make_model(ts, i_c, i_x, i_p)
+
+    pp = np.array([1.0, 2.0])
+    assert pp.size == N
+    ens = DistributionEnsemble(model, size=S, rng=np.random.default_rng(0))
+
+    result = Evaluation(model).evaluate(ensemble=ens, parameters={i_p: pp})
+    # Constant scalar: PARAMETER singleton dims are preserved by _squeeze_domain,
+    # so shape is (1,) after squeezing the ENSEMBLE dim.  All values equal 10.0.
+    assert np.all(np.isclose(result.marginalize(i_c), 10.0))
+    # Timeseries: not downstream of any substitution → (1, 1, T) after normalisation.
+    # After squeezing ENSEMBLE singleton at pos 1 → (1, T); PARAMETER singleton preserved.
+    marginalised_ts = result.marginalize(ts)
+    assert marginalised_ts.shape == (1, T)
+    assert np.allclose(marginalised_ts, np.arange(float(T))[None, :])
+
+
+# ---------------------------------------------------------------------------
 # Backward compatibility (deprecation window)
 # ---------------------------------------------------------------------------
 

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -55,8 +55,9 @@ def test_1d_single_scenario_placeholder():
     a: dict[GenericIndex, Any] = {I_x: 5.0}
     scenarios: list[WeightedScenario] = [(1.0, a)]
     result = Evaluation(model).evaluate(scenarios)
-    # Shape (S, 1): S=1 scenario, trailing 1 from DOMAIN placeholder; value = 2 * 5 = 10
-    assert result[I_result].shape == (1, 1)
+    # Shape (S,): S=1 scenario; value = 2 * 5 = 10
+    # (No trailing DOMAIN placeholder in non-timeseries models after bug fix #155.)
+    assert result[I_result].shape == (1,)
     assert np.isclose(result[I_result][0], 10.0)
 
 
@@ -70,7 +71,7 @@ def test_1d_multiple_scenarios():
     a1: dict[GenericIndex, Any] = {I_x: 3.0}
     scenarios: list[WeightedScenario] = [(0.5, a0), (0.5, a1)]
     result = Evaluation(model).evaluate(scenarios)
-    assert result[I_result].shape == (2, 1)
+    assert result[I_result].shape == (2,)
     assert np.isclose(result[I_result][0], 4.0)
     assert np.isclose(result[I_result][1], 9.0)
 

--- a/tests/dt_model/simulation/test_model_variant_evaluation.py
+++ b/tests/dt_model/simulation/test_model_variant_evaluation.py
@@ -184,15 +184,16 @@ def test_evaluation_emissions_train_only():
 
 
 def test_selector_index_accessible_in_result():
-    """result[mv._selector_index] returns a (S, 1) string array of variant keys."""
+    """result[mv._selector_index] returns a (S,) string array of variant keys."""
     mode = CategoricalIndex("mode", {"bike": 1.0})
     mv = _make_mv_with_mode(mode)
     ens = DistributionEnsemble(mv, size=3, rng=np.random.default_rng(0))
     ev = Evaluation(mv)
     result = ev.evaluate(ens, [mv._selector_index, mv.outputs.throughput])
     arr = result[mv._selector_index]
-    # Should be shape (S, 1) with all entries "bike"
-    assert arr.shape == (3, 1)
+    # Should be shape (S,) with all entries "bike"
+    # (No trailing DOMAIN placeholder in non-timeseries models after bug fix #155.)
+    assert arr.shape == (3,)
     assert all(v == "bike" for v in arr.ravel())
 
 

--- a/tests/dt_model/simulation/test_partitioned_ensemble.py
+++ b/tests/dt_model/simulation/test_partitioned_ensemble.py
@@ -188,7 +188,7 @@ def test_assignments_shape_two_axes():
 
 
 def test_evaluation_result_shape_two_axes():
-    """evaluate() with two ENSEMBLE axes gives result shape (S0, S1, 1)."""
+    """evaluate() with two ENSEMBLE axes gives result shape (S0, S1)."""
     i_a = _dist_index("a")
     i_b = _dist_index("b")
     i_result = Index("result", i_a.node + i_b.node)
@@ -204,8 +204,8 @@ def test_evaluation_result_shape_two_axes():
     )
     result = Evaluation(model).evaluate(ensemble=ens)
     arr = result[i_result]
-    # Shape: (S0=10, S1=5, 1) — trailing 1 from domain placeholder
-    assert arr.shape == (10, 5, 1)
+    # Shape: (S0=10, S1=5) — no trailing DOMAIN placeholder in non-timeseries models after bug fix #155
+    assert arr.shape == (10, 5)
 
 
 def test_marginalize_contracts_both_ensemble_axes():


### PR DESCRIPTION
## Summary

Fixes two bugs introduced in v0.9.0 (PR #149) that broke evaluation when PARAMETER axes, ENSEMBLE axes, and timeseries nodes were combined. Both stem from the same root cause: the post-evaluation shape normalisation was incomplete.

## Bug #155 — `IndexError` in grid+ensemble mode

`marginalize()` raised `IndexError` on constant nodes when the model was evaluated with two or more PARAMETER axes plus at least one ENSEMBLE axis.

## Bug #156 — `ValueError` in grid+ensemble+timeseries mode

`evaluate()` raised a numpy broadcast `ValueError` when PARAMETER axes, an ENSEMBLE, and timeseries nodes were all present and the ENSEMBLE size differed from the timeseries length. This was also broken in pure-PARAMETER+timeseries mode (no ensemble).

## What changed

- The per-axis singleton-insertion loop is replaced by a unified reshape that enforces the *all-or-nothing* invariant: nodes not downstream of any substitution always have natural shape (zero leading dims), so a single `reshape((1,) * n_total + arr.shape)` is always correct.
- `n_total = n_params + n_ensemble + extra_ts` is the single authoritative expected ndim for every result node. `extra_ts = 1` when the graph contains timeseries nodes, ensuring scalars and timeseries nodes all carry a consistent number of dims.
- The normalisation and post-normalisation assertions now run for all axis combinations, not only when an ENSEMBLE is present.
- Post-normalisation `assert` statements (elided by `python -O`) verify the invariant for every result node after evaluation.

## Breaking shape change

In pure-ENSEMBLE mode with no PARAMETER axes and no timeseries nodes, scalar result arrays are now `(S,)` instead of `(S, 1)`. The trailing `1` was an artefact of the old workaround. `marginalize()` output is identical; only direct `result[idx].shape` comparisons are affected.

## Known limitation (#157)

`marginalize()` silently drops the time axis for `T=1` timeseries (returns a scalar instead of shape `(1,)`). A proper fix requires first-class DOMAIN axis tracking and is deferred.

---

**Closes #155, #156.**