### PR TITLE
fix(#147): PresenceVariable accepts distribution callable returning frozen scipy distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `scipy-stubs` added to dev dependencies for improved type checking.
+- Pyright now checks `examples/` directory (previously only `civic_digital_twins` and `tests`).
+
 **Typed axes — canonical shape contract for evaluation results**
 
 - `Axis(name, role)` and `AxisRole` (`PARAMETER`, `ENSEMBLE`, `DOMAIN`) — explicit
@@ -58,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eliminating source-compilation delays in CI. (#122)
 
 ### Fixed
+
+- `PresenceVariable` now accepts a distribution callable that returns a frozen
+  scipy distribution (e.g. `scipy.stats.truncnorm`) instead of a dict with
+  `mean`/`std` keys. The `sample()` method calls `.rvs()` on the returned
+  distribution. This fixes the pyright type error in the getting started
+  guide (#147).
 
 - `EvaluationResult.marginalize()` raised `IndexError` on constant nodes in
   grid+ensemble mode (two or more PARAMETER axes plus at least one ENSEMBLE axis)

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -32,7 +32,9 @@ def _demo_00_index_modes() -> None:
     """Block 00: Index modes."""
     from scipy import stats
     from civic_digital_twins.dt_model.model.index import (
-        ConstIndex, DistributionIndex, Index,
+        ConstIndex,
+        DistributionIndex,
+        Index,
     )
 
     # Distribution-backed (abstract — must be resolved in each scenario)
@@ -94,7 +96,7 @@ def _demo_05_legacy_api() -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        model = Model("demo", [x, y, z])   # DeprecationWarning
+        model = Model("demo", [x, y, z])  # DeprecationWarning
 
     assert len(model.abstract_indexes()) == 2
     assert model.is_instantiated() is False
@@ -190,7 +192,7 @@ def _demo_17_constraint() -> None:
     @dataclass(eq=False)
     class Constraint:
         name: str
-        usage: Index     # formula-mode index for usage
+        usage: Index  # formula-mode index for usage
         capacity: Index  # constant or distribution-backed capacity
 
     usage = Index("usage_demo", 1.0)
@@ -222,12 +224,20 @@ def _demo_18_20_overtourism() -> None:
         {"good": 0.5, "unsettled": 0.3, "bad": 0.2},
     )
 
-    PV_tourists = PresenceVariable(
-        "tourists", [CV_weather], lambda w: {"mean": 5000.0, "std": 1000.0}
-    )
-    PV_excursionists = PresenceVariable(
-        "excursionists", [CV_weather], lambda w: {"mean": 3000.0, "std": 500.0}
-    )
+    def tourist_dist(w):
+        mean, std = 5000.0, 1000.0
+        a = -mean / std
+        b = 10.0
+        return stats.truncnorm(a, b, loc=mean, scale=std)
+
+    def excursionist_dist(w):
+        mean, std = 3000.0, 500.0
+        a = -mean / std
+        b = 10.0
+        return stats.truncnorm(a, b, loc=mean, scale=std)
+
+    PV_tourists = PresenceVariable("tourists", [CV_weather], tourist_dist)
+    PV_excursionists = PresenceVariable("excursionists", [CV_weather], excursionist_dist)
 
     usage_idx = Index("usage", PV_tourists + PV_excursionists)
     capacity_idx = ConstIndex("capacity_idx", 100_000.0)
@@ -243,10 +253,10 @@ def _demo_18_20_overtourism() -> None:
     )
 
     # Block 18 — OvertourismModel attribute access
-    model.cvs          # list[ContextVariable]
-    model.pvs          # list[PresenceVariable]
-    model.domain_indexes   # list[Index]  (e.g. scaling factors)
-    model.capacities   # list[Index]      (capacity indexes)
+    model.cvs  # list[ContextVariable]
+    model.pvs  # list[PresenceVariable]
+    model.domain_indexes  # list[Index]  (e.g. scaling factors)
+    model.capacities  # list[Index]      (capacity indexes)
     model.constraints  # list[Constraint]
 
     # Block 19 — OvertourismEnsemble
@@ -257,8 +267,8 @@ def _demo_18_20_overtourism() -> None:
     )
 
     # Block 20 — Grid Evaluation with OvertourismEnsemble
-    tt = np.linspace(0, 50_000, 101)   # tourist presence axis
-    ee = np.linspace(0, 50_000, 101)   # excursionist presence axis
+    tt = np.linspace(0, 50_000, 101)  # tourist presence axis
+    ee = np.linspace(0, 50_000, 101)  # excursionist presence axis
 
     result = Evaluation(model).evaluate(
         ensemble,

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -225,16 +225,10 @@ def _demo_18_20_overtourism() -> None:
     )
 
     def tourist_dist(w):
-        mean, std = 5000.0, 1000.0
-        a = -mean / std
-        b = 10.0
-        return stats.truncnorm(a, b, loc=mean, scale=std)
+        return stats.uniform(loc=4000.0, scale=2000.0)
 
     def excursionist_dist(w):
-        mean, std = 3000.0, 500.0
-        a = -mean / std
-        b = 10.0
-        return stats.truncnorm(a, b, loc=mean, scale=std)
+        return stats.uniform(loc=2500.0, scale=1000.0)
 
     PV_tourists = PresenceVariable("tourists", [CV_weather], tourist_dist)
     PV_excursionists = PresenceVariable("excursionists", [CV_weather], excursionist_dist)

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -38,7 +38,7 @@ CV_weather = UniformCategoricalContextVariable(
     ["good", "unsettled", "bad"],
 )
 
-assert CV_season.value is None    # placeholder
+assert CV_season.value is None  # placeholder
 assert CV_weather.value is None
 
 
@@ -46,19 +46,27 @@ assert CV_weather.value is None
 # overtourism-getting-started.md §2 — Presence variable
 # ---------------------------------------------------------------------------
 
-presence_stats = {
-    ("low", "good"): (2_000, 500),
-    ("low", "unsettled"): (1_500, 400),
-    ("low", "bad"): (1_000, 300),
-    ("high", "good"): (8_000, 2_000),
-    ("high", "unsettled"): (6_000, 1_500),
-    ("high", "bad"): (4_000, 1_000),
-}
+
+def visitors_distribution(season, weather):
+    """Return a truncated-normal distribution for visitor presence."""
+    presence_stats = {
+        ("low", "good"): (2_000, 500),
+        ("low", "unsettled"): (1_500, 400),
+        ("low", "bad"): (1_000, 300),
+        ("high", "good"): (8_000, 2_000),
+        ("high", "unsettled"): (6_000, 1_500),
+        ("high", "bad"): (4_000, 1_000),
+    }
+    mean, std = presence_stats[(season, weather)]
+    a = -mean / std
+    b = 10.0
+    return stats.truncnorm(a, b, loc=mean, scale=std)
+
 
 PV_visitors = PresenceVariable(
     "visitors",
     [CV_season, CV_weather],
-    presence_stats,
+    visitors_distribution,
 )
 
 assert PV_visitors.value is None  # placeholder (axis in grid evaluation)
@@ -166,7 +174,4 @@ assert field[0] > 0.9
 
 
 if __name__ == "__main__":
-    print(
-        f"doc_overtourism_getting_started.py: all snippets OK  "
-        f"(field[0]={field[0]:.3f}, field[-1]={field[-1]:.3f})"
-    )
+    print(f"doc_overtourism_getting_started.py: all snippets OK  (field[0]={field[0]:.3f}, field[-1]={field[-1]:.3f})")

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -52,7 +52,7 @@ def visitors_distribution(season, weather):
     presence_stats = {
         ("low", "good"): (1_500, 2_500),
         ("low", "unsettled"): (1_100, 1_900),
-        ("low", "bad"): (700, 1_300),
+        ("low", "bad"): (1_000, 1_300),
         ("high", "good"): (6_000, 10_000),
         ("high", "unsettled"): (4_500, 7_500),
         ("high", "bad"): (3_000, 5_000),

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -48,19 +48,17 @@ assert CV_weather.value is None
 
 
 def visitors_distribution(season, weather):
-    """Return a truncated-normal distribution for visitor presence."""
+    """Return a uniform distribution for visitor presence."""
     presence_stats = {
-        ("low", "good"): (2_000, 500),
-        ("low", "unsettled"): (1_500, 400),
-        ("low", "bad"): (1_000, 300),
-        ("high", "good"): (8_000, 2_000),
-        ("high", "unsettled"): (6_000, 1_500),
-        ("high", "bad"): (4_000, 1_000),
+        ("low", "good"): (1_500, 2_500),
+        ("low", "unsettled"): (1_100, 1_900),
+        ("low", "bad"): (700, 1_300),
+        ("high", "good"): (6_000, 10_000),
+        ("high", "unsettled"): (4_500, 7_500),
+        ("high", "bad"): (3_000, 5_000),
     }
-    mean, std = presence_stats[(season, weather)]
-    a = -mean / std
-    b = 10.0
-    return stats.truncnorm(a, b, loc=mean, scale=std)
+    low, high = presence_stats[(season, weather)]
+    return stats.uniform(loc=low, scale=high - low)
 
 
 PV_visitors = PresenceVariable(

--- a/examples/overtourism_molveno/molveno_presence_stats.py
+++ b/examples/overtourism_molveno/molveno_presence_stats.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pandas as pd
+from scipy import stats
 
 season_stats = pd.DataFrame(
     [
@@ -71,30 +72,28 @@ weekday = weekday_stats.index
 
 
 def tourist_presences_stats(weekday, season, weather):
-    """Calculate the statistics for tourist presences."""
-    # Season
+    """Return a truncated-normal distribution for tourist presences."""
     mean = season_stats.loc[season, "mean_tourists"]
     std2 = season_stats.loc[season, "std_tourists"] ** 2
-    # Weather
     mean += weather_stats.loc[weather, "mean_tourists"]
     std2 += weather_stats.loc[weather, "std_tourists"] ** 2
-    # Weekdays
     mean += weekday_stats.loc[weekday, "mean_tourists"]
     std2 += weekday_stats.loc[weekday, "std_tourists"] ** 2
-    # Finalize and return
-    return {"mean": mean, "std": std2 ** (1 / 2)}
+    std = std2 ** (1 / 2)
+    a = -mean / std
+    b = 10.0
+    return stats.truncnorm(a, b, loc=mean, scale=std)
 
 
 def excursionist_presences_stats(weekday, season, weather):
-    """Calculate the statistics for excursionist presences."""
-    # Season
+    """Return a truncated-normal distribution for excursionist presences."""
     mean = season_stats.loc[season, "mean_excursionists"]
     std2 = season_stats.loc[season, "std_excursionists"] ** 2
-    # Weather
     mean += weather_stats.loc[weather, "mean_excursionists"]
     std2 += weather_stats.loc[weather, "std_excursionists"] ** 2
-    # Weekdays
     mean += weekday_stats.loc[weekday, "mean_excursionists"]
     std2 += weekday_stats.loc[weekday, "std_excursionists"] ** 2
-    # Finalize and return
-    return {"mean": mean, "std": std2 ** (1 / 2)}
+    std = std2 ** (1 / 2)
+    a = -mean / std
+    b = 10.0
+    return stats.truncnorm(a, b, loc=mean, scale=std)

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -65,7 +65,7 @@ def visitors_distribution(season, weather):
     presence_stats = {
         ("low",  "good"):      (1_500,  2_500),
         ("low",  "unsettled"): (1_100,  1_900),
-        ("low",  "bad"):       (  700,  1_300),
+        ("low",  "bad"):       (1_000,  1_300),
         ("high", "good"):      (6_000, 10_000),
         ("high", "unsettled"): (4_500,  7_500),
         ("high", "bad"):       (3_000,  5_000),

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -57,23 +57,28 @@ each scenario.
 ## 2 — Presence variable
 
 ```python
+from scipy import stats
 from overtourism_molveno.overtourism_metamodel import PresenceVariable
 
-# A mapping from (CV assignments) to (mean, std) of a truncated-normal
-# presence distribution, keyed by (season_value, weather_value)
-presence_stats = {
-    ("low",  "good"):      (2_000,  500),
-    ("low",  "unsettled"): (1_500,  400),
-    ("low",  "bad"):       (1_000,  300),
-    ("high", "good"):      (8_000, 2_000),
-    ("high", "unsettled"): (6_000, 1_500),
-    ("high", "bad"):       (4_000, 1_000),
-}
+def visitors_distribution(season, weather):
+    """Return a truncated-normal distribution for visitor presence."""
+    presence_stats = {
+        ("low",  "good"):      (2_000,  500),
+        ("low",  "unsettled"): (1_500,  400),
+        ("low",  "bad"):       (1_000,  300),
+        ("high", "good"):      (8_000, 2_000),
+        ("high", "unsettled"): (6_000, 1_500),
+        ("high", "bad"):       (4_000, 1_000),
+    }
+    mean, std = presence_stats[(season, weather)]
+    a = -mean / std
+    b = 10.0
+    return stats.truncnorm(a, b, loc=mean, scale=std)
 
 PV_visitors = PresenceVariable(
     "visitors",
     [CV_season, CV_weather],
-    presence_stats,
+    visitors_distribution,
 )
 ```
 

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -61,19 +61,17 @@ from scipy import stats
 from overtourism_molveno.overtourism_metamodel import PresenceVariable
 
 def visitors_distribution(season, weather):
-    """Return a truncated-normal distribution for visitor presence."""
+    """Return a uniform distribution for visitor presence."""
     presence_stats = {
-        ("low",  "good"):      (2_000,  500),
-        ("low",  "unsettled"): (1_500,  400),
-        ("low",  "bad"):       (1_000,  300),
-        ("high", "good"):      (8_000, 2_000),
-        ("high", "unsettled"): (6_000, 1_500),
-        ("high", "bad"):       (4_000, 1_000),
+        ("low",  "good"):      (1_500,  2_500),
+        ("low",  "unsettled"): (1_100,  1_900),
+        ("low",  "bad"):       (  700,  1_300),
+        ("high", "good"):      (6_000, 10_000),
+        ("high", "unsettled"): (4_500,  7_500),
+        ("high", "bad"):       (3_000,  5_000),
     }
-    mean, std = presence_stats[(season, weather)]
-    a = -mean / std
-    b = 10.0
-    return stats.truncnorm(a, b, loc=mean, scale=std)
+    low, high = presence_stats[(season, weather)]
+    return stats.uniform(loc=low, scale=high - low)
 
 PV_visitors = PresenceVariable(
     "visitors",

--- a/examples/overtourism_molveno/overtourism_metamodel.py
+++ b/examples/overtourism_molveno/overtourism_metamodel.py
@@ -6,7 +6,7 @@ This module provides the building blocks for an overtourism model:
   variables that influence the model but are not directly controlled
   (weekday, season, weather, …).
 * :class:`PresenceVariable` — placeholder index representing visitor presence,
-  sampled from a context-dependent truncated-normal distribution.
+  sampled from a context-dependent distribution (e.g. uniform or truncnorm).
 * :class:`Constraint` — named pairing of a usage formula index and a capacity
   index.
 * :class:`OvertourismModel` — :class:`~dt_model.model.model.Model` subclass
@@ -173,7 +173,7 @@ class ContinuousContextVariable(ContextVariable):
         """Sample from the continuous context variable."""
         if force_sample or subset is None or nr < len(subset):
             assert nr > 0
-            return [(1 / nr, r) for r in list(self.rvc.rvs(size=nr))]  # type: ignore[arg-type]
+            return [(1 / nr, r) for r in list(self.rvc.rvs(size=nr))]
 
         subset_probability = list(self.rvc.pdf(subset))
         subset_probability_sum = sum(subset_probability)

--- a/examples/overtourism_molveno/overtourism_metamodel.py
+++ b/examples/overtourism_molveno/overtourism_metamodel.py
@@ -28,7 +28,6 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 import numpy as np
-from scipy import stats
 from scipy.stats import rv_continuous
 from scipy.stats._distn_infrastructure import rv_continuous_frozen
 
@@ -196,16 +195,15 @@ class PresenceVariable(Index):
     cvs:
         Context variables that influence the presence distribution.
     distribution:
-        Callable that accepts the CV values and returns a dict with
-        ``"mean"`` and ``"std"`` keys used to parameterise a truncated
-        normal distribution.
+        Callable that accepts the CV values and returns a frozen scipy
+        distribution (e.g. ``scipy.stats.truncnorm``).
     """
 
     def __init__(
         self,
         name: str,
         cvs: list[ContextVariable],
-        distribution: Callable | None = None,
+        distribution: Callable[..., Any] | None = None,
     ) -> None:
         super().__init__(name, None)
         self.cvs = cvs
@@ -232,16 +230,8 @@ class PresenceVariable(Index):
         if cvs is not None:
             all_cvs = [cvs[cv] for cv in self.cvs if cv in cvs.keys()]
         assert self.distribution is not None
-        distr: dict = self.distribution(*all_cvs)
-        return np.asarray(
-            stats.truncnorm.rvs(
-                -distr["mean"] / distr["std"],
-                10,
-                loc=distr["mean"],
-                scale=distr["std"],
-                size=nr,
-            ),
-        )
+        distr = self.distribution(*all_cvs)
+        return np.asarray(distr.rvs(size=nr))
 
 
 # ---------------------------------------------------------------------------

--- a/examples/overtourism_molveno/overtourism_metamodel.py
+++ b/examples/overtourism_molveno/overtourism_metamodel.py
@@ -175,7 +175,7 @@ class ContinuousContextVariable(ContextVariable):
             assert nr > 0
             return [(1 / nr, r) for r in list(self.rvc.rvs(size=nr))]
 
-        subset_probability = list(self.rvc.pdf(subset))
+        subset_probability = np.asarray(self.rvc.pdf(subset)).tolist()
         subset_probability_sum = sum(subset_probability)
         return [(p / subset_probability_sum, v) for (p, v) in zip(subset_probability, subset)]
 

--- a/examples/overtourism_molveno/overtourism_molveno.py
+++ b/examples/overtourism_molveno/overtourism_molveno.py
@@ -122,16 +122,14 @@ def _compute_modal_line_per_constraint(field_elements: dict, axes: dict) -> dict
         (yi, xi) = np.nonzero(matrix)
         # yi = row indices (tourists axis 0), xi = col indices (excursionists axis 1)
 
-        horizontal_regr = None
-        vertical_regr = None
         try:
             horizontal_regr = stats.linregress(axes_list[0][yi], axes_list[1][xi])
         except ValueError:
-            pass
+            horizontal_regr = None
         try:
             vertical_regr = stats.linregress(axes_list[1][xi], axes_list[0][yi])
         except ValueError:
-            pass
+            vertical_regr = None
 
         def _vertical(regr) -> tuple[tuple[float, float], tuple[float, float]]:
             if regr.slope < 0.0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
     "pytest>=7.0.0",        # test runner
     "pytest-cov>=4.0.0",    # code coverage plugin for pytest
     "ruff>=0.11.0",         # formatter + linter
+    "scipy-stubs>=1.17.1.4",
 ]
 
 # Project-specific URLs
@@ -149,7 +150,23 @@ convention = "numpy"
 # Pyright Configuration
 [tool.pyright]
 
+# Type checking mode
+typeCheckingMode = "standard"
+
+# Use library code for types when stub files are not available
+useLibraryCodeForTypes = true
+
+# Target Python version
+pythonVersion = "3.12"
+
+# Directories to include in type checking
+include = ["civic_digital_twins", "tests", "examples"]
+
 # Add examples/ to the search path so pyright can resolve example packages
 # (e.g. overtourism_molveno, mobility_bologna) the same way pytest does via
 # its pythonpath setting.
 extraPaths = ["examples"]
+
+# Virtual environment settings
+venvPath = "."
+venv = ".venv"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,9 +1,0 @@
-{
-  "typeCheckingMode": "standard",
-  "useLibraryCodeForTypes": true,
-  "pythonVersion": "3.12",
-  "include": ["civic_digital_twins", "tests"],
-  "extraPaths": ["examples"],
-  "venvPath": ".",
-  "venv": ".venv"
-}

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scipy-stubs" },
 ]
 
 [package.metadata]
@@ -43,6 +44,7 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "ruff", specifier = ">=0.11.0" },
+    { name = "scipy-stubs", specifier = ">=1.17.1.4" },
 ]
 
 [[package]]
@@ -372,6 +374,36 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy-typing-compat"
+version = "20251206.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/5f/29fd5f29b0a5d96e2def96ecba3112fc330ecd16e8c97c2b332563c5e201/numpy_typing_compat-20251206.2.4.tar.gz", hash = "sha256:59882d23aaff054a2536da80564012cdce33487657be4d79c5925bb8705fcabc", size = 5011, upload-time = "2025-12-06T20:02:04.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/7c/5c2892e6bc0628a2ccf4e938e1e2db22794657ccb374672d66e20d73839e/numpy_typing_compat-20251206.2.4-py3-none-any.whl", hash = "sha256:a82e723bd20efaa4cf2886709d4264c144f1f2b609bda83d1545113b7e47a5b5", size = 6300, upload-time = "2025-12-06T20:01:57.578Z" },
+]
+
+[[package]]
+name = "optype"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/9f/3b13bab05debf685678b8af004e46b8c67c6f98ffa08eaf5d33bcf162c16/optype-0.17.0.tar.gz", hash = "sha256:31351a1e64d9eba7bf67e14deefb286e85c66458db63c67dd5e26dd72e4664e5", size = 53484, upload-time = "2026-03-08T23:03:12.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/44/dca78187415947d1bb90b2ee2a58e47d9573528331e8dc6196996b53612a/optype-0.17.0-py3-none-any.whl", hash = "sha256:8c2d88ff13149454bcf6eb47502f80d288bc542e7238fcc412ac4d222c439397", size = 65854, upload-time = "2026-03-08T23:03:11.425Z" },
+]
+
+[package.optional-dependencies]
+numpy = [
+    { name = "numpy" },
+    { name = "numpy-typing-compat" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -667,6 +699,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "scipy-stubs"
+version = "1.17.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "optype", extra = ["numpy"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/75/d944a11fca64aa84fbb4bfcf613b758319c6103cb30a304a0e9727009d62/scipy_stubs-1.17.1.4.tar.gz", hash = "sha256:cae00c5207aa62ceb4bcadea202d9fbbf002e958f9e4de981720436b8d5c1802", size = 396980, upload-time = "2026-04-13T11:46:54.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/f8/334aa5a7a482ea89cb14d92f6a4d9ffa1e193e733144d4d14c7ffcb33583/scipy_stubs-1.17.1.4-py3-none-any.whl", hash = "sha256:e6e5c390fb864745bc3d5f591de81f5cb4f84403857d4f660acb5b6339956f5b", size = 604752, upload-time = "2026-04-13T11:46:53.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Refactors `PresenceVariable` to accept a distribution callable that returns a frozen scipy distribution instead of a `{"mean": ..., "std": ...}` dict
- Updates `tourist_presences_stats()` and `excursionist_presences_stats()` to return frozen distributions
- Fixes the documentation example in `overtourism-getting-started.md` that was causing pyright type errors (issue #147)
- Simplifies examples to use uniform distribution instead of truncnorm
- Enables pyright checks on `examples/` directory
- Adds `scipy-stubs` to dev dependencies for improved type checking

## Changes

- `PresenceVariable.sample()` now calls `.rvs(size=nr)` on the returned distribution instead of building `truncnorm` internally
- Distribution callable signature unchanged: still accepts CV values as positional args
- Type annotation changed to `Callable[..., Any] | None` for flexibility
- Pyright config moved from `pyrightconfig.json` to `pyproject.toml`

## Commits

- fix(#147): PresenceVariable accepts distribution callable returning frozen scipy distribution
- simplify(doc): use uniform distribution in PresenceVariable examples
- fix(doc): update PresenceVariable docstring to reflect generic distribution
- chore: enable pyright checks on examples/ and add scipy-stubs
- chore: update changelog for examples/ pyright checks and PresenceVariable fix