### PR TITLE
chore: doc/example cleanup (#151), graph shim (#123), SPDX headers, strict doc-sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,4 +39,5 @@ uv run python examples/doc/doc_readme.py
 - **Pyright config**: `pyproject.toml` includes `examples` in both `include` (type-checked) and `extraPaths` (import resolution).
 - **Release process**: Update version in `pyproject.toml`, run `uv lock`, update `CHANGELOG.md`, verify doc examples, then tag and push.
 - **Doc/example alignment**: Every script under `examples/doc/` must be kept verbatim-aligned with its counterpart in `docs/`. This is enforced as a release checklist step — run the doc examples and confirm no drift.
+- **SPDX headers**: Every `.py` file must open with `# SPDX-License-Identifier: Apache-2.0`; every `.md` file must open with `<!-- SPDX-License-Identifier: Apache-2.0 -->`. Add the header whenever you create a new file. Pre-release, verify with `git ls-files '*.py' '*.md' | xargs grep -rL "SPDX-License-Identifier"` (should print nothing).
 - **Minimum Python**: 3.12 (defined in pyproject.toml).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Agent Guidance for civic-digital-twins
 
 ## Development Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Guidance for civic-digital-twins
+
+## Development Commands
+
+All commands should be run via `uv` (use `uv run` for python scripts, or prefix bin commands with `uv run`).
+
+```bash
+# Setup
+uv venv && source .venv/bin/activate && uv sync --dev
+
+# Run all tests
+uv run pytest
+
+# Run a single test file
+uv run pytest tests/dt_model/engine/frontend/test_graph.py
+
+# Lint and format check
+uv run ruff check .
+uv run ruff format --check .
+
+# Type check
+uv run pyright
+
+# Run doc examples (must pass for releases; must stay verbatim-aligned with docs/)
+uv run python examples/doc/doc_engine.py
+uv run python examples/doc/doc_model.py
+uv run python examples/doc/doc_modularity.py
+uv run python examples/doc/doc_getting_started.py
+uv run python examples/doc/doc_overtourism_getting_started.py
+uv run python examples/doc/doc_readme.py
+```
+
+## Important Details
+
+- **Package structure**: `civic_digital_twins/dt_model/` contains the main code with subpackages: `engine/` (DSL compiler), `model/` (higher-level abstractions), `symbols/` (Index, TimeseriesIndex).
+- **Python path**: `pyproject.toml` sets `pythonpath = ["examples"]` so tests can import example packages like `mobility_bologna` and `overtourism_molveno`.
+- **Pyright config**: `pyproject.toml` includes `examples` in both `include` (type-checked) and `extraPaths` (import resolution).
+- **Release process**: Update version in `pyproject.toml`, run `uv lock`, update `CHANGELOG.md`, verify doc examples, then tag and push.
+- **Doc/example alignment**: Every script under `examples/doc/` must be kept verbatim-aligned with its counterpart in `docs/`. This is enforced as a release checklist step — run the doc examples and confirm no drift.
+- **Minimum Python**: 3.12 (defined in pyproject.toml).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ambiguity (#142).
 - `OvertourismEnsemble` refactored to implement `AxisEnsemble`.
 
-**Document snippes - test alignment check**
+**Document snippets - test alignment check**
 
 - `tests/test_doc_sync.py` — automated snippet-alignment test that compares
   every Python code block in the design docs and guides against its paired
@@ -42,9 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compact per-pair summary (`= OK` / `~ OK` / `~ Warn` / `✗ Fail`); pass a
   doc-name fragment for a verbose block-by-block report.  Stub and
   reference-only blocks are detected and skipped automatically.
+  `= OK` now requires 100% score and all per-line ratios ≥ 0.99; any `~ OK`
+  or `~ Warn` block fails the test unless listed in `_EXPECTED_NEAR_VERBATIM`.
 - `examples/doc/doc_readme.py` — new script covering the two README code
   snippets (engine layer and model/simulation layer).
 - `examples/doc/` scripts updated to better match the docs.
+- `civic_digital_twins.dt_model.graph` shim — `graph` is now importable
+  directly from the top-level `dt_model` package (`from
+  civic_digital_twins.dt_model import graph`), closing #123.
+- SPDX-License-Identifier headers added to all tracked Python and Markdown
+  files; pre-release verification step added to README checklist.
 
 ### Changed
 
@@ -73,7 +80,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mean`/`std` keys. The `sample()` method calls `.rvs()` on the returned
   distribution. This fixes the pyright type error in the getting started
   guide (#147).
-
 - `EvaluationResult.marginalize()` raised `IndexError` on constant nodes in
   grid+ensemble mode (two or more PARAMETER axes plus at least one ENSEMBLE axis)
   (#155).
@@ -91,6 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PARAMETER dims and non-trivial DOMAIN dims are now preserved.
 - Dependabot vulnerability alerts resolved: `fonttools` bumped to `>=4.60.2`
   (moderate) and `pillow` to `>=12.1.1` (high) via lockfile regeneration. (#132)
+- Documents and `examples/doc/` scripts updated so that the scripts no longer emit
+  warnings at runtime.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ evaluated by a NumPy-based interpreter that maps each node to the
 corresponding `numpy` operation.
 
 ```python
+import numpy as np
+
 from civic_digital_twins.dt_model.engine.frontend import graph, linearize
 from civic_digital_twins.dt_model.engine.numpybackend import executor
-import numpy as np
 
 a = graph.placeholder("a")
 b = graph.placeholder("b")
@@ -62,9 +63,9 @@ abstractions built on top of the engine:
   define the scenario contract consumed by `Evaluation`.
 
 ```python
-from civic_digital_twins.dt_model import Evaluation, Model, DistributionIndex
-from civic_digital_twins.dt_model.model.index import Index
 from scipy import stats
+
+from civic_digital_twins.dt_model import DistributionIndex, Evaluation, Index, Model
 
 # Two distribution-backed indexes
 x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 1.0})

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ uv sync --upgrade
 
 ## Releasing
 
-Per-release checklist (six manual steps):
+Per-release checklist (seven manual steps):
 
 1. Make sure the version number in `pyproject.toml` is correct.
 
@@ -210,7 +210,18 @@ Per-release checklist (six manual steps):
    uv run python examples/doc/doc_getting_started.py
    ```
 
-6. Commit the changes above, then create and push a version tag:
+6. Verify that every tracked Python and Markdown file carries an SPDX header:
+   ```bash
+   # Python files — should print nothing (no files missing the header)
+   git ls-files '*.py' | xargs grep -rL "SPDX-License-Identifier"
+   # Markdown files — should print nothing
+   git ls-files '*.md' | xargs grep -rL "SPDX-License-Identifier"
+   ```
+   Add `# SPDX-License-Identifier: Apache-2.0` (Python) or
+   `<!-- SPDX-License-Identifier: Apache-2.0 -->` (Markdown) to any file
+   that is missing the header.
+
+7. Commit the changes above, then create and push a version tag:
    ```bash
    git add pyproject.toml uv.lock CHANGELOG.md docs/
    git commit -m "chore: prepare v<version> release"

--- a/civic_digital_twins/__init__.py
+++ b/civic_digital_twins/__init__.py
@@ -1,1 +1,2 @@
 """Civic Digital Twins Modelling Framework."""
+# SPDX-License-Identifier: Apache-2.0

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -1,4 +1,5 @@
 """Digital twin modeling and simulation library."""
+# SPDX-License-Identifier: Apache-2.0
 
 from .model import (
     DOMAIN,

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -1,6 +1,5 @@
 """Digital twin modeling and simulation library."""
 
-from .engine.frontend.graph import piecewise
 from .model import (
     DOMAIN,
     ENSEMBLE,
@@ -57,5 +56,4 @@ __all__ = [
     "PartitionedEnsemble",
     "TimeseriesIndex",
     "WeightedScenario",
-    "piecewise",
 ]

--- a/civic_digital_twins/dt_model/engine/atomic/__init__.py
+++ b/civic_digital_twins/dt_model/engine/atomic/__init__.py
@@ -2,6 +2,7 @@
 
 It implements an atomic integer counter class similar to Go's atomic.Int64.
 """
+# SPDX-License-Identifier: Apache-2.0
 
 import threading
 

--- a/civic_digital_twins/dt_model/engine/compileflags/__init__.py
+++ b/civic_digital_twins/dt_model/engine/compileflags/__init__.py
@@ -13,6 +13,7 @@ of flag names before starting Python.  For example::
 
 Available flag names: ``trace``, ``dump``, ``break``.
 """
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 from collections.abc import Callable

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -13,6 +13,7 @@ This approach offers several advantages over walking the AST:
 The executor expects all placeholder values to be provided in the initial
 state and evaluates each node exactly once, storing results for later reuse.
 """
+# SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable
 from dataclasses import dataclass, field

--- a/civic_digital_twins/dt_model/graph.py
+++ b/civic_digital_twins/dt_model/graph.py
@@ -1,0 +1,33 @@
+"""Public graph-building helpers for dt_model users.
+
+This module re-exports the subset of ``engine.frontend.graph`` that is
+intended for use in model definitions.  Import it as::
+
+    from civic_digital_twins.dt_model import graph
+
+    peak = Index("peak", graph.piecewise((1.8, season == "summer"), (1.0, True)))
+    smoothed = TimeseriesIndex("smoothed", graph.function_call("smooth", demand_ts))
+
+The raw engine path (``dt_model.engine.frontend.graph``) remains available
+for engine-level work (DAG construction, backends, debugging).
+"""
+
+from .engine.frontend.graph import (
+    Node,
+    exp,
+    function_call,
+    log,
+    maximum,
+    piecewise,
+    where,
+)
+
+__all__ = [
+    "Node",
+    "exp",
+    "function_call",
+    "log",
+    "maximum",
+    "piecewise",
+    "where",
+]

--- a/civic_digital_twins/dt_model/graph.py
+++ b/civic_digital_twins/dt_model/graph.py
@@ -11,6 +11,7 @@ intended for use in model definitions.  Import it as::
 The raw engine path (``dt_model.engine.frontend.graph``) remains available
 for engine-level work (DAG construction, backends, debugging).
 """
+# SPDX-License-Identifier: Apache-2.0
 
 from .engine.frontend.graph import (
     Node,

--- a/civic_digital_twins/dt_model/model/__init__.py
+++ b/civic_digital_twins/dt_model/model/__init__.py
@@ -1,4 +1,5 @@
 """Model and index types for digital twin models."""
+# SPDX-License-Identifier: Apache-2.0
 
 from .axis import DOMAIN, ENSEMBLE, PARAMETER, Axis, AxisRole
 from .index import (

--- a/civic_digital_twins/dt_model/model/index.py
+++ b/civic_digital_twins/dt_model/model/index.py
@@ -5,6 +5,7 @@ An index variable is a variable that is used to represent a conversion factor or
 parameter that is used to calculate the value of a symbol. The index variable can
 be a constant, a distribution, or a symbolic expression.
 """
+# SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable

--- a/civic_digital_twins/dt_model/simulation/__init__.py
+++ b/civic_digital_twins/dt_model/simulation/__init__.py
@@ -1,4 +1,5 @@
 """Scenario-based simulation and evaluation of digital twin models."""
+# SPDX-License-Identifier: Apache-2.0
 
 from .ensemble import (
     AxisEnsemble,

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -1,4 +1,5 @@
 """Generic model evaluation."""
+# SPDX-License-Identifier: Apache-2.0
 
 import warnings
 from collections.abc import Mapping

--- a/docs/design/dd-cdt-engine.md
+++ b/docs/design/dd-cdt-engine.md
@@ -458,7 +458,7 @@ using `print` on each node in the DAG.
 For example, `print(a)` produces the following output:
 
 ```python
-n1 = graph.placeholder(name='a', default_value=None)
+n1 = graph.placeholder(name="a", default_value=None)
 ```
 
 As you can see, a node's string representation is valid Python
@@ -482,14 +482,14 @@ value associated with the placeholder.
 Similarly, `print(scale)` produces the following output:
 
 ```python
-n3 = graph.constant(value=1024, name='')
+n3 = graph.constant(value=1024, name="")
 ```
 
 So far, we have dumped constants and placeholders, which are
 simple to understand. If we `print(c)`, instead, we get:
 
 ```python
-n7 = graph.add(left=n4, right=n6, name='c')
+n7 = graph.add(left=n4, right=n6, name="c")
 ```
 
 This tells us that `c` corresponds to a node with ID `7` that
@@ -536,11 +536,11 @@ linearizing a forest of trees embedded into the DAG.)
 This is the output that we get:
 
 ```python
-n1 = graph.placeholder(name='a', default_value=None)
-n4 = graph.exp(node=n1, name='')
-n5 = graph.constant(value=55, name='')
-n6 = graph.divide(left=n5, right=n1, name='')
-n7 = graph.add(left=n4, right=n6, name='')
+n1 = graph.placeholder(name="a", default_value=None)
+n4 = graph.exp(node=n1, name="")
+n5 = graph.constant(value=55, name="")
+n6 = graph.divide(left=n5, right=n1, name="")
+n7 = graph.add(left=n4, right=n6, name="")
 ```
 
 This plan basically tells us that to produce `c`, which is
@@ -612,10 +612,10 @@ how you can use the executor in your code:
 ```python
 # ...
 
+import numpy as np
+
 from civic_digital_twins.dt_model.engine.frontend import linearize
 from civic_digital_twins.dt_model.engine.numpybackend import executor
-
-import numpy as np
 
 # create state with placeholder values
 state = executor.State(

--- a/docs/design/dd-cdt-engine.md
+++ b/docs/design/dd-cdt-engine.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # DSL Compiler Engine
 
 |              | Document data                                  |

--- a/docs/design/dd-cdt-engine.md
+++ b/docs/design/dd-cdt-engine.md
@@ -6,7 +6,7 @@
 |--------------|------------------------------------------------|
 | Author       | [@bassosimone](https://github.com/bassosimone) |
 | Co-authors   | [@pistore](https://github.com/pistore)         |
-| Last-Updated | 2026-04-04                                     |
+| Last-Updated | 2026-04-19                                     |
 | Status       | Draft                                          |
 | Approved-By  | N/A                                            |
 

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -5,7 +5,7 @@
 |              | Document data                                  |
 |--------------| ---------------------------------------------- |
 | Author       | [@pistore](https://github.com/pistore)         |
-| Last-Updated | 2026-04-11                                     |
+| Last-Updated | 2026-04-19                                     |
 | Status       | Draft                                          |
 | Approved-By  | N/A                                            |
 

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -544,7 +544,7 @@ model = Model("demo", [x, y, z])
 ensemble = DistributionEnsemble(model, size=200)
 
 # Evaluate
-result = Evaluation(model).evaluate(ensemble)
+result = Evaluation(model).evaluate(ensemble=ensemble)
 
 # Weighted mean of z across all scenarios
 print(result.marginalize(z))  # ≈ 10.0
@@ -651,7 +651,7 @@ tt = np.linspace(0, 50_000, 101)   # tourist presence axis
 ee = np.linspace(0, 50_000, 101)   # excursionist presence axis
 
 result = Evaluation(model).evaluate(
-    ensemble,
+    ensemble=ensemble,
     parameters={PV_tourists: tt, PV_excursionists: ee},
 )
 

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -91,9 +91,8 @@ dedicated subclasses (`DistributionIndex`, `ConstIndex`, `CategoricalIndex`) rat
 
 ```python
 from scipy import stats
-from civic_digital_twins.dt_model.model.index import (
-    ConstIndex, DistributionIndex, Index,
-)
+
+from civic_digital_twins.dt_model import ConstIndex, DistributionIndex, Index
 
 # Distribution-backed (abstract — must be resolved in each scenario)
 # Pass any scipy-compatible distribution callable and a params dict:
@@ -154,7 +153,8 @@ For the usage pattern and integration with `ModelVariant`, see
 
 ```python
 import numpy as np
-from civic_digital_twins.dt_model.model.index import TimeseriesIndex
+
+from civic_digital_twins.dt_model import TimeseriesIndex
 
 # Fixed time series
 flow = TimeseriesIndex("flow", np.array([10.0, 20.0, 30.0]))
@@ -220,9 +220,10 @@ constructor parameter must be declared as a field in `Inputs`.  If a
 
 ```python
 from dataclasses import dataclass
-from civic_digital_twins.dt_model import Model
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+
 from scipy import stats
+
+from civic_digital_twins.dt_model import DistributionIndex, Index, Model
 
 class DemoModel(Model):
 
@@ -253,8 +254,8 @@ use the dataclass-based API above.
 
 ```python
 from scipy import stats
-from civic_digital_twins.dt_model.model.model import Model
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+
+from civic_digital_twins.dt_model import DistributionIndex, Index, Model
 
 x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
 y = DistributionIndex("y", stats.uniform, {"loc": 0.0, "scale": 10.0})
@@ -350,9 +351,10 @@ declared in `Inputs`:
 
 ```python
 from dataclasses import dataclass
-from civic_digital_twins.dt_model import Model
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+
 from scipy import stats
+
+from civic_digital_twins.dt_model import DistributionIndex, Index, Model
 
 class BadModel(Model):
 
@@ -421,7 +423,7 @@ for models whose abstract indexes are all distribution-backed.  It draws
 axis with uniform weights (`1/size` each).
 
 ```python
-from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
+from civic_digital_twins.dt_model import DistributionEnsemble
 
 ensemble = DistributionEnsemble(model, size=100)
 # ensemble.ensemble_axes   → (Axis("x", ENSEMBLE), …)
@@ -444,9 +446,7 @@ model's abstract indexes.  Each `EnsembleAxisSpec` names the axis and
 lists the indexes it covers:
 
 ```python
-from civic_digital_twins.dt_model.simulation.ensemble import (
-    EnsembleAxisSpec, PartitionedEnsemble,
-)
+from civic_digital_twins.dt_model import EnsembleAxisSpec, PartitionedEnsemble
 
 ens = PartitionedEnsemble(
     model,
@@ -531,9 +531,8 @@ grid.
 ```python
 import numpy as np
 from scipy import stats
-from civic_digital_twins.dt_model import Evaluation, Model
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
-from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
+
+from civic_digital_twins.dt_model import DistributionEnsemble, DistributionIndex, Evaluation, Index, Model
 
 # Define the model
 x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
@@ -645,8 +644,8 @@ The standard overtourism evaluation pattern:
 
 ```python
 import numpy as np
-from civic_digital_twins.dt_model import Evaluation
-from civic_digital_twins.dt_model.model.index import Distribution
+
+from civic_digital_twins.dt_model import Distribution, Evaluation
 
 tt = np.linspace(0, 50_000, 101)   # tourist presence axis
 ee = np.linspace(0, 50_000, 101)   # excursionist presence axis

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Model / Simulation Layer
 
 |              | Document data                                  |

--- a/docs/design/dd-cdt-modularity.md
+++ b/docs/design/dd-cdt-modularity.md
@@ -5,7 +5,7 @@
 |              | Document data                                  |
 |--------------| ---------------------------------------------- |
 | Author       | [@pistore](https://github.com/pistore)         |
-| Last-Updated | 2026-04-04                                     |
+| Last-Updated | 2026-04-19                                     |
 | Status       | Draft                                          |
 | Approved-By  | N/A                                            |
 

--- a/docs/design/dd-cdt-modularity.md
+++ b/docs/design/dd-cdt-modularity.md
@@ -209,6 +209,10 @@ indexes from one to the next.
 class PipelineModel(Model):
 
     @dataclass
+    class Inputs:
+        raw_data: DistributionIndex
+
+    @dataclass
     class Outputs:
         result: Index
 
@@ -217,13 +221,12 @@ class PipelineModel(Model):
         stage_a_indexes: list[GenericIndex]
         stage_b_indexes: list[GenericIndex]
 
-    def __init__(self) -> None:
-        Outputs = PipelineModel.Outputs
-        Expose  = PipelineModel.Expose
+    def __init__(self, raw_data: DistributionIndex) -> None:
+        inputs = PipelineModel.Inputs(raw_data=raw_data)
 
         # Step 1 — construct sub-models in dependency order.
         # All leaf indexes are created here; sub-models receive them as arguments.
-        stage_a = StageAModel(raw_data=raw_data)
+        stage_a = StageAModel(raw_data=inputs.raw_data)
 
         # Step 2 — thread Level-1 outputs of stage A into stage B
         stage_b = StageBModel(
@@ -234,8 +237,9 @@ class PipelineModel(Model):
         # Step 3 — promote KPI outputs and collect sub-model indexes for engine visibility
         super().__init__(
             "Pipeline",
-            outputs=Outputs(result=stage_b.outputs.result),
-            expose=Expose(
+            inputs=inputs,
+            outputs=PipelineModel.Outputs(result=stage_b.outputs.result),
+            expose=PipelineModel.Expose(
                 stage_a_indexes=list(stage_a.indexes),
                 stage_b_indexes=list(stage_b.indexes),
             ),

--- a/docs/design/dd-cdt-modularity.md
+++ b/docs/design/dd-cdt-modularity.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Model Modularity
 
 |              | Document data                                  |

--- a/docs/design/dd-cdt-modularity.md
+++ b/docs/design/dd-cdt-modularity.md
@@ -317,7 +317,8 @@ incrementally.  During development and in CI, escalate it to an error:
 
 ```python
 import warnings
-from civic_digital_twins.dt_model import ModelContractWarning, InputsContractWarning
+
+from civic_digital_twins.dt_model import InputsContractWarning, ModelContractWarning
 
 # Escalate all contract warnings to errors (recommended for CI)
 warnings.filterwarnings("error", category=ModelContractWarning)
@@ -445,6 +446,7 @@ directly.  Use `ModelVariant.guards_to_selector` to build one from a list of `(k
 
 ```python
 from scipy import stats
+
 from civic_digital_twins.dt_model import DistributionIndex, ModelVariant
 
 cost_threshold = DistributionIndex("cost_threshold", stats.uniform, {"loc": 3.0, "scale": 8.0})
@@ -496,15 +498,17 @@ scenario — useful for post-evaluation analysis.
 `ModelVariant` selector:
 
 ```python
-season = CategoricalIndex("season", {"summer": 0.25, "spring": 0.25,
-                                      "autumn": 0.25, "winter": 0.25})
+season = CategoricalIndex("season", {"summer": 0.25, "spring": 0.25, "autumn": 0.25, "winter": 0.25})
 
-peak_factor = Index("peak_factor", graph.piecewise(
-    (1.8, season == "summer"),
-    (1.2, season == "spring"),
-    (1.0, season == "autumn"),
-    (0.7, True),              # winter — default
-))
+peak_factor = Index(
+    "peak_factor",
+    graph.piecewise(
+        (1.8, season == "summer"),
+        (1.2, season == "spring"),
+        (1.0, season == "autumn"),
+        (0.7, True),  # winter — default
+    ),
+)
 ```
 
 `season == "summer"` produces a `graph.equal` node that the engine evaluates as a boolean mask
@@ -1320,7 +1324,8 @@ categories:
 
 ```python
 import warnings
-from civic_digital_twins.dt_model import ModelContractWarning, InputsContractWarning
+
+from civic_digital_twins.dt_model import InputsContractWarning, ModelContractWarning
 
 # Recommended for CI — escalate all contract warnings to errors
 warnings.filterwarnings("error", category=ModelContractWarning)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 |              | Document data                                  |
 |--------------| ---------------------------------------------- |
 | Author       | [@pistore](https://github.com/pistore)         |
-| Last-Updated | 2026-04-11                                     |
+| Last-Updated | 2026-04-19                                     |
 | Status       | Draft                                          |
 | Approved-By  | N/A                                            |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Getting Started
 
 |              | Document data                                  |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,7 +147,7 @@ ensemble = DistributionEnsemble(co2_model, size=1000)
 ```python
 from civic_digital_twins.dt_model import Evaluation
 
-result = Evaluation(co2_model).evaluate(ensemble)
+result = Evaluation(co2_model).evaluate(ensemble=ensemble)
 ```
 
 `result` is an `EvaluationResult`.  Use `result[idx]` for the raw array
@@ -185,12 +185,10 @@ smoothed = TimeseriesIndex(
     graph.function_call("smooth", demand_ts.node),
 )
 
-model    = ...  # define a suitable model that includes demand_ts and smoothed
-ensemble = ...  # define a suitable ensemble (or pass [(1.0, {})] if there are no abstract indexes)
+model = ...  # define a suitable model that includes demand_ts and smoothed
 
-# Register the implementation at evaluation time
+# Register the implementation at evaluation time — no abstract indexes, so no ensemble needed
 result = Evaluation(model).evaluate(
-    ensemble,
     functions={
         "smooth": executor.LambdaAdapter(
             lambda ts: np.convolve(ts, np.ones(3) / 3, mode="same")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,8 +45,8 @@ plain `Index` for formulas and constants.
 ```python
 import numpy as np
 from scipy import stats
-from civic_digital_twins.dt_model import Model
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+
+from civic_digital_twins.dt_model import DistributionIndex, Index, Model
 
 # Two uncertain parameters
 fuel_efficiency = DistributionIndex("fuel_efficiency_km_l", stats.uniform, {"loc": 10.0, "scale": 5.0})
@@ -75,8 +75,10 @@ and `DistributionEnsemble` can sample it:
 
 ```python
 from dataclasses import dataclass
-from civic_digital_twins.dt_model import DistributionIndex, Index, Model
+
 from scipy import stats
+
+from civic_digital_twins.dt_model import DistributionIndex, Index, Model
 
 class Co2Model(Model):
 
@@ -170,8 +172,8 @@ time.
 
 ```python
 import numpy as np
-from civic_digital_twins.dt_model.model.index import TimeseriesIndex
-from civic_digital_twins.dt_model.engine.frontend import graph
+
+from civic_digital_twins.dt_model import TimeseriesIndex, graph
 from civic_digital_twins.dt_model.engine.numpybackend import executor
 
 # 24-hour demand time series (one value per hour)

--- a/examples/doc/doc_engine.py
+++ b/examples/doc/doc_engine.py
@@ -1,4 +1,4 @@
-""" Runnable snippets from docs/design/dd-cdt-engine.md."""
+"""Runnable snippets from docs/design/dd-cdt-engine.md."""
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -7,7 +7,6 @@ import numpy as np
 from civic_digital_twins.dt_model.engine import compileflags
 from civic_digital_twins.dt_model.engine.frontend import graph, linearize
 from civic_digital_twins.dt_model.engine.numpybackend import executor
-
 
 # ---------------------------------------------------------------------------
 # Block 00 — End-to-End Example
@@ -154,18 +153,18 @@ def _demo_ssa_and_sorting() -> None:
     # --- Blocks 08, 09, 10: individual node SSA form ---
     # These are the lines that print(a), print(scale), and print(c) would produce
     # in a fresh context where `a` is node #1 and `scale` is node #3.
-    n1 = graph.placeholder(name='a', default_value=None)
-    n3 = graph.constant(value=1024, name='')
-    n4 = graph.exp(node=n1, name='')
-    n5 = graph.constant(value=55, name='')
-    n6 = graph.divide(left=n5, right=n1, name='')
-    n7 = graph.add(left=n4, right=n6, name='c')   # block 10: print(c) — named root
+    n1 = graph.placeholder(name="a", default_value=None)
+    n3 = graph.constant(value=1024, name="")
+    n4 = graph.exp(node=n1, name="")
+    n5 = graph.constant(value=55, name="")
+    n6 = graph.divide(left=n5, right=n1, name="")
+    n7 = graph.add(left=n4, right=n6, name="c")  # block 10: print(c) — named root
 
     assert n3 is not None
 
     # --- Block 12: topological sort of c = graph.exp(a) + 55/a ---
     # Same structural nodes; the root add-node has an empty name in this context.
-    n7 = graph.add(left=n4, right=n6, name='')    # noqa: F841  block 12 line 5
+    n7 = graph.add(left=n4, right=n6, name="")  # noqa: F841  block 12 line 5
 
     # --- Blocks 11, 13: shorthand notation and linearize.forest ---
     a = graph.placeholder("a")

--- a/examples/doc/doc_getting_started.py
+++ b/examples/doc/doc_getting_started.py
@@ -1,4 +1,5 @@
 """Runnable snippets from docs/getting-started.md."""
+# SPDX-License-Identifier: Apache-2.0
 
 import warnings
 from dataclasses import dataclass

--- a/examples/doc/doc_getting_started.py
+++ b/examples/doc/doc_getting_started.py
@@ -105,7 +105,7 @@ ensemble = DistributionEnsemble(co2_model, size=1000)
 # getting-started.md §3 — Evaluate
 # ---------------------------------------------------------------------------
 
-result = Evaluation(co2_model).evaluate(ensemble)
+result = Evaluation(co2_model).evaluate(ensemble=ensemble)
 
 co2 = co2_model.outputs.co2  # access via contractual output
 co2_samples = result[co2]  # np.ndarray, shape (1000,)
@@ -142,11 +142,9 @@ smoothed = TimeseriesIndex(
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
     model = Model("ts_model", [demand_ts, smoothed])
-    ensemble = [(1.0, {})]
 
-# Single scenario with no abstract indexes
+# No abstract indexes — omit ensemble (deterministic evaluation)
 result = Evaluation(model).evaluate(
-    ensemble,
     functions={
         "smooth": executor.LambdaAdapter(
             lambda ts: np.convolve(ts, np.ones(3) / 3, mode="same"),

--- a/examples/doc/doc_getting_started.py
+++ b/examples/doc/doc_getting_started.py
@@ -6,10 +6,16 @@ from dataclasses import dataclass
 import numpy as np
 from scipy import stats
 
-from civic_digital_twins.dt_model import DistributionEnsemble, Evaluation, Model
-from civic_digital_twins.dt_model.engine.frontend import graph
+from civic_digital_twins.dt_model import (
+    DistributionEnsemble,
+    DistributionIndex,
+    Evaluation,
+    Index,
+    Model,
+    TimeseriesIndex,
+    graph,
+)
 from civic_digital_twins.dt_model.engine.numpybackend import executor
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index, TimeseriesIndex
 
 # ---------------------------------------------------------------------------
 # getting-started.md §1 — Define the model (legacy flat-list API)
@@ -26,7 +32,7 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
     model = Model("co2_model", [fuel_efficiency, distance, litres, co2_per_litre, co2])
 
-assert len(model.abstract_indexes()) == 2   # fuel_efficiency, distance
+assert len(model.abstract_indexes()) == 2  # fuel_efficiency, distance
 assert model.is_instantiated() is False
 
 
@@ -58,8 +64,8 @@ class Co2Model(Model):
         Outputs = Co2Model.Outputs
 
         inputs = Inputs(
-            fuel_efficiency = DistributionIndex("fuel_efficiency_km_l2", stats.uniform, {"loc": 10.0, "scale": 5.0}),
-            distance = DistributionIndex("distance_km2", stats.uniform, {"loc": 50.0, "scale": 30.0}),
+            fuel_efficiency=DistributionIndex("fuel_efficiency_km_l2", stats.uniform, {"loc": 10.0, "scale": 5.0}),
+            distance=DistributionIndex("distance_km2", stats.uniform, {"loc": 50.0, "scale": 30.0}),
         )
 
         litres = Index("litres2", inputs.distance / inputs.fuel_efficiency)
@@ -79,7 +85,7 @@ class Co2Model(Model):
 
 co2_model = Co2Model()
 
-assert len(co2_model.abstract_indexes()) == 2   # fuel_efficiency, distance
+assert len(co2_model.abstract_indexes()) == 2  # fuel_efficiency, distance
 assert co2_model.is_instantiated() is False
 assert co2_model.outputs.co2 is not None
 assert co2_model.outputs.litres is not None
@@ -101,9 +107,9 @@ ensemble = DistributionEnsemble(co2_model, size=1000)
 
 result = Evaluation(co2_model).evaluate(ensemble)
 
-co2 = co2_model.outputs.co2   # access via contractual output
-co2_samples = result[co2]            # np.ndarray, shape (1000,)
-co2_mean = result.marginalize(co2)   # scalar
+co2 = co2_model.outputs.co2  # access via contractual output
+co2_samples = result[co2]  # np.ndarray, shape (1000,)
+co2_mean = result.marginalize(co2)  # scalar
 
 assert co2_samples.shape == (1000,)
 # E[CO2] = E[distance / fuel_efficiency * 2.31]
@@ -115,8 +121,8 @@ assert 0 < co2_mean < 200, f"Unexpected CO2 mean: {co2_mean:.1f}"
 # getting-started.md §1 — abstract_indexes / is_instantiated (Block 02)
 # ---------------------------------------------------------------------------
 
-co2_model.abstract_indexes()   # → [fuel_efficiency, distance]
-co2_model.is_instantiated()    # → False
+co2_model.abstract_indexes()  # → [fuel_efficiency, distance]
+co2_model.is_instantiated()  # → False
 
 
 # ---------------------------------------------------------------------------
@@ -143,13 +149,13 @@ result = Evaluation(model).evaluate(
     ensemble,
     functions={
         "smooth": executor.LambdaAdapter(
-            lambda ts: np.convolve(ts, np.ones(3) / 3, mode="same")
-        )
+            lambda ts: np.convolve(ts, np.ones(3) / 3, mode="same"),
+        ),
     },
 )
 
 smoothed_values = result[smoothed]
-assert smoothed_values.shape[-1] == 24   # 24 time steps
+assert smoothed_values.shape[-1] == 24  # 24 time steps
 
 
 if __name__ == "__main__":

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -1,4 +1,5 @@
 """Runnable snippets from docs/design/dd-cdt-model.md."""
+# SPDX-License-Identifier: Apache-2.0
 
 import sys
 import warnings

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -12,16 +12,17 @@ _examples_dir = Path(__file__).parent.parent
 if str(_examples_dir) not in sys.path:
     sys.path.insert(0, str(_examples_dir))
 
-from civic_digital_twins.dt_model import Evaluation, Model, ModelContractWarning
-from civic_digital_twins.dt_model.model.index import (
+from civic_digital_twins.dt_model import (
     ConstIndex,
+    Distribution,
+    DistributionEnsemble,
     DistributionIndex,
+    Evaluation,
     Index,
+    Model,
+    ModelContractWarning,
     TimeseriesIndex,
 )
-from civic_digital_twins.dt_model.model.index import Distribution
-from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
-
 
 # ---------------------------------------------------------------------------
 # Block 00: dd-cdt-model.md — Index Types: Index modes
@@ -31,11 +32,8 @@ from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsembl
 def _demo_00_index_modes() -> None:
     """Block 00: Index modes."""
     from scipy import stats
-    from civic_digital_twins.dt_model.model.index import (
-        ConstIndex,
-        DistributionIndex,
-        Index,
-    )
+
+    from civic_digital_twins.dt_model import ConstIndex, DistributionIndex, Index
 
     # Distribution-backed (abstract — must be resolved in each scenario)
     # Pass any scipy-compatible distribution callable and a params dict:
@@ -67,7 +65,8 @@ def _demo_00_index_modes() -> None:
 def _demo_02_timeseries_index() -> None:
     """Block 02: TimeseriesIndex."""
     import numpy as np
-    from civic_digital_twins.dt_model.model.index import TimeseriesIndex
+
+    from civic_digital_twins.dt_model import TimeseriesIndex
 
     # Fixed time series
     flow = TimeseriesIndex("flow", np.array([10.0, 20.0, 30.0]))
@@ -87,8 +86,8 @@ def _demo_02_timeseries_index() -> None:
 def _demo_05_legacy_api() -> None:
     """Block 05: Legacy indexes= API."""
     from scipy import stats
-    from civic_digital_twins.dt_model.model.model import Model
-    from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+
+    from civic_digital_twins.dt_model import DistributionIndex, Index, Model
 
     x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
     y = DistributionIndex("y", stats.uniform, {"loc": 0.0, "scale": 10.0})
@@ -110,6 +109,7 @@ def _demo_05_legacy_api() -> None:
 def _demo_08_contract_warnings() -> None:
     """Block 08: Contract warnings — filterwarnings."""
     import warnings
+
     from civic_digital_twins.dt_model import ModelContractWarning
 
     with warnings.catch_warnings():
@@ -125,8 +125,8 @@ def _demo_08_contract_warnings() -> None:
 def _demo_12_distribution_ensemble() -> None:
     """Block 12: DistributionEnsemble."""
     from scipy import stats
-    from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
-    from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+
+    from civic_digital_twins.dt_model import DistributionEnsemble, DistributionIndex, Index
 
     x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
     y = DistributionIndex("y", stats.uniform, {"loc": 0.0, "scale": 10.0})
@@ -155,9 +155,8 @@ def _demo_14_15_end_to_end() -> None:
     """Blocks 14+15: Grid-mode marginalize + End-to-End Example (1-D mode)."""
     import numpy as np
     from scipy import stats
-    from civic_digital_twins.dt_model import Evaluation, Model
-    from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
-    from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
+
+    from civic_digital_twins.dt_model import DistributionEnsemble, DistributionIndex, Evaluation, Index, Model
 
     # Define the model
     x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
@@ -209,8 +208,6 @@ def _demo_17_constraint() -> None:
 def _demo_18_20_overtourism() -> None:
     """Blocks 18+19+20: OvertourismModel attributes + Grid Evaluation."""
     import numpy as np
-    from civic_digital_twins.dt_model import Evaluation
-    from civic_digital_twins.dt_model.model.index import ConstIndex, Distribution, Index
     from overtourism_molveno.overtourism_metamodel import (
         CategoricalContextVariable,
         Constraint,
@@ -218,6 +215,8 @@ def _demo_18_20_overtourism() -> None:
         OvertourismModel,
         PresenceVariable,
     )
+
+    from civic_digital_twins.dt_model import ConstIndex, Distribution, Evaluation, Index
 
     CV_weather = CategoricalContextVariable(
         "weather",

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -162,13 +162,15 @@ def _demo_14_15_end_to_end() -> None:
     x = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
     y = DistributionIndex("y", stats.uniform, {"loc": 0.0, "scale": 10.0})
     z = Index("z", x + y)
-    model = Model("demo", [x, y, z])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        model = Model("demo", [x, y, z])
 
     # Build an ensemble of 200 scenarios
     ensemble = DistributionEnsemble(model, size=200)
 
     # Evaluate
-    result = Evaluation(model).evaluate(ensemble)
+    result = Evaluation(model).evaluate(ensemble=ensemble)
 
     # Weighted mean of z across all scenarios
     print(result.marginalize(z))  # ≈ 10.0
@@ -264,7 +266,7 @@ def _demo_18_20_overtourism() -> None:
     ee = np.linspace(0, 50_000, 101)  # excursionist presence axis
 
     result = Evaluation(model).evaluate(
-        ensemble,
+        ensemble=ensemble,
         parameters={PV_tourists: tt, PV_excursionists: ee},
     )
 

--- a/examples/doc/doc_modularity.py
+++ b/examples/doc/doc_modularity.py
@@ -550,7 +550,7 @@ from civic_digital_twins.dt_model import DistributionEnsemble, Evaluation  # noq
 # PipelineModel has a DistributionIndex (raw_data), so DistributionEnsemble works.
 _pipeline_eval = PipelineModel()
 _ensemble_eval = DistributionEnsemble(_pipeline_eval, size=50)
-_result_eval = Evaluation(_pipeline_eval).evaluate(_ensemble_eval)
+_result_eval = Evaluation(_pipeline_eval).evaluate(ensemble=_ensemble_eval)
 
 mean_pipeline_result = _result_eval.marginalize(_pipeline_eval.outputs.result)
 assert mean_pipeline_result > 0

--- a/examples/doc/doc_modularity.py
+++ b/examples/doc/doc_modularity.py
@@ -11,16 +11,17 @@ from scipy import stats
 
 from civic_digital_twins.dt_model import (
     CategoricalIndex,
+    ConstIndex,
     DistributionIndex,
+    GenericIndex,
     Index,
     InputsContractWarning,
     Model,
     ModelContractWarning,
     ModelVariant,
     TimeseriesIndex,
+    graph,
 )
-from civic_digital_twins.dt_model.engine.frontend import graph
-from civic_digital_twins.dt_model.model.index import ConstIndex, GenericIndex
 
 
 def _id_in(idx: GenericIndex, seq: Sequence[GenericIndex]) -> bool:
@@ -334,7 +335,8 @@ assert any(issubclass(w.category, InputsContractWarning) for w in caught), (
 def _demo_08_filterwarnings() -> None:
     """Block 08: Escalate contract warnings to errors."""
     import warnings
-    from civic_digital_twins.dt_model import ModelContractWarning, InputsContractWarning
+
+    from civic_digital_twins.dt_model import InputsContractWarning, ModelContractWarning
 
     with warnings.catch_warnings():
         # Escalate all contract warnings to errors (recommended for CI)
@@ -429,11 +431,11 @@ def _demo_10_proxy_attributes() -> None:
         },
         selector="bike",
     )
-    mv.outputs.emissions        # delegates to BikeModel.outputs.emissions
-    mv.inputs.capacity          # delegates to BikeModel.inputs.capacity
-    mv.indexes                  # index list of the active (BikeModel) variant only
-    mv.abstract_indexes()       # delegates to BikeModel.abstract_indexes()
-    mv.is_instantiated()        # delegates to BikeModel.is_instantiated()
+    mv.outputs.emissions  # delegates to BikeModel.outputs.emissions
+    mv.inputs.capacity  # delegates to BikeModel.inputs.capacity
+    mv.indexes  # index list of the active (BikeModel) variant only
+    mv.abstract_indexes()  # delegates to BikeModel.abstract_indexes()
+    mv.is_instantiated()  # delegates to BikeModel.is_instantiated()
 
 
 # ---------------------------------------------------------------------------
@@ -451,8 +453,8 @@ def _demo_11_inactive_variants() -> None:
         },
         selector="bike",
     )
-    mv.variants["train"].outputs.emissions   # explicit — reaches inactive variant
-    mv.variants["train"].indexes             # index list of TrainModel only
+    mv.variants["train"].outputs.emissions  # explicit — reaches inactive variant
+    mv.variants["train"].indexes  # index list of TrainModel only
 
     # Active variant's emissions IS in mv.indexes; inactive's is NOT
     assert _id_in(mv.variants["bike"].outputs.emissions, mv.indexes)
@@ -493,7 +495,7 @@ def _demo_13_categorical_selector() -> None:
     mv = ModelVariant(
         "TransportModel",
         variants={
-            "bike":  BikeModel(),
+            "bike": BikeModel(),
             "train": TrainModel(),
         },
         selector=mode,
@@ -522,18 +524,19 @@ assert peak_factor.value is not None
 
 def _demo_15_piecewise_categorical() -> None:
     """Block 15: CategoricalIndex season guard with four-clause graph.piecewise."""
-    from civic_digital_twins.dt_model import CategoricalIndex
-    from civic_digital_twins.dt_model.engine.frontend import graph
+    from civic_digital_twins.dt_model import CategoricalIndex, graph
 
-    season = CategoricalIndex("season", {"summer": 0.25, "spring": 0.25,
-                                          "autumn": 0.25, "winter": 0.25})
+    season = CategoricalIndex("season", {"summer": 0.25, "spring": 0.25, "autumn": 0.25, "winter": 0.25})
 
-    peak_factor = Index("peak_factor", graph.piecewise(
-        (1.8, season == "summer"),
-        (1.2, season == "spring"),
-        (1.0, season == "autumn"),
-        (0.7, True),              # winter — default
-    ))
+    peak_factor = Index(
+        "peak_factor",
+        graph.piecewise(
+            (1.8, season == "summer"),
+            (1.2, season == "spring"),
+            (1.0, season == "autumn"),
+            (0.7, True),  # winter — default
+        ),
+    )
 
     assert peak_factor.value is not None
 
@@ -570,7 +573,8 @@ assert _smoothed_node is not None
 def _demo_29_filterwarnings_api() -> None:
     """Block 29: API reference — escalate contract warnings."""
     import warnings
-    from civic_digital_twins.dt_model import ModelContractWarning, InputsContractWarning
+
+    from civic_digital_twins.dt_model import InputsContractWarning, ModelContractWarning
 
     with warnings.catch_warnings():
         # Recommended for CI — escalate all contract warnings to errors

--- a/examples/doc/doc_modularity.py
+++ b/examples/doc/doc_modularity.py
@@ -224,6 +224,12 @@ class PipelineModel(Model):
     """Root model that wires StageAModel → StageBModel as a pipeline."""
 
     @dataclass
+    class Inputs:
+        """Inputs of :class:`PipelineModel`."""
+
+        raw_data: DistributionIndex
+
+    @dataclass
     class Outputs:
         """Outputs of :class:`PipelineModel`."""
 
@@ -236,13 +242,10 @@ class PipelineModel(Model):
         stage_a_indexes: list[GenericIndex]
         stage_b_indexes: list[GenericIndex]
 
-    def __init__(self) -> None:
-        raw_data = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
+    def __init__(self, raw_data: DistributionIndex) -> None:
+        inputs = PipelineModel.Inputs(raw_data=raw_data)
 
-        Outputs = PipelineModel.Outputs
-        Expose = PipelineModel.Expose
-
-        stage_a = StageAModel(raw_data=raw_data)
+        stage_a = StageAModel(raw_data=inputs.raw_data)
         stage_b = StageBModel(
             processed=stage_a.outputs.processed,
             ratio=stage_a.outputs.ratio,
@@ -250,15 +253,17 @@ class PipelineModel(Model):
 
         super().__init__(
             "Pipeline",
-            outputs=Outputs(result=stage_b.outputs.result),
-            expose=Expose(
+            inputs=inputs,
+            outputs=PipelineModel.Outputs(result=stage_b.outputs.result),
+            expose=PipelineModel.Expose(
                 stage_a_indexes=list(stage_a.indexes),
                 stage_b_indexes=list(stage_b.indexes),
             ),
         )
 
 
-pipeline = PipelineModel()
+_raw_data = DistributionIndex("x", stats.uniform, {"loc": 0.0, "scale": 10.0})
+pipeline = PipelineModel(raw_data=_raw_data)
 
 assert pipeline.outputs.result is not None
 # raw_data is a DistributionIndex (abstract) → model is not fully instantiated
@@ -548,7 +553,7 @@ def _demo_15_piecewise_categorical() -> None:
 from civic_digital_twins.dt_model import DistributionEnsemble, Evaluation  # noqa: E402
 
 # PipelineModel has a DistributionIndex (raw_data), so DistributionEnsemble works.
-_pipeline_eval = PipelineModel()
+_pipeline_eval = PipelineModel(raw_data=DistributionIndex("x_eval", stats.uniform, {"loc": 0.0, "scale": 10.0}))
 _ensemble_eval = DistributionEnsemble(_pipeline_eval, size=50)
 _result_eval = Evaluation(_pipeline_eval).evaluate(ensemble=_ensemble_eval)
 

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -10,10 +10,6 @@ if str(_examples_dir) not in sys.path:
     sys.path.insert(0, str(_examples_dir))
 
 import numpy as np
-from scipy import stats
-
-from civic_digital_twins.dt_model import Evaluation, piecewise
-from civic_digital_twins.dt_model.model.index import Distribution, DistributionIndex, Index
 from overtourism_molveno.overtourism_metamodel import (
     CategoricalContextVariable,
     Constraint,
@@ -23,6 +19,9 @@ from overtourism_molveno.overtourism_metamodel import (
     PresenceVariable,
     UniformCategoricalContextVariable,
 )
+from scipy import stats
+
+from civic_digital_twins.dt_model import Distribution, DistributionIndex, Evaluation, Index, graph
 
 # ---------------------------------------------------------------------------
 # overtourism-getting-started.md §1 — Context variables
@@ -80,7 +79,7 @@ I_C_beach = DistributionIndex("beach_capacity", stats.triang, {"loc": 3000.0, "s
 # Usage factor: depends on context variable (bad weather reduces beach use)
 I_U_beach_visitors = Index(
     "beach_usage_factor",
-    piecewise((0.30, CV_weather == "bad"), (0.70, True)),
+    graph.piecewise((0.30, CV_weather == "bad"), (0.70, True)),
 )
 
 # Usage formula: visitors × usage_factor

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -1,4 +1,5 @@
 """Runnable snippets from examples/overtourism_molveno/overtourism-getting-started.md."""
+# SPDX-License-Identifier: Apache-2.0
 
 import sys
 from pathlib import Path

--- a/examples/doc/doc_readme.py
+++ b/examples/doc/doc_readme.py
@@ -7,10 +7,9 @@ import warnings
 import numpy as np
 from scipy import stats
 
-from civic_digital_twins.dt_model import Model
+from civic_digital_twins.dt_model import DistributionIndex, Index, Model
 from civic_digital_twins.dt_model.engine.frontend import graph, linearize
 from civic_digital_twins.dt_model.engine.numpybackend import executor
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
 
 # ---------------------------------------------------------------------------
 # README — Engine layer snippet

--- a/examples/mobility_bologna/mobility_bologna.py
+++ b/examples/mobility_bologna/mobility_bologna.py
@@ -21,10 +21,23 @@ import pandas as pd
 from matplotlib.colors import LinearSegmentedColormap
 from scipy import stats
 
-from civic_digital_twins.dt_model import DistributionEnsemble, DistributionIndex, Index, Model, TimeseriesIndex
-from civic_digital_twins.dt_model.engine.frontend import graph
+from civic_digital_twins.dt_model import (
+    DistributionEnsemble,
+    DistributionIndex,
+    Evaluation,
+    EvaluationResult,
+    Index,
+    Model,
+    TimeseriesIndex,
+    graph,
+)
 from civic_digital_twins.dt_model.engine.numpybackend import executor
-from civic_digital_twins.dt_model.simulation.evaluation import Evaluation, EvaluationResult
+
+_LN2: float = math.log(2)
+"""Natural logarithm of 2 (≈ 0.6931). Normalisation constant in half-life decay formulas."""
+
+_LN_HALF: float = -_LN2
+"""Natural logarithm of 0.5 (= −ln 2). Exponent base for half-life decay: exp(Δt / p50 · ln½) = ½^(Δt/p50)."""
 
 try:
     from .mobility_bologna_data import euro_class_emission, euro_class_split, vehicle_inflow, vehicle_starting
@@ -176,7 +189,7 @@ class InflowModel(Model):
         i_fraction_rigid_euro = [
             Index(
                 f"rigid vehicles euro_{e} %",
-                (1 - inputs.i_p_fraction_exempted) * (np.e ** (inputs.i_p_cost[e] / inputs.i_b_p50_cost * np.log(0.5))),
+                (1 - inputs.i_p_fraction_exempted) * graph.exp(inputs.i_p_cost[e] / inputs.i_b_p50_cost * _LN_HALF),
             )
             for e in range(7)
         ]
@@ -215,7 +228,7 @@ class InflowModel(Model):
 
         i_fraction_anticipating = TimeseriesIndex(
             "anticipating vehicles %",
-            np.e ** (i_delta_from_start / inputs.i_b_p50_anticipating * np.log(0.5))
+            graph.exp(i_delta_from_start / inputs.i_b_p50_anticipating * _LN_HALF)
             * (1 - inputs.i_p_fraction_exempted - fraction_rigid),
         )
 
@@ -234,7 +247,7 @@ class InflowModel(Model):
 
         i_fraction_postponing = TimeseriesIndex(
             "postponing vehicles %",
-            np.e ** (i_delta_to_end / inputs.i_b_p50_postponing * np.log(0.5))
+            graph.exp(i_delta_to_end / inputs.i_b_p50_postponing * _LN_HALF)
             * (1 - inputs.i_p_fraction_exempted - fraction_rigid),
         )
 
@@ -256,9 +269,9 @@ class InflowModel(Model):
 
         i_number_anticipated = TimeseriesIndex(
             "anticipated vehicles",
-            np.e ** (i_delta_before_start / inputs.i_b_p50_anticipation * np.log(0.5))
+            graph.exp(i_delta_before_start / inputs.i_b_p50_anticipation * _LN_HALF)
             / inputs.i_b_p50_anticipation
-            * np.log(2)
+            * _LN2
             / 12
             * i_total_anticipating,
         )
@@ -276,9 +289,9 @@ class InflowModel(Model):
 
         i_number_postponed = TimeseriesIndex(
             "postponed vehicles",
-            np.e ** (i_delta_after_end / inputs.i_b_p50_postponement * np.log(0.5))
+            graph.exp(i_delta_after_end / inputs.i_b_p50_postponement * _LN_HALF)
             / inputs.i_b_p50_postponement
-            * np.log(2)
+            * _LN2
             / 12
             * i_total_postponing,
         )

--- a/examples/mobility_bologna/mobility_bologna_data.py
+++ b/examples/mobility_bologna/mobility_bologna_data.py
@@ -1,4 +1,5 @@
 """Data for the Mobility Bologna example."""
+# SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
 

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -286,12 +286,10 @@ class ParkingModel(Model):
 
         i_u_parking = Index(
             "parking usage",
-            inputs.pv_tourists.node
-            * inputs.i_u_tourists_parking.node
-            / (inputs.i_xa_tourists_per_vehicle.node * inputs.i_xo_tourists_parking.node)
-            + inputs.pv_excursionists.node
-            * inputs.i_u_excursionists_parking.node
-            / (inputs.i_xa_excursionists_per_vehicle.node * inputs.i_xo_excursionists_parking.node),
+            inputs.pv_tourists * inputs.i_u_tourists_parking
+            / (inputs.i_xa_tourists_per_vehicle * inputs.i_xo_tourists_parking)
+            + inputs.pv_excursionists * inputs.i_u_excursionists_parking
+            / (inputs.i_xa_excursionists_per_vehicle * inputs.i_xo_excursionists_parking),
         )
 
         super().__init__(
@@ -389,8 +387,8 @@ class BeachModel(Model):
 
         i_u_beach = Index(
             "beach usage",
-            inputs.pv_tourists.node * inputs.i_u_tourists_beach.node / inputs.i_xo_tourists_beach.node
-            + inputs.pv_excursionists.node * inputs.i_u_excursionists_beach.node / inputs.i_xo_excursionists_beach.node,
+            inputs.pv_tourists * inputs.i_u_tourists_beach / inputs.i_xo_tourists_beach
+            + inputs.pv_excursionists * inputs.i_u_excursionists_beach / inputs.i_xo_excursionists_beach,
         )
 
         super().__init__(
@@ -462,7 +460,7 @@ class AccommodationModel(Model):
 
         i_u_accommodation = Index(
             "accommodation usage",
-            inputs.pv_tourists.node * inputs.i_u_tourists_accommodation.node / inputs.i_xa_tourists_accommodation.node,
+            inputs.pv_tourists * inputs.i_u_tourists_accommodation / inputs.i_xa_tourists_accommodation,
         )
 
         super().__init__(
@@ -559,10 +557,10 @@ class FoodModel(Model):
         i_u_food = Index(
             "food usage",
             (
-                inputs.pv_tourists.node * inputs.i_u_tourists_food.node
-                + inputs.pv_excursionists.node * inputs.i_u_excursionists_food.node
+                inputs.pv_tourists * inputs.i_u_tourists_food
+                + inputs.pv_excursionists * inputs.i_u_excursionists_food
             )
-            / (inputs.i_xa_visitors_food.node * inputs.i_xo_visitors_food.node),
+            / (inputs.i_xa_visitors_food * inputs.i_xo_visitors_food),
         )
 
         super().__init__(

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -78,9 +78,7 @@ from dataclasses import dataclass
 
 from scipy import stats
 
-from civic_digital_twins.dt_model import piecewise
-from civic_digital_twins.dt_model.model.index import DistributionIndex, GenericIndex, Index
-from civic_digital_twins.dt_model.model.model import Model
+from civic_digital_twins.dt_model import DistributionIndex, GenericIndex, Index, Model, graph
 
 try:
     from .molveno_presence_stats import (
@@ -286,9 +284,11 @@ class ParkingModel(Model):
 
         i_u_parking = Index(
             "parking usage",
-            inputs.pv_tourists * inputs.i_u_tourists_parking
+            inputs.pv_tourists
+            * inputs.i_u_tourists_parking
             / (inputs.i_xa_tourists_per_vehicle * inputs.i_xo_tourists_parking)
-            + inputs.pv_excursionists * inputs.i_u_excursionists_parking
+            + inputs.pv_excursionists
+            * inputs.i_u_excursionists_parking
             / (inputs.i_xa_excursionists_per_vehicle * inputs.i_xo_excursionists_parking),
         )
 
@@ -556,10 +556,7 @@ class FoodModel(Model):
 
         i_u_food = Index(
             "food usage",
-            (
-                inputs.pv_tourists * inputs.i_u_tourists_food
-                + inputs.pv_excursionists * inputs.i_u_excursionists_food
-            )
+            (inputs.pv_tourists * inputs.i_u_tourists_food + inputs.pv_excursionists * inputs.i_u_excursionists_food)
             / (inputs.i_xa_visitors_food * inputs.i_xo_visitors_food),
         )
 
@@ -628,7 +625,7 @@ class MolvenoModel(OvertourismModel):
         i_u_tourists_parking = Index("tourist parking usage factor", 0.02)
         i_u_excursionists_parking = Index(
             "excursionist parking usage factor",
-            piecewise((0.55, cv_weather == "bad"), (0.80, True)),
+            graph.piecewise((0.55, cv_weather == "bad"), (0.80, True)),
         )
         i_xa_tourists_per_vehicle = Index("tourists per vehicle allocation factor", 2.5)
         i_xa_excursionists_per_vehicle = Index("excursionists per vehicle allocation factor", 2.5)
@@ -639,11 +636,11 @@ class MolvenoModel(OvertourismModel):
         # Beach parameters
         i_u_tourists_beach = Index(
             "tourist beach usage factor",
-            piecewise((0.25, cv_weather == "bad"), (0.50, True)),
+            graph.piecewise((0.25, cv_weather == "bad"), (0.50, True)),
         )
         i_u_excursionists_beach = Index(
             "excursionist beach usage factor",
-            piecewise((0.35, cv_weather == "bad"), (0.80, True)),
+            graph.piecewise((0.35, cv_weather == "bad"), (0.80, True)),
         )
         i_xo_tourists_beach = DistributionIndex(
             "tourists on beach rotation factor",
@@ -666,7 +663,7 @@ class MolvenoModel(OvertourismModel):
         i_u_tourists_food = Index("tourist food service usage factor", 0.20)
         i_u_excursionists_food = Index(
             "excursionist food service usage factor",
-            piecewise((0.80, cv_weather == "bad"), (0.40, True)),
+            graph.piecewise((0.80, cv_weather == "bad"), (0.40, True)),
         )
         i_xa_visitors_food = Index("visitors in food service allocation factor", 0.9)
         i_xo_visitors_food = Index("visitors in food service rotation factor", 2.0)

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -88,8 +88,8 @@ dense range of visitor counts.
 
 ```python
 from scipy import stats
-from civic_digital_twins.dt_model import piecewise
-from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
+
+from civic_digital_twins.dt_model import DistributionIndex, Index, graph
 from overtourism_molveno.overtourism_metamodel import Constraint
 
 # Capacity with uncertainty
@@ -98,7 +98,7 @@ I_C_beach = DistributionIndex("beach_capacity", stats.triang, {"loc": 3000.0, "s
 # Usage factor: depends on context variable (bad weather reduces beach use)
 I_U_beach_visitors = Index(
     "beach_usage_factor",
-    piecewise((0.30, CV_weather == "bad"), (0.70, True)),
+    graph.piecewise((0.30, CV_weather == "bad"), (0.70, True)),
 )
 
 # Usage formula: visitors × usage_factor
@@ -109,7 +109,7 @@ C_beach = Constraint(
 )
 ```
 
-`piecewise((expr, cond), …)` builds a conditional formula node that the
+`graph.piecewise((expr, cond), …)` builds a conditional formula node that the
 engine evaluates lazily — the condition `CV_weather == "bad"` is a graph
 node that resolves to `True` or `False` once `CV_weather` is assigned a
 concrete value in a scenario.
@@ -135,8 +135,7 @@ flat `indexes` list so that `Evaluation` can find it.
 ## 5 — Ensemble
 
 ```python
-from overtourism_molveno.overtourism_metamodel import OvertourismEnsemble
-from civic_digital_twins.dt_model.model.index import ContextVariable
+from overtourism_molveno.overtourism_metamodel import ContextVariable, OvertourismEnsemble
 
 scenario: dict[ContextVariable, list] = {
     CV_season:  ["low", "high"],
@@ -182,7 +181,7 @@ The sustainability field measures what fraction of the weighted scenario
 population considers each visitor count sustainable:
 
 ```python
-from civic_digital_twins.dt_model.model.index import Distribution
+from civic_digital_twins.dt_model import Distribution
 
 field = np.ones(visitors_axis.size)
 

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Getting Started with the Overtourism Model
 
 This guide walks through the **vertical extension pattern** of the

--- a/examples/overtourism_molveno/overtourism_metamodel.py
+++ b/examples/overtourism_molveno/overtourism_metamodel.py
@@ -31,9 +31,7 @@ import numpy as np
 from scipy.stats import rv_continuous
 from scipy.stats._distn_infrastructure import rv_continuous_frozen
 
-from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
-from civic_digital_twins.dt_model.model.index import Distribution, GenericIndex, Index
-from civic_digital_twins.dt_model.model.model import Model
+from civic_digital_twins.dt_model import ENSEMBLE, Axis, Distribution, GenericIndex, Index, Model
 
 # ---------------------------------------------------------------------------
 # Context variables

--- a/examples/overtourism_molveno/overtourism_molveno.py
+++ b/examples/overtourism_molveno/overtourism_molveno.py
@@ -17,8 +17,7 @@ from scipy import interpolate, ndimage, stats
 
 matplotlib.use("Agg")  # must be called before any other matplotlib sub-imports
 
-from civic_digital_twins.dt_model import Evaluation
-from civic_digital_twins.dt_model.model.index import Distribution
+from civic_digital_twins.dt_model import Distribution, Evaluation
 
 warnings.filterwarnings("ignore", message=".*sample arguments is too small.*")
 

--- a/tests/dt_model/examples/__init__.py
+++ b/tests/dt_model/examples/__init__.py
@@ -1,1 +1,2 @@
 """Tests for the example models."""
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/dt_model/simulation/__init__.py
+++ b/tests/dt_model/simulation/__init__.py
@@ -1,1 +1,2 @@
 """Tests for the simulation layer."""
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/test_doc_sync.py
+++ b/tests/test_doc_sync.py
@@ -28,12 +28,13 @@ example script as a *snippet-to-example* check:
 
 Deviation levels (per snippet):
 
-* Score ≥ ``_ALIGNED_THRESHOLD`` (0.85) — snippet is aligned; no action.
-* ``_MINOR_THRESHOLD`` (0.60) ≤ score < ``_ALIGNED_THRESHOLD`` — minor
-  deviation; a ``UserWarning`` is emitted listing the unmatched lines together
-  with their best candidate in the example.
-* Score < ``_MINOR_THRESHOLD`` — major deviation; the test **fails** with a
-  report of every problematic snippet and its unmatched lines.
+* Score = 100 % AND every matched line ratio ≥ 0.99 — ``= OK``; test passes silently.
+* Score = 100 % but at least one near-verbatim match (ratio < 0.99) — ``~ OK``; treated as a deviation.
+* ``_MINOR_THRESHOLD`` (0.60) ≤ score < 100 % — ``~ Warn``; treated as a deviation.
+* Score < ``_MINOR_THRESHOLD`` — ``✗ Fail``; always fails.
+
+``~ OK`` and ``~ Warn`` deviations **fail** the test unless the block is listed in
+``_EXPECTED_NEAR_VERBATIM``, in which case the test is marked ``xfail``.
 
 Reference-only blocks
 ---------------------
@@ -73,7 +74,6 @@ the best match in the script), and each unmatched line as ``✗``.
 
 import difflib
 import re
-import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -111,12 +111,16 @@ DOC_TO_SCRIPT: dict[str, str] = {
 #: suffixes / minor literal changes.
 _LINE_THRESHOLD: float = 0.75
 
-#: Per-snippet score above which the snippet is treated as aligned (no action).
-_ALIGNED_THRESHOLD: float = 0.85
-
-#: Per-snippet score below which the deviation is *major* (test fails).
-#: Scores in [_MINOR_THRESHOLD, _ALIGNED_THRESHOLD) are *minor* (warning).
+#: Per-snippet score below which the deviation is *major* (test fails regardless
+#: of ``_EXPECTED_NEAR_VERBATIM``).  Scores in [_MINOR_THRESHOLD, 1.0) are
+#: *minor* (``~ Warn``); score == 1.0 with all ratios ≥ 0.99 is ``= OK``.
 _MINOR_THRESHOLD: float = 0.60
+
+#: ``(doc_rel, block_index)`` pairs that are intentionally near-verbatim rather
+#: than verbatim-exact.  The test is marked ``xfail`` for these blocks instead
+#: of failing.  Add an entry here only when a ``~ OK`` or ``~ Warn`` result is
+#: genuinely expected and fixing the drift is not worthwhile.
+_EXPECTED_NEAR_VERBATIM: set[tuple[str, int]] = set()
 
 # ---------------------------------------------------------------------------
 # Compiled regular expressions
@@ -139,6 +143,13 @@ _PLACEHOLDER_RE = re.compile(r"^\s*[\w.]+\s*=\s*\.\.\.\s*$")
 
 # print(…) statement
 _PRINT_STMT_RE = re.compile(r"^\s*print\s*\(")
+
+# Trailing inline comment:  <code>  # …   (any whitespace before #, space after)
+# The PEP 8 pattern ``\s+#\s`` matches ``# scalar``, ``# noqa: F841``, etc.
+# while avoiding bare ``#noqa`` (no space) and in-string ``#`` tokens.
+# Stripping these from both doc and script lines prevents helper annotations
+# from reducing the match ratio against lines that lack such annotations.
+_INLINE_COMMENT_RE = re.compile(r"\s+#\s.*$")
 
 # Class definition (captures name):  class Foo
 _CLASS_DEF_RE = re.compile(r"^\s*class\s+([A-Z]\w*)")
@@ -303,7 +314,7 @@ def _is_reference_only_block(code: str, example_text: str) -> bool:
 
 
 def _normalize_line(line: str) -> str:
-    """Strip leading/trailing whitespace and collapse internal runs to one space.
+    """Strip leading/trailing whitespace, trailing inline comments, and collapse spaces.
 
     Parameters
     ----------
@@ -314,7 +325,15 @@ def _normalize_line(line: str) -> str:
     -------
     str
         Normalised line suitable for fuzzy comparison.
+
+    Notes
+    -----
+    Trailing inline comments (whitespace + ``#`` + space + rest, PEP 8 style)
+    are stripped before collapsing whitespace so annotations such as
+    ``# noqa: F841`` in scripts or ``# scalar`` in doc snippets do not reduce
+    the match ratio when the code part is otherwise identical.
     """
+    line = _INLINE_COMMENT_RE.sub("", line)
     return " ".join(line.split())
 
 
@@ -508,16 +527,25 @@ def _format_snippet_report(result: SnippetResult, doc_rel: str) -> str:
     str
         Multi-line text suitable for inclusion in a warning or failure message.
     """
+    score = result.match_score
     lines = [
         f"  Block {result.block_index} of {doc_rel}  "
-        f"(score {result.match_score:.0%}: "
+        f"(score {score:.0%}: "
         f"{len(result.matched)} matched, {len(result.missed)} unmatched "
         f"out of {result.total_key_lines} key lines)",
         f"    First line: {result.preview!r}",
-        "    Unmatched lines (doc line  →  best candidate in example):",
     ]
-    for doc_line, best_ratio in sorted(result.missed, key=lambda t: t[1]):
-        lines.append(f"      [{best_ratio:.2f}]  {doc_line!r}")
+    if result.missed:
+        lines.append("    Unmatched lines (doc line  →  best candidate in example):")
+        for doc_line, best_ratio in sorted(result.missed, key=lambda t: t[1]):
+            lines.append(f"      [{best_ratio:.2f}]  {doc_line!r}")
+    else:
+        # score == 1.0 but near-verbatim (~ OK): show the near-verbatim matches
+        lines.append("    Near-verbatim matches (ratio < 0.99, doc line  →  best match in example):")
+        for doc_line, ex_line, ratio in result.matched:
+            if ratio < 0.99:
+                lines.append(f"      [{ratio:.2f}]  {doc_line!r}")
+                lines.append(f"              →  {ex_line!r}")
     return "\n".join(lines)
 
 
@@ -537,9 +565,9 @@ class PairStats:
     total : int
         Total number of Python code blocks in the document.
     perfect : int
-        Aligned blocks where every matched key line has ratio >= 0.99 (all ``=``).
+        Blocks where score == 100 % and every matched line ratio >= 0.99 (``= OK``).
     aligned : int
-        Aligned blocks that have at least one near-verbatim (``~``) matched line.
+        Blocks where score == 100 % but at least one near-verbatim match (``~ OK``).
     minor : int
         Blocks with ``_MINOR_THRESHOLD`` <= score < ``_ALIGNED_THRESHOLD``.
     fail : int
@@ -608,7 +636,7 @@ def _collect_pair_stats(doc_rel: str, script_rel: str) -> PairStats:
             continue
 
         score = result.match_score
-        if score >= _ALIGNED_THRESHOLD:
+        if score == 1.0:
             if all(ratio >= 0.99 for _, _, ratio in result.matched):
                 stats.perfect += 1
             else:
@@ -629,10 +657,10 @@ def _print_summary_table() -> None:
     the bottom.  Pairs with no failures are prefixed ``✓``; pairs with
     failures ``✗``.
 
-    The ``= OK`` column counts blocks where every matched key line is an exact
-    or near-exact match (ratio >= 0.99).  The ``~ OK`` column counts blocks
-    that are aligned overall but contain at least one near-verbatim (``~``)
-    matched line.
+    The ``= OK`` column counts blocks where score == 100 % and every matched
+    line has ratio >= 0.99.  The ``~ OK`` column counts blocks where score ==
+    100 % but at least one match is near-verbatim (ratio < 0.99) — these are
+    deviations.
     """
     _COL = 32  # width of the doc-name column (covers longest name + prefix)
 
@@ -730,13 +758,13 @@ def _report_pair(doc_rel: str, script_rel: str) -> None:
             continue
 
         score = result.match_score
-        if score >= _ALIGNED_THRESHOLD:
+        if score == 1.0:
             if all(ratio >= 0.99 for _, _, ratio in result.matched):
                 tag = "PERFECT"
             else:
-                tag = "ALIGNED"
+                tag = "~OK"
         elif score >= _MINOR_THRESHOLD:
-            tag = "minor"
+            tag = "~Warn"
         else:
             tag = "FAIL"
 
@@ -785,15 +813,18 @@ def test_doc_sync(doc_rel: str, script_rel: str) -> None:
       ``difflib.SequenceMatcher`` with threshold ``_LINE_THRESHOLD`` (0.75).
     * The *snippet match score* = matched / total key lines.
 
-    **Major deviation** (score < ``_MINOR_THRESHOLD`` = 0.60)
-        The test **fails** and reports every problematic snippet with the
-        unmatched lines and their best available similarity scores.
+    **Perfect** (score = 100 % and all per-line ratios ≥ 0.99)
+        ``= OK``; the test passes silently.
 
-    **Minor deviation** (``_MINOR_THRESHOLD`` ≤ score < ``_ALIGNED_THRESHOLD`` = 0.85)
-        A ``UserWarning`` is emitted listing the unmatched lines; the test passes.
+    **Near-verbatim** (score = 100 % but at least one ratio < 0.99) — ``~ OK``
+        Treated as a deviation.  The test **fails** unless the block is listed
+        in ``_EXPECTED_NEAR_VERBATIM``, in which case it is marked ``xfail``.
 
-    **Aligned** (score ≥ ``_ALIGNED_THRESHOLD``)
-        No output; the test passes silently.
+    **Minor deviation** (``_MINOR_THRESHOLD`` ≤ score < 100 %) — ``~ Warn``
+        Treated as a deviation (same as ``~ OK``).
+
+    **Major deviation** (score < ``_MINOR_THRESHOLD``) — ``✗ Fail``
+        Always fails, regardless of ``_EXPECTED_NEAR_VERBATIM``.
 
     The test is **skipped** (rather than failing with an error) when either
     file does not exist at the expected path.
@@ -812,8 +843,7 @@ def test_doc_sync(doc_rel: str, script_rel: str) -> None:
     blocks = _extract_python_blocks(doc_text)
     example_lines_norm = [_normalize_line(ln) for ln in script_text.splitlines() if ln.strip()]
 
-    major_deviations: list[SnippetResult] = []
-    minor_deviations: list[SnippetResult] = []
+    deviations: list[SnippetResult] = []
 
     for idx, block in enumerate(blocks):
         # Skip stub / pseudo-code blocks (API-reference signatures, TL;DR pseudo-code, …)
@@ -829,40 +859,38 @@ def test_doc_sync(doc_rel: str, script_rel: str) -> None:
             continue  # no key lines → nothing to check
 
         score = result.match_score
-        if score < _MINOR_THRESHOLD:
-            major_deviations.append(result)
-        elif score < _ALIGNED_THRESHOLD:
-            minor_deviations.append(result)
+        is_perfect = score == 1.0 and all(ratio >= 0.99 for _, _, ratio in result.matched)
+        if not is_perfect:
+            deviations.append(result)
+
+    if not deviations:
+        return  # all blocks are = OK
 
     # ------------------------------------------------------------------ #
-    # Emit UserWarning for minor deviations (test still passes)           #
+    # Split into major (always fail), unexpected, and expected (xfail)   #
     # ------------------------------------------------------------------ #
-    for result in minor_deviations:
-        warnings.warn(
-            f"Minor deviation in {doc_rel}:\n" + _format_snippet_report(result, doc_rel),
-            UserWarning,
-            stacklevel=2,
-        )
+    major = [r for r in deviations if r.match_score < _MINOR_THRESHOLD]
+    non_major = [r for r in deviations if r.match_score >= _MINOR_THRESHOLD]
+    unexpected = [r for r in non_major if (doc_rel, r.block_index) not in _EXPECTED_NEAR_VERBATIM]
+    expected = [r for r in non_major if (doc_rel, r.block_index) in _EXPECTED_NEAR_VERBATIM]
 
-    # ------------------------------------------------------------------ #
-    # Fail on major deviations                                            #
-    # ------------------------------------------------------------------ #
-    if major_deviations:
+    if major or unexpected:
+        failing = major + unexpected
         report_lines = [
-            f"Major deviation(s) detected — {len(major_deviations)} snippet(s) in",
-            f"  {doc_rel}",
-            "are not present as near-verbatim copies in",
-            f"  {script_rel}.",
+            f"{len(failing)} snippet(s) in {doc_rel} deviate from their",
+            f"near-verbatim copy in {script_rel}.",
             "",
             "Each documentation Python code block should appear in the example",
             "script with at most minor adaptations (variable renames, added",
             "assertions, wrapping context).  The core logic must match.",
             "",
-            "Problematic snippets:",
+            "Deviating snippets:",
             "",
         ]
-        for result in major_deviations:
-            report_lines.append(_format_snippet_report(result, doc_rel))
+        for result in failing:
+            score = result.match_score
+            kind = "✗ Fail" if score < _MINOR_THRESHOLD else ("~ OK" if score == 1.0 else "~ Warn")
+            report_lines.append(f"  [{kind}]" + _format_snippet_report(result, doc_rel)[1:])
             report_lines.append("")
         report_lines += [
             "To fix, either:",
@@ -870,8 +898,14 @@ def test_doc_sync(doc_rel: str, script_rel: str) -> None:
             f"    of the flagged code blocks from {doc_rel}, or",
             f"  • Update {doc_rel} to match what is actually demonstrated in",
             f"    {script_rel}.",
+            "  • If the deviation is intentional, add (doc_rel, block_index) to",
+            "    _EXPECTED_NEAR_VERBATIM.",
         ]
         pytest.fail("\n".join(report_lines))
+
+    # Only expected (xfail) deviations remain.
+    xfail_indices = [r.block_index for r in expected]
+    pytest.xfail(reason=f"known near-verbatim block(s) in {doc_rel}: indices {xfail_indices}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Closes #123 (\`dt_model.graph\` shim) and #151 (DeprecationWarnings in \`examples/doc/\` scripts); imports consolidated, \`PipelineModel\` example fixed.
- SPDX-License-Identifier headers on all tracked \`.py\`/\`.md\` files; \`test_doc_sync\` now requires 100%-exact matches (\`= OK\`), with an \`_EXPECTED_NEAR_VERBATIM\` allowlist for intentional drift.