### PR TITLE
feat(#134): tests and docs for CategoricalIndex as parameters= axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `CategoricalIndex` selector can be passed as a `parameters=` axis to
+  `Evaluation.evaluate()` to sweep over variant outcomes deterministically
+  (no ensemble required), including in combination with numeric PARAMETER axes
+  for multi-dimensional grids.  Tests and documentation added; no implementation
+  change was needed (closing #134).
+
 ## [0.9.0] - 2026-05-02
 
 ### Added

--- a/docs/design/dd-cdt-modularity.md
+++ b/docs/design/dd-cdt-modularity.md
@@ -479,6 +479,59 @@ the variant selection emerges from existing sampled parameters.
 | Sampled by | `DistributionEnsemble` (extended) | existing sampling pipeline |
 | Typical use | "30 % bike / 70 % train" | "if cost > threshold → train" |
 
+#### Deterministic variant sweep via `parameters=`
+
+A `CategoricalIndex` selector can also be used as a **PARAMETER axis** to compare variants
+side-by-side, without any probabilistic ensemble.  Pass it directly to `parameters=` with an
+array of outcome strings:
+
+```python
+mode_param = CategoricalIndex("mode_param", {"bike": 0.5, "train": 0.5})
+mv_param = ModelVariant(
+    "TransportParam",
+    variants={"bike": BikeModel(), "train": TrainModel()},
+    selector=mode_param,
+)
+
+result = Evaluation(mv_param).evaluate(
+    ensemble=None,
+    parameters={mode_param: np.array(["bike", "train"])},
+)
+# result.marginalize(mv_param.outputs.emissions) → shape (2,)
+# index 0 = bike emissions, index 1 = train emissions
+```
+
+`ensemble=None` signals a fully deterministic run: no ENSEMBLE axis is created and
+`mode_param` is resolved by the PARAMETER grid alone.  A `CategoricalIndex` PARAMETER axis
+can be combined with numeric PARAMETER axes for a 2-D grid.  Variant sub-models must
+accept the numeric index as an abstract input:
+
+```python
+presence = Index("presence", None)  # abstract — swept by the grid
+mv_grid = ModelVariant(
+    "TransportGrid",
+    variants={
+        "bike": BikeModelPres(presence),
+        "train": TrainModelPres(presence),
+    },
+    selector=mode_param,
+)
+
+result = Evaluation(mv_grid).evaluate(
+    ensemble=None,
+    parameters={
+        mode_param: np.array(["bike", "train"]),
+        presence:   np.array([100.0, 200.0, 300.0]),
+    },
+)
+# result.marginalize(mv_grid.outputs.emissions) → shape (2, 3)
+# row 0 = bike emissions for each presence level
+# row 1 = train emissions for each presence level
+```
+
+The variant ordering in the result follows the order of entries in the `parameters=` array,
+not the declaration order of `variants`.
+
 #### Runtime mode — what changes
 
 In runtime mode `ModelVariant` builds a **merged computation graph** at construction time.

--- a/examples/doc/doc_modularity.py
+++ b/examples/doc/doc_modularity.py
@@ -546,6 +546,53 @@ def _demo_15_piecewise_categorical() -> None:
 
 
 # ---------------------------------------------------------------------------
+# dd-cdt-modularity.md — Presence-aware variant models for 2-D parameter sweep
+# ---------------------------------------------------------------------------
+
+
+class BikeModelPres(Model):
+    """Bike variant whose emissions scale with an abstract presence index."""
+
+    @dataclass
+    class Inputs:
+        """Inputs of :class:`BikeModelPres`."""
+
+        presence: Index
+
+    @dataclass
+    class Outputs:
+        """Outputs of :class:`BikeModelPres`."""
+
+        emissions: Index
+
+    def __init__(self, presence: Index) -> None:
+        inputs = BikeModelPres.Inputs(presence=presence)
+        emissions = Index("bike_pres_emissions", inputs.presence * 3.0)
+        super().__init__("BikePres", inputs=inputs, outputs=BikeModelPres.Outputs(emissions=emissions))
+
+
+class TrainModelPres(Model):
+    """Train variant whose emissions scale with an abstract presence index."""
+
+    @dataclass
+    class Inputs:
+        """Inputs of :class:`TrainModelPres`."""
+
+        presence: Index
+
+    @dataclass
+    class Outputs:
+        """Outputs of :class:`TrainModelPres`."""
+
+        emissions: Index
+
+    def __init__(self, presence: Index) -> None:
+        inputs = TrainModelPres.Inputs(presence=presence)
+        emissions = Index("train_pres_emissions", inputs.presence * 1.0)
+        super().__init__("TrainPres", inputs=inputs, outputs=TrainModelPres.Outputs(emissions=emissions))
+
+
+# ---------------------------------------------------------------------------
 # dd-cdt-modularity.md — End-to-End evaluation with marginalize
 # ---------------------------------------------------------------------------
 
@@ -558,6 +605,66 @@ _result_eval = Evaluation(_pipeline_eval).evaluate(ensemble=_ensemble_eval)
 
 mean_pipeline_result = _result_eval.marginalize(_pipeline_eval.outputs.result)
 assert mean_pipeline_result > 0
+
+
+# ---------------------------------------------------------------------------
+# dd-cdt-modularity.md — CategoricalIndex as PARAMETER axis (1-D sweep)
+# ---------------------------------------------------------------------------
+
+
+def _demo_catidx_param_axis_1d() -> None:
+    """1-D deterministic sweep: mode ∈ {bike, train}, constant capacity variants."""
+    mode_param = CategoricalIndex("mode_param", {"bike": 0.5, "train": 0.5})
+    mv_param = ModelVariant(
+        "TransportParam",
+        variants={"bike": BikeModel(), "train": TrainModel()},
+        selector=mode_param,
+    )
+
+    result = Evaluation(mv_param).evaluate(
+        ensemble=None,
+        parameters={mode_param: np.array(["bike", "train"])},
+    )
+    # result.marginalize(mv_param.outputs.emissions) → shape (2,)
+    # index 0 = bike emissions, index 1 = train emissions
+    arr = result.marginalize(mv_param.outputs.emissions)
+    assert arr.shape == (2,)
+    assert np.isclose(arr[0], 100.0 * 3.0)  # BikeModel: capacity=100, factor=3
+    assert np.isclose(arr[1], 500.0 * 1.0)  # TrainModel: capacity=500, factor=1
+
+
+# ---------------------------------------------------------------------------
+# dd-cdt-modularity.md — CategoricalIndex as PARAMETER axis (2-D grid)
+# ---------------------------------------------------------------------------
+
+
+def _demo_catidx_param_axis_2d() -> None:
+    """2-D deterministic grid: mode × presence, presence-aware variants."""
+    mode_param = CategoricalIndex("mode_param", {"bike": 0.5, "train": 0.5})
+    presence = Index("presence", None)  # abstract — swept by the grid
+    mv_grid = ModelVariant(
+        "TransportGrid",
+        variants={
+            "bike": BikeModelPres(presence),
+            "train": TrainModelPres(presence),
+        },
+        selector=mode_param,
+    )
+
+    result = Evaluation(mv_grid).evaluate(
+        ensemble=None,
+        parameters={
+            mode_param: np.array(["bike", "train"]),
+            presence:   np.array([100.0, 200.0, 300.0]),
+        },
+    )
+    # result.marginalize(mv_grid.outputs.emissions) → shape (2, 3)
+    # row 0 = bike emissions for each presence level
+    # row 1 = train emissions for each presence level
+    arr = result.marginalize(mv_grid.outputs.emissions)
+    assert arr.shape == (2, 3)
+    assert np.allclose(arr[0], [100.0 * 3, 200.0 * 3, 300.0 * 3])  # bike: presence * 3
+    assert np.allclose(arr[1], [100.0 * 1, 200.0 * 1, 300.0 * 1])  # train: presence * 1
 
 
 # ---------------------------------------------------------------------------
@@ -599,6 +706,8 @@ _demo_10_proxy_attributes()
 _demo_11_inactive_variants()
 _demo_13_categorical_selector()
 _demo_15_piecewise_categorical()
+_demo_catidx_param_axis_1d()
+_demo_catidx_param_axis_2d()
 _demo_29_filterwarnings_api()
 
 

--- a/tests/dt_model/simulation/test_model_variant_evaluation.py
+++ b/tests/dt_model/simulation/test_model_variant_evaluation.py
@@ -283,3 +283,52 @@ def test_grid_mode_node_selector_from_axis():
     # presence=200 → train → 200*10=2000
     # presence=300 → train → 300*10=3000
     assert np.allclose(result.marginalize(mv.outputs.throughput), [100.0, 2000.0, 3000.0])
+
+
+# ===========================================================================
+# Grid mode — CategoricalIndex selector as the PARAMETER axis itself
+# ===========================================================================
+
+
+def test_grid_mode_categorical_index_as_sole_parameter_axis():
+    """CategoricalIndex used as the sole PARAMETER axis (no ensemble).
+
+    Sweeping mode over ["bike", "train"] produces a (2,) result:
+      bike  → throughput = capacity * 1  = 100
+      train → throughput = capacity * 10 = 1000
+    """
+    mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
+    mv = _make_mv_with_mode(mode)
+
+    result = Evaluation(mv).evaluate(
+        ensemble=None,
+        nodes_of_interest=[mv.outputs.throughput],
+        parameters={mode: np.array(["bike", "train"])},
+    )
+
+    assert np.allclose(result.marginalize(mv.outputs.throughput), [_CAPACITY_VALUE * 1.0, _CAPACITY_VALUE * 10.0])
+
+
+def test_grid_mode_categorical_index_and_numeric_axis_2d():
+    """CategoricalIndex + numeric index as a 2-D PARAMETER grid (no ensemble).
+
+    Grid: mode ∈ {"bike", "train"} × presence ∈ {100, 200}
+      [0, 0] bike,  presence=100 → 100 * 1   = 100
+      [0, 1] bike,  presence=200 → 200 * 1   = 200
+      [1, 0] train, presence=100 → 100 * 10  = 1000
+      [1, 1] train, presence=200 → 200 * 10  = 2000
+    """
+    mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
+    presence, mv = _make_presence_mv(mode)
+
+    result = Evaluation(mv).evaluate(
+        ensemble=None,
+        nodes_of_interest=[mv.outputs.throughput],
+        parameters={
+            mode: np.array(["bike", "train"]),
+            presence: np.array([100.0, 200.0]),
+        },
+    )
+
+    expected = np.array([[100.0, 200.0], [1000.0, 2000.0]])
+    assert np.allclose(result.marginalize(mv.outputs.throughput), expected)


### PR DESCRIPTION
Verifies and documents that a `CategoricalIndex` selector can be passed directly as a `parameters=` axis to `Evaluation.evaluate()`, sweeping over variant outcomes deterministically — including in combination with numeric PARAMETER axes for multi-dimensional grids. No implementation change was needed; the existing eager `np.select()` path already handles string-typed PARAMETER substitutions correctly.

Closes #134.