### PR TITLE
feat: engine layer interface cleanup — HasNode protocol and NumpyBackend adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (no ensemble required), including in combination with numeric PARAMETER axes
   for multi-dimensional grids.  Tests and documentation added; no implementation
   change was needed (closing #134).
+- `HasNode[T]` protocol in `engine.frontend.graph` — structural protocol satisfied
+  by any object with a `.node: Node[T]` property (e.g. `GenericIndex`).  Re-exported
+  from `civic_digital_twins.dt_model`.  `function_call`, `piecewise`, and `where`
+  now accept `HasNode` in all node positions, eliminating the need for explicit
+  `.node` at call sites (closing #161).
+- `NumpyBackend` class in `engine.numpybackend.executor` — user-facing binding
+  point for the numpy backend.  `NumpyBackend.adapt(fn)` wraps a callable as a
+  `Functor` bound to the numpy convention; `Evaluation.evaluate()` accepts
+  `backend=NumpyBackend` (default, currently the only supported backend).
+  `Functor`, `NumpyBackend`, and `LambdaAdapter` are re-exported from
+  `civic_digital_twins.dt_model` (closing #162).
+
+### Deprecated
+
+- `LambdaAdapter` — use `NumpyBackend.adapt()` instead.  `LambdaAdapter` now
+  emits a `DeprecationWarning` on construction and will be removed in a future
+  release (closing #162).
 
 ## [0.9.0] - 2026-05-02
 

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -1,6 +1,7 @@
 """Digital twin modeling and simulation library."""
 # SPDX-License-Identifier: Apache-2.0
 
+from .engine.frontend.graph import HasNode
 from .model import (
     DOMAIN,
     ENSEMBLE,
@@ -37,6 +38,7 @@ from .simulation import (
 
 __all__ = [
     "AbstractIndexNotInInputsWarning",
+    "HasNode",
     "Axis",
     "AxisEnsemble",
     "AxisRole",

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .engine.frontend.graph import HasNode
+from .engine.numpybackend.executor import Functor, LambdaAdapter, NumpyBackend
 from .model import (
     DOMAIN,
     ENSEMBLE,
@@ -38,7 +39,9 @@ from .simulation import (
 
 __all__ = [
     "AbstractIndexNotInInputsWarning",
+    "Functor",
     "HasNode",
+    "LambdaAdapter",
     "Axis",
     "AxisEnsemble",
     "AxisRole",
@@ -62,6 +65,7 @@ __all__ = [
     "Model",
     "ModelContractWarning",
     "ModelVariant",
+    "NumpyBackend",
     "PARAMETER",
     "PartitionedEnsemble",
     "TimeseriesIndex",

--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -175,6 +175,7 @@ This behavior impacts code that needs to find nodes in collections like lists:
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
 
 from numpy.typing import ArrayLike
 
@@ -272,21 +273,18 @@ _id_generator = atomic.Int()
 # while `C` is used as a type parameter for boolean conditions.
 
 
-def ensure_node[T](value: Node[T] | Scalar) -> Node[T]:
+def ensure_node[T](value: Node[T] | HasNode[T] | Scalar) -> Node[T]:
     """Convert a scalar value to a constant node if necessary.
 
-    If *value* is already a ``Node`` it is returned as-is.  If it exposes
-    a ``.node`` attribute that is itself a ``Node`` (e.g. any
-    ``GenericIndex`` subclass), that inner node is returned so that index
-    objects can appear on either side of a graph operator without being
-    incorrectly wrapped in a ``constant``.  Anything else is wrapped in a
+    If *value* is already a ``Node`` it is returned as-is.  If it implements
+    :class:`HasNode` (e.g. any ``GenericIndex`` subclass), its ``.node``
+    property is returned directly.  Anything else is wrapped in a
     ``constant`` node.
     """
     if isinstance(value, Node):
         return value
-    inner = getattr(value, "node", None)
-    if isinstance(inner, Node):
-        return inner
+    if isinstance(value, HasNode):
+        return value.node
     return constant(value)
 
 
@@ -428,6 +426,26 @@ class Node[T]:
     def __invert__(self) -> Node[T]:
         """Lazily check whether one node is logically not."""
         return logical_not(self)
+
+
+@runtime_checkable
+class HasNode[T](Protocol):
+    """Protocol for objects that expose a graph node via a ``.node`` property.
+
+    Implemented by all ``GenericIndex`` subclasses in ``dt_model``.  Accepting
+    ``HasNode[T]`` alongside ``Node[T]`` in graph-function signatures lets
+    callers pass index objects directly without extracting ``.node`` explicitly
+    (lexical-scope analogue: the binding is determined by the call site, not by
+    the object's internal structure).
+
+    ``ensure_node()`` already handles ``HasNode``-shaped objects at runtime;
+    this protocol closes the static-type gap so type checkers accept them too.
+    """
+
+    @property
+    def node(self) -> Node[T]:
+        """The underlying computation graph node."""
+        ...  # pragma: no cover
 
 
 class constant[T](Node[T]):
@@ -705,11 +723,13 @@ class where[C, T](Node[T]):
         otherwise: Values to use where condition is False
     """
 
-    def __init__(self, condition: Node[C], then: Node[T], otherwise: Node[T], name="") -> None:
+    def __init__(
+        self, condition: Node[C] | HasNode[C], then: Node[T] | HasNode[T], otherwise: Node[T] | HasNode[T], name=""
+    ) -> None:
         super().__init__(name)
-        self.condition = condition
-        self.then = then
-        self.otherwise = otherwise
+        self.condition = ensure_node(condition)
+        self.then = ensure_node(then)
+        self.otherwise = ensure_node(otherwise)
 
     def __repr__(self) -> str:
         """Return a round-trippable SSA representation of the node."""
@@ -858,10 +878,10 @@ class exclusive_multi_clause_where[C, T](MultiClauseOp[C, T]):
         )
 
 
-type Expr[T] = Node[T] | Scalar
+type Expr[T] = Node[T] | HasNode[T] | Scalar
 """Type alias for piecewise expression operands."""
 
-type Cond[T] = Node[T] | Scalar
+type Cond[T] = Node[T] | HasNode[T] | Scalar
 """Type alias for piecewise condition operands."""
 
 
@@ -912,23 +932,19 @@ def _piecewise_to_node[T](
     if last_cond is True:
         default = last_expr
         clauses = clauses[:-1]
-    if isinstance(default, Scalar):
-        default = constant(default)
+    default_node = ensure_node(default)
 
     # If filtering consumed all clauses, just return the default.
     if not clauses:
-        return default  # type: ignore[return-value]
+        return default_node
 
     # Build the (condition, expression) pairs expected by multi_clause_where.
-    node_clauses: list[tuple[Node[T], Node[T]]] = []
-    for expr, cond in clauses:
-        if isinstance(expr, Scalar):
-            expr = constant(expr)
-        if isinstance(cond, Scalar):
-            cond = constant(cond)
-        node_clauses.append((cond, expr))  # type: ignore[arg-type]
+    node_clauses: list[tuple[Node[T], Node[T]]] = [
+        (ensure_node(cond), ensure_node(expr))  # type: ignore[arg-type]
+        for expr, cond in clauses
+    ]
 
-    return multi_clause_where(node_clauses, default)  # type: ignore[arg-type]
+    return multi_clause_where(node_clauses, default_node)  # type: ignore[arg-type]
 
 
 # Shape-changing operations
@@ -1212,10 +1228,10 @@ class function_call[T](Node[T]):
     providing the corresponding function binding.
     """
 
-    def __init__(self, name: str, *args: Node[T], **kwargs: Node[T]) -> None:
+    def __init__(self, name: str, *args: Node[T] | HasNode[T], **kwargs: Node[T] | HasNode[T]) -> None:
         super().__init__(name)
-        self.args = args
-        self.kwargs = kwargs
+        self.args = tuple(ensure_node(a) for a in args)
+        self.kwargs = {k: ensure_node(v) for k, v in kwargs.items()}
 
     def __repr__(self) -> str:
         """Return a round-trippable SSA representation of the node."""

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -15,6 +15,7 @@ state and evaluates each node exactly once, storing results for later reuse.
 """
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import (
@@ -353,18 +354,58 @@ class Functor(Protocol):
         ...  # pragma: no cover
 
 
-class LambdaAdapter:
-    """Adapter that transforms a Callable into a Functor."""
+class _NumpyFunctor:
+    """A callable bound to the numpy array convention (internal implementation)."""
 
-    def __init__(self, callable: Callable[..., np.ndarray]) -> None:
-        self.callable = callable
+    def __init__(self, fn: Callable[..., np.ndarray]) -> None:
+        self._fn = fn
 
     def __call__(self, *args: np.ndarray, **kwargs: np.ndarray) -> np.ndarray:
-        """Execute the wrapped callable with the given arguments."""
-        return self.callable(*args, **kwargs)
+        return self._fn(*args, **kwargs)
 
 
-_: Functor = LambdaAdapter(lambda *, a, b: np.add(a, b))
+class LambdaAdapter(_NumpyFunctor):
+    """Adapter that transforms a Callable into a Functor.
+
+    .. deprecated::
+        Use :meth:`NumpyBackend.adapt` instead.
+        ``LambdaAdapter`` will be removed in a future release.
+    """
+
+    def __init__(self, callable: Callable[..., np.ndarray]) -> None:
+        warnings.warn(
+            "LambdaAdapter is deprecated; use NumpyBackend.adapt() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(callable)
+
+
+class NumpyBackend:
+    """The numpy computation backend.
+
+    Binds user-defined callables to the numpy array convention for use
+    with :meth:`~civic_digital_twins.dt_model.simulation.evaluation.Evaluation.evaluate`.
+
+    Example::
+
+        from civic_digital_twins.dt_model import NumpyBackend
+
+        result = evaluation.evaluate(
+            ensemble=ens,
+            functions={"ts_solve": NumpyBackend.adapt(_ts_solve)},
+            backend=NumpyBackend,
+        )
+    """
+
+    @staticmethod
+    def adapt(fn: Callable[..., np.ndarray]) -> Functor:
+        """Bind *fn* to the numpy array convention.
+
+        The callable must accept and return :class:`numpy.ndarray` values.
+        Returns a :class:`Functor` wrapping *fn*.
+        """
+        return _NumpyFunctor(fn)
 
 
 @dataclass(frozen=True)

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -408,6 +408,12 @@ class NumpyBackend:
         return _NumpyFunctor(fn)
 
 
+# Belt-and-suspenders: assert at import time that _NumpyFunctor satisfies Functor.
+# Pyright catches this statically; the assignment also catches it at runtime if the
+# protocol drifts (e.g. signature change) without a corresponding type-checker run.
+_: Functor = _NumpyFunctor(lambda *, a, b: np.add(a, b))
+
+
 @dataclass(frozen=True)
 class State:
     """

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -264,6 +264,7 @@ class Evaluation:
         axes: dict[GenericIndex, np.ndarray] | None = None,
         ensemble: AxisEnsemble | Ensemble | None = None,
         functions: dict[str, executor.Functor] | None = None,
+        backend: type[executor.NumpyBackend] = executor.NumpyBackend,
     ) -> EvaluationResult:
         """Evaluate *nodes_of_interest* over the given ensemble.
 
@@ -291,7 +292,11 @@ class Evaluation:
             (deprecated, emits :class:`DeprecationWarning`).  Pass ``None``
             for deterministic evaluation (no ENSEMBLE axes).
         functions:
-            Optional user-defined functions passed to the executor.
+            Optional user-defined functions passed to the executor.  Wrap
+            callables with :meth:`~executor.NumpyBackend.adapt` before passing.
+        backend:
+            The computation backend to use.  Currently only
+            :class:`~executor.NumpyBackend` is supported (the default).
 
         Returns
         -------
@@ -414,6 +419,9 @@ class Evaluation:
         # Snapshot the substituted node keys before the executor mutates state.values
         # (executor.State takes c_subs by reference and adds all computed nodes into it).
         substituted_nodes: set[graph.Node] = set(c_subs)
+
+        if backend is not executor.NumpyBackend:
+            raise NotImplementedError(f"Backend {backend!r} is not supported; only NumpyBackend is available.")
 
         state = executor.State(c_subs, functions=functions or {})
         executor.evaluate_nodes(state, *linearized_nodes)

--- a/docs/design/dd-cdt-engine.md
+++ b/docs/design/dd-cdt-engine.md
@@ -108,7 +108,7 @@ state = executor.State(
         b: np.asarray([200, 20, 2]),
     },
     functions={
-        "reduce": executor.LambdaAdapter(
+        "reduce": executor.NumpyBackend.adapt(
             lambda n: np.divide(n, np.asarray(5)),
         ),
     },
@@ -789,8 +789,8 @@ state = executor.State(
 
 ## User-Defined Functions
 
-Use the `numpybackend.executor.LambdaAdapter` to wrap an
-ordinary Python `lambda` and register a user-defined function.
+Use `executor.NumpyBackend.adapt` to bind an ordinary Python callable
+to the numpy array convention and register a user-defined function.
 
 The following code shows some usage examples:
 
@@ -822,13 +822,13 @@ nodes = linearize.forest(scaled1, scaled2, scaled3)
 state = executor.State(
     values={},
     functions={
-        "scale1": executor.LambdaAdapter(
+        "scale1": executor.NumpyBackend.adapt(
             lambda k0, k1: np.add(k0, k1),
         ),
-        "scale2": executor.LambdaAdapter(
+        "scale2": executor.NumpyBackend.adapt(
             lambda **kwargs: np.add(kwargs["k0"], kwargs["k1"]),
         ),
-        "scale3": executor.LambdaAdapter(
+        "scale3": executor.NumpyBackend.adapt(
             lambda k0, k1, **kwargs: np.add(
                 k0, np.add(k1, np.add(kwargs["k2"], np.add(kwargs["k3"], kwargs["scaled2"])))
             ),

--- a/docs/design/dd-cdt-modularity.md
+++ b/docs/design/dd-cdt-modularity.md
@@ -1313,8 +1313,7 @@ outcomes.  Extends `Index` with `value=None`, so it is automatically identified 
 | `sample(rng)` | `str` | Draw one key proportional to outcome probabilities. |
 
 Because `CategoricalIndex` inherits the full `GenericIndex` algebra protocol, comparison operators
-produce graph nodes: `mode == "bike"` yields `graph.equal(mode.node, constant("bike"))`, a valid
-boolean-per-scenario node usable in `graph.piecewise` or any formula.
+produce valid boolean-per-scenario values usable in `graph.piecewise` or any formula.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -195,7 +195,6 @@ result = Evaluation(model).evaluate(
             lambda ts: np.convolve(ts, np.ones(3) / 3, mode="same")
         )
     },
-    backend=NumpyBackend,
 )
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -169,14 +169,13 @@ print(f"Expected CO2: {co2_mean:.1f} kg")
 
 For time-indexed quantities use `TimeseriesIndex`.  If a computation
 cannot be expressed as a graph formula (e.g. an iterative solver), wrap
-it in a `function_call` node and register a `LambdaAdapter` at evaluation
-time.
+it in a `function_call` node and bind the implementation to the numpy
+backend using `NumpyBackend.adapt()` at evaluation time.
 
 ```python
 import numpy as np
 
-from civic_digital_twins.dt_model import TimeseriesIndex, graph
-from civic_digital_twins.dt_model.engine.numpybackend import executor
+from civic_digital_twins.dt_model import NumpyBackend, TimeseriesIndex, graph
 
 # 24-hour demand time series (one value per hour)
 demand_ts = TimeseriesIndex("demand", np.array([10.0, 12.0, 15.0, 14.0] * 6))
@@ -192,10 +191,11 @@ model = ...  # define a suitable model that includes demand_ts and smoothed
 # Register the implementation at evaluation time — no abstract indexes, so no ensemble needed
 result = Evaluation(model).evaluate(
     functions={
-        "smooth": executor.LambdaAdapter(
+        "smooth": NumpyBackend.adapt(
             lambda ts: np.convolve(ts, np.ones(3) / 3, mode="same")
         )
     },
+    backend=NumpyBackend,
 )
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -184,7 +184,7 @@ demand_ts = TimeseriesIndex("demand", np.array([10.0, 12.0, 15.0, 14.0] * 6))
 # A custom smoothing function applied as a graph node
 smoothed = TimeseriesIndex(
     "smoothed_demand",
-    graph.function_call("smooth", demand_ts.node),
+    graph.function_call("smooth", demand_ts),
 )
 
 model = ...  # define a suitable model that includes demand_ts and smoothed

--- a/examples/doc/doc_engine.py
+++ b/examples/doc/doc_engine.py
@@ -47,7 +47,7 @@ def _demo_end_to_end() -> None:
             b: np.asarray([200, 20, 2]),
         },
         functions={
-            "reduce": executor.LambdaAdapter(
+            "reduce": executor.NumpyBackend.adapt(
                 lambda n: np.divide(n, np.asarray(5)),
             ),
         },
@@ -293,13 +293,13 @@ def _demo_udf() -> None:
     state = executor.State(
         values={},
         functions={
-            "scale1": executor.LambdaAdapter(
+            "scale1": executor.NumpyBackend.adapt(
                 lambda k0, k1: np.add(k0, k1),
             ),
-            "scale2": executor.LambdaAdapter(
+            "scale2": executor.NumpyBackend.adapt(
                 lambda **kwargs: np.add(kwargs["k0"], kwargs["k1"]),
             ),
-            "scale3": executor.LambdaAdapter(
+            "scale3": executor.NumpyBackend.adapt(
                 lambda k0, k1, **kwargs: np.add(
                     k0, np.add(k1, np.add(kwargs["k2"], np.add(kwargs["k3"], kwargs["scaled2"])))
                 ),

--- a/examples/doc/doc_getting_started.py
+++ b/examples/doc/doc_getting_started.py
@@ -136,7 +136,7 @@ demand_ts = TimeseriesIndex("demand", np.array([10.0, 12.0, 15.0, 14.0] * 6))
 # A custom smoothing function applied as a graph node
 smoothed = TimeseriesIndex(
     "smoothed_demand",
-    graph.function_call("smooth", demand_ts.node),
+    graph.function_call("smooth", demand_ts),
 )
 
 # Build a small model that uses the timeseries indexes

--- a/examples/doc/doc_getting_started.py
+++ b/examples/doc/doc_getting_started.py
@@ -151,7 +151,6 @@ result = Evaluation(model).evaluate(
             lambda ts: np.convolve(ts, np.ones(3) / 3, mode="same"),
         ),
     },
-    backend=NumpyBackend,
 )
 
 smoothed_values = result[smoothed]

--- a/examples/doc/doc_getting_started.py
+++ b/examples/doc/doc_getting_started.py
@@ -16,7 +16,7 @@ from civic_digital_twins.dt_model import (
     TimeseriesIndex,
     graph,
 )
-from civic_digital_twins.dt_model.engine.numpybackend import executor
+from civic_digital_twins.dt_model import NumpyBackend
 
 # ---------------------------------------------------------------------------
 # getting-started.md §1 — Define the model (legacy flat-list API)
@@ -147,10 +147,11 @@ with warnings.catch_warnings():
 # No abstract indexes — omit ensemble (deterministic evaluation)
 result = Evaluation(model).evaluate(
     functions={
-        "smooth": executor.LambdaAdapter(
+        "smooth": NumpyBackend.adapt(
             lambda ts: np.convolve(ts, np.ones(3) / 3, mode="same"),
         ),
     },
+    backend=NumpyBackend,
 )
 
 smoothed_values = result[smoothed]

--- a/examples/doc/doc_modularity.py
+++ b/examples/doc/doc_modularity.py
@@ -672,7 +672,7 @@ def _demo_catidx_param_axis_2d() -> None:
 # ---------------------------------------------------------------------------
 
 _mv_base = Index("base_fc", 10.0)
-_smoothed_node = graph.function_call("smooth", _mv_base.node)
+_smoothed_node = graph.function_call("smooth", _mv_base)
 assert _smoothed_node is not None
 
 

--- a/examples/mobility_bologna/mobility_bologna.py
+++ b/examples/mobility_bologna/mobility_bologna.py
@@ -28,10 +28,10 @@ from civic_digital_twins.dt_model import (
     EvaluationResult,
     Index,
     Model,
+    NumpyBackend,
     TimeseriesIndex,
     graph,
 )
-from civic_digital_twins.dt_model.engine.numpybackend import executor
 
 _LN2: float = math.log(2)
 """Natural logarithm of 2 (≈ 0.6931). Normalisation constant in half-life decay formulas."""
@@ -771,7 +771,8 @@ def evaluate(model: BolognaModel, size: int = 1) -> EvaluationResult:
     ensemble = DistributionEnsemble(model, size)
     return Evaluation(model).evaluate(
         ensemble=ensemble,
-        functions={"ts_solve": executor.LambdaAdapter(_ts_solve)},
+        functions={"ts_solve": NumpyBackend.adapt(_ts_solve)},
+        backend=NumpyBackend,
     )
 
 

--- a/tests/dt_model/engine/frontend/test_graph.py
+++ b/tests/dt_model/engine/frontend/test_graph.py
@@ -826,6 +826,7 @@ def test_function_call_accepts_hasnode_args():
 
 
 def test_function_call_accepts_hasnode_kwargs():
+    """HasNode in kwargs position is unwrapped to its underlying node."""
     n = graph.constant(2.0)
     idx = _FakeIndex(n)
     fc = graph.function_call("g", x=idx)
@@ -844,7 +845,7 @@ def test_where_accepts_hasnode():
 
 
 def test_piecewise_accepts_hasnode():
-    """piecewise accepts HasNode in expression position; literal True still works as fallback."""
+    """Piecewise accepts HasNode in expression position; literal True still works as fallback."""
     expr_n = graph.constant(10.0)
     # HasNode in expression position, plain Python True as the unconditional fallback
     result = graph.piecewise((_FakeIndex(expr_n), True))
@@ -853,7 +854,7 @@ def test_piecewise_accepts_hasnode():
 
 
 def test_piecewise_accepts_hasnode_condition():
-    """piecewise accepts HasNode in condition position for non-unconditional clauses."""
+    """Piecewise accepts HasNode in condition position for non-unconditional clauses."""
     expr_n = graph.constant(10.0)
     cond_n = graph.placeholder("c")
     default_n = graph.constant(0.0)

--- a/tests/dt_model/engine/frontend/test_graph.py
+++ b/tests/dt_model/engine/frontend/test_graph.py
@@ -781,3 +781,84 @@ def test_variant_selector_repr_after_merge_nodes_populated():
     assert f"n{mcw.id}" in r
     # The companion back-reference creates a cross-reference, not a cycle in repr.
     assert f"n{vs.id}" in repr(mcw)
+
+
+# ---------------------------------------------------------------------------
+# HasNode protocol
+# ---------------------------------------------------------------------------
+
+
+class _FakeIndex:
+    """Minimal HasNode implementation for testing."""
+
+    def __init__(self, node: graph.Node) -> None:
+        self._node = node
+
+    @property
+    def node(self) -> graph.Node:
+        return self._node
+
+
+def test_hasnode_isinstance():
+    """HasNode is runtime-checkable: any object with a .node Node property qualifies."""
+    n = graph.constant(1.0)
+    idx = _FakeIndex(n)
+    assert isinstance(idx, graph.HasNode)
+    assert not isinstance(n, graph.HasNode)
+    assert not isinstance(1.0, graph.HasNode)
+
+
+def test_ensure_node_accepts_hasnode():
+    """ensure_node extracts the inner Node from a HasNode object."""
+    n = graph.constant(42.0)
+    idx = _FakeIndex(n)
+    result = graph.ensure_node(idx)
+    assert result is n
+
+
+def test_function_call_accepts_hasnode_args():
+    """function_call.__init__ accepts HasNode in *args and **kwargs."""
+    n = graph.constant(1.0)
+    idx = _FakeIndex(n)
+    fc = graph.function_call("f", idx)
+    assert len(fc.args) == 1
+    assert fc.args[0] is n
+
+
+def test_function_call_accepts_hasnode_kwargs():
+    n = graph.constant(2.0)
+    idx = _FakeIndex(n)
+    fc = graph.function_call("g", x=idx)
+    assert fc.kwargs["x"] is n
+
+
+def test_where_accepts_hasnode():
+    """where.__init__ accepts HasNode for condition, then, and otherwise."""
+    cond_n = graph.constant(True)
+    then_n = graph.constant(1.0)
+    else_n = graph.constant(0.0)
+    w = graph.where(condition=_FakeIndex(cond_n), then=_FakeIndex(then_n), otherwise=_FakeIndex(else_n))
+    assert w.condition is cond_n
+    assert w.then is then_n
+    assert w.otherwise is else_n
+
+
+def test_piecewise_accepts_hasnode():
+    """piecewise accepts HasNode in expression position; literal True still works as fallback."""
+    expr_n = graph.constant(10.0)
+    # HasNode in expression position, plain Python True as the unconditional fallback
+    result = graph.piecewise((_FakeIndex(expr_n), True))
+    # single True-condition clause: ensure_node(HasNode) → inner node returned as default
+    assert result is expr_n
+
+
+def test_piecewise_accepts_hasnode_condition():
+    """piecewise accepts HasNode in condition position for non-unconditional clauses."""
+    expr_n = graph.constant(10.0)
+    cond_n = graph.placeholder("c")
+    default_n = graph.constant(0.0)
+    result = graph.piecewise((_FakeIndex(expr_n), _FakeIndex(cond_n)), (default_n, True))
+    # result is a multi_clause_where; check the clause contains the unwrapped nodes
+    assert isinstance(result, graph.multi_clause_where)
+    assert result.clauses[0][0] is cond_n  # condition unwrapped
+    assert result.clauses[0][1] is expr_n  # expression unwrapped

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -474,3 +474,16 @@ def test_lambda_adapter_deprecated():
 
     with pytest.warns(DeprecationWarning, match="NumpyBackend.adapt"):
         executor.LambdaAdapter(lambda x: x)
+
+
+def test_unsupported_backend_raises():
+    """Passing an unsupported backend raises NotImplementedError."""
+    from civic_digital_twins.dt_model.model.index import Index
+
+    model = _make_model(Index("x", 1.0))
+
+    class _FakeBackend:
+        pass
+
+    with pytest.raises(NotImplementedError, match="not supported"):
+        Evaluation(model).evaluate(backend=_FakeBackend)  # type: ignore[arg-type]

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -422,3 +422,55 @@ def test_distribution_ensemble_with_rng_is_reproducible():
     for (w1, a1), (w2, a2) in zip(scenarios1, scenarios2):
         assert w1 == w2
         assert np.array_equal(a1[I_x], a2[I_x])
+
+
+# ---------------------------------------------------------------------------
+# functions= and NumpyBackend (Step 2 / #162)
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_functions_numpy_backend_adapt():
+    """NumpyBackend.adapt() binds a callable to numpy and produces correct results."""
+    from civic_digital_twins.dt_model import NumpyBackend
+    from civic_digital_twins.dt_model.engine.frontend import graph
+    from civic_digital_twins.dt_model.model.index import Index
+
+    p = graph.placeholder("x", default_value=3.0)
+    fc = graph.function_call("double", p)
+    I_x = Index("x", p)
+    I_out = Index("out", fc)
+    model = _make_model(I_x, I_out)
+
+    result = Evaluation(model).evaluate(
+        functions={"double": NumpyBackend.adapt(lambda x: x * 2)},
+        backend=NumpyBackend,
+    )
+    assert float(result[I_out]) == pytest.approx(float(result[I_x]) * 2)
+
+
+def test_evaluate_functions_adapt_functor_passed_through_unchanged():
+    """A Functor from NumpyBackend.adapt() is accepted and used as-is."""
+    from civic_digital_twins.dt_model import NumpyBackend
+    from civic_digital_twins.dt_model.engine.frontend import graph
+    from civic_digital_twins.dt_model.model.index import Index
+
+    p = graph.placeholder("x", default_value=5.0)
+    fc = graph.function_call("negate", p)
+    I_x = Index("x", p)
+    I_out = Index("out", fc)
+    model = _make_model(I_x, I_out)
+
+    functor = NumpyBackend.adapt(lambda x: -x)
+    result = Evaluation(model).evaluate(
+        functions={"negate": functor},
+        backend=NumpyBackend,
+    )
+    assert float(result[I_out]) == pytest.approx(-float(result[I_x]))
+
+
+def test_lambda_adapter_deprecated():
+    """Constructing LambdaAdapter directly triggers a DeprecationWarning."""
+    from civic_digital_twins.dt_model.engine.numpybackend import executor
+
+    with pytest.warns(DeprecationWarning, match="NumpyBackend.adapt"):
+        executor.LambdaAdapter(lambda x: x)


### PR DESCRIPTION
## Summary

- **#161 — HasNode protocol**: defines `HasNode[T]` in `graph.py` (re-exported from
  `dt_model`) and widens `function_call`, `piecewise`, and `where` to accept it in all
  node positions. Eliminates the need for `.node` at call sites; `ensure_node()` already
  handled this at runtime — the gap was static-type only.

- **#162 — NumpyBackend adapter**: introduces `NumpyBackend` class with
  `NumpyBackend.adapt(fn) → Functor` as the explicit user-facing binding point.
  `LambdaAdapter` is kept as a deprecated subclass (emits `DeprecationWarning`).
  `evaluate()` gains `backend=NumpyBackend` (default; placeholder for future backends
  tracked in #171). `Functor`, `NumpyBackend`, and `LambdaAdapter` are re-exported from
  `dt_model`. Step 3 (per-variant function namespaces, #135) is deferred — the
  branch-key API lacks the encapsulation needed for composed models.

Closes: #161
Closes: #162