### PR TITLE
feat(simulation): add n_samples_per_combo to CrossProductEnsemble (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   examples, replacing the previous ad-hoc module-level evaluation functions.
 - `Scenario.overrides` — public read-only property returning the active
   override mapping.
+- `CrossProductEnsemble`: new `n_samples_per_combo: int = 1` constructor
+  parameter.  When `> 1`, each categorical combination is replicated
+  `n_samples_per_combo` times with independently drawn distribution samples;
+  total ensemble size becomes `|categorical cross-product| × n_samples_per_combo`
+  and each replicate carries weight `w_combo / n_samples_per_combo`, so ensemble
+  weights still sum to 1.0.  Decouples the categorical enumeration budget from
+  the distribution sampling budget, reducing Monte Carlo variance for models
+  that retain distribution-backed indexes in the ensemble (closing #192).
+  Default `n_samples_per_combo=1` preserves existing behaviour exactly.
 
 ### Changed
 

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -602,6 +602,22 @@ class CrossProductEnsemble:
         scenario = Scenario(model, overrides={cv_weather: {"good": 0.8, "unsettled": 0.2}})
         ensemble = CrossProductEnsemble(scenario)  # only good/unsettled, with 80/20 weights
 
+    **Sampling budget for distribution-backed indexes** — when a model retains
+    distribution-backed indexes in the ensemble (i.e. they are *not* in
+    *exclude*), each categorical combination would by default receive exactly
+    one sample from those distributions, giving a total of only
+    ``|categorical cross-product|`` samples and high run-to-run variance.  Use
+    *n_samples_per_combo* to draw more independent samples per categorical
+    combination::
+
+        # 3 weather × 2 seasons = 6 combos × 50 samples = 300 total scenarios
+        ensemble = CrossProductEnsemble(model, n_samples_per_combo=50)
+
+    Each combo's weight ``w`` is split equally among its *n_samples_per_combo*
+    replicates (each replicate carries weight ``w / n_samples_per_combo``), so
+    the ensemble weights still sum to 1.0.  The default value of 1 preserves
+    the previous behaviour exactly.
+
     Parameters
     ----------
     scenario_or_model:
@@ -614,6 +630,11 @@ class CrossProductEnsemble:
         Maximum number of samples per categorical axis.  When the support (or
         restricted subset) is larger than this threshold, the axis is Monte-Carlo
         sampled *max_categorical_size* times.
+    n_samples_per_combo:
+        Number of independent distribution samples to draw for each categorical
+        combination.  Total ensemble size is
+        ``|categorical cross-product| × n_samples_per_combo``.  Must be >= 1.
+        Has no effect when all distribution-backed indexes are in *exclude*.
     exclude:
         Indexes to exclude from ensemble enumeration / sampling.  Use this to
         mark PARAMETER-axis indexes (e.g. presence variables supplied as grid
@@ -630,6 +651,7 @@ class CrossProductEnsemble:
         scenario_or_model: Scenario | Model | ModelVariant,
         restrictions: Mapping[Any, Sequence[str]] | None = None,
         max_categorical_size: int = 20,
+        n_samples_per_combo: int = 1,
         exclude: Sequence[GenericIndex] | None = None,
         rng: np.random.Generator | None = None,
     ) -> None:
@@ -654,6 +676,8 @@ class CrossProductEnsemble:
                 f"{type(self).__name__}() expects a Scenario, Model, or ModelVariant; "
                 f"got {type(scenario_or_model).__name__!r}."
             )
+        if n_samples_per_combo < 1:
+            raise ValueError(f"n_samples_per_combo must be >= 1; got {n_samples_per_combo}.")
         if restrictions is None:
             restrictions = {}
         excluded_ids = {id(idx) for idx in (exclude or [])}
@@ -700,39 +724,65 @@ class CrossProductEnsemble:
             combos = new_combos
 
         S = len(combos)
-        weights = np.array([w for (w, _) in combos])
-        weights /= weights.sum()  # normalise against FP drift
+        S_total = S * n_samples_per_combo
+        combo_weights = np.array([w for (w, _) in combos])
+        combo_weights /= combo_weights.sum()  # normalise against FP drift
+        # Each combo is replicated n_samples_per_combo times; its weight is
+        # split equally across all replicates so the total still sums to 1.0.
+        weights = np.repeat(combo_weights, n_samples_per_combo) / n_samples_per_combo
 
-        # Build categorical assignment arrays.
+        # Build categorical assignment arrays (each value repeated n_samples_per_combo times).
         self._assignments: dict[GenericIndex, np.ndarray] = {}
         for cat in categoricals:
-            self._assignments[cat] = np.array([combo[1][id(cat)] for combo in combos], dtype=object)
+            cat_arr = np.array([combo[1][id(cat)] for combo in combos], dtype=object)
+            self._assignments[cat] = np.repeat(cat_arr, n_samples_per_combo)
 
         # Sample distribution-backed indexes (topo order — parents before children).
         for idx in distributions:
             if isinstance(idx, ConditionalDistributionIndex):
-                samples = np.empty(S)
+                samples = np.empty(S_total)
                 for i, (_, combo_cats) in enumerate(combos):
-                    parent_vals: dict[str, Any] = {}
+                    # Separate categorical parents (fixed for all replicates of this combo)
+                    # from distribution parents (vary per replicate).
+                    cat_parent_vals: dict[str, Any] = {}
+                    dist_parents: list[Any] = []
                     for p in idx.parents:
                         if isinstance(p, CategoricalIndex | ConditionalCategoricalIndex):
-                            parent_vals[p.name] = combo_cats[id(p)]
+                            cat_parent_vals[p.name] = combo_cats[id(p)]
                         else:
-                            parent_vals[p.name] = float(self._assignments[p][i])
-                    d = idx.distribution_for(**parent_vals)
-                    samples[i] = float(d.rvs(random_state=rng) if rng is not None else d.rvs())
+                            dist_parents.append(p)
+                    if not dist_parents:
+                        # All parents are categorical → same distribution for every replicate;
+                        # draw all n_samples_per_combo values in one vectorised call.
+                        d = idx.distribution_for(**cat_parent_vals)
+                        start = i * n_samples_per_combo
+                        raws = (
+                            d.rvs(size=n_samples_per_combo, random_state=rng)
+                            if rng is not None
+                            else d.rvs(size=n_samples_per_combo)
+                        )
+                        samples[start : start + n_samples_per_combo] = np.asarray(raws).ravel()
+                    else:
+                        # At least one distribution parent → distribution differs per replicate.
+                        for r in range(n_samples_per_combo):
+                            full_idx = i * n_samples_per_combo + r
+                            parent_vals: dict[str, Any] = dict(cat_parent_vals)
+                            for p in dist_parents:
+                                parent_vals[p.name] = float(self._assignments[p][full_idx])
+                            d = idx.distribution_for(**parent_vals)
+                            samples[full_idx] = float(d.rvs(random_state=rng) if rng is not None else d.rvs())
                 self._assignments[idx] = samples
             else:
                 dist = scenario.effective_distribution(idx)
                 assert dist is not None
                 if rng is not None:
-                    self._assignments[idx] = np.asarray(dist.rvs(size=S, random_state=rng))
+                    self._assignments[idx] = np.asarray(dist.rvs(size=S_total, random_state=rng))
                 else:
-                    self._assignments[idx] = np.asarray(dist.rvs(size=S))
+                    self._assignments[idx] = np.asarray(dist.rvs(size=S_total))
 
         self._axis = Axis("_cross_product", ENSEMBLE)
         self._weights_arr = weights
-        self.size = S
+        self.size = S_total
         self._scenario = scenario
 
     @property

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -5,7 +5,7 @@
 |              | Document data                                  |
 |--------------| ---------------------------------------------- |
 | Author       | [@pistore](https://github.com/pistore)         |
-| Last-Updated | 2026-05-02                                     |
+| Last-Updated | 2026-05-27                                     |
 | Status       | Draft                                          |
 | Approved-By  | N/A                                            |
 
@@ -524,7 +524,7 @@ ens = PartitionedEnsemble(
 
 ### CrossProductEnsemble
 
-`CrossProductEnsemble(model, restrictions, max_categorical_size, exclude, rng)` implements
+`CrossProductEnsemble(model, restrictions, max_categorical_size, n_samples_per_combo, exclude, rng)` implements
 `AxisEnsemble`.  It materialises a batched ENSEMBLE axis by:
 
 1. Discovering the model's abstract indexes via `model.abstract_indexes()`.
@@ -533,8 +533,12 @@ ens = PartitionedEnsemble(
    probability weights are the product of per-category outcome probabilities.
    When a categorical's support exceeds `max_categorical_size`, values are
    Monte-Carlo sampled instead.
-3. Pre-sampling one value per distribution-backed abstract index
-   (e.g. stochastic capacities) for each scenario.
+3. Pre-sampling `n_samples_per_combo` independent values per distribution-backed
+   abstract index (e.g. stochastic capacities) for each categorical combination.
+   Total ensemble size is `|categorical cross-product| × n_samples_per_combo`.
+   The default `n_samples_per_combo=1` draws one sample per combination;
+   increase it to reduce Monte Carlo variance when distribution-backed indexes
+   are retained in the ensemble.
 
 Indexes passed via `exclude` are skipped in steps 2–3 — they are provided
 as PARAMETER axes at evaluation time.  See [Domain Modeling Pattern](#domain-modeling-pattern)
@@ -547,6 +551,7 @@ class CrossProductEnsemble:
         model: Model | ModelVariant,
         restrictions: Mapping[Any, Sequence[str]] | None = None,
         max_categorical_size: int = 20,
+        n_samples_per_combo: int = 1,
         exclude: Sequence[GenericIndex] | None = None,
         rng: np.random.Generator | None = None,
     ) -> None: ...
@@ -702,10 +707,12 @@ objects can be used as dictionary keys, matching the convention of
 ### Step 2 — Ensemble (CV cross-product)
 
 `CrossProductEnsemble` enumerates the joint support of the model's
-`CategoricalIndex` instances into weighted scenarios.  Each scenario also
-includes one Monte-Carlo sample of every distribution-backed abstract index
-that is *not* listed in `exclude` (PVs are excluded because they are swept
-on the grid in step 3 instead):
+`CategoricalIndex` instances into weighted scenarios.  Each categorical
+combination also draws `n_samples_per_combo` independent Monte-Carlo samples
+of every distribution-backed abstract index that is *not* listed in `exclude`
+(PVs are excluded because they are swept on the grid in step 3 instead).
+The default `n_samples_per_combo=1` gives one sample per combination; increase
+it to reduce variance when stochastic capacities are retained in the ensemble:
 
 ```python
 from civic_digital_twins.dt_model import CrossProductEnsemble

--- a/tests/dt_model/simulation/test_cross_product_ensemble.py
+++ b/tests/dt_model/simulation/test_cross_product_ensemble.py
@@ -431,6 +431,158 @@ def test_sample_across_multi_axis_raises():
 
 
 # ---------------------------------------------------------------------------
+# n_samples_per_combo
+# ---------------------------------------------------------------------------
+
+
+def test_cpe_n_samples_per_combo_size():
+    """Total size equals |categorical cross-product| × n_samples_per_combo."""
+    season = CategoricalIndex("season", {"summer": 0.5, "winter": 0.5})
+    weather = CategoricalIndex("weather", {"good": 0.7, "bad": 0.3})
+    model = _simple_model(season, weather)
+    ens = CrossProductEnsemble(model, n_samples_per_combo=10)
+    assert ens.size == 4 * 10
+    assert len(ens) == 4 * 10
+
+
+def test_cpe_n_samples_per_combo_weights_sum_to_one():
+    """Weights still sum to 1.0 with n_samples_per_combo > 1."""
+    season = CategoricalIndex("season", {"summer": 0.6, "winter": 0.4})
+    model = _simple_model(season)
+    ens = CrossProductEnsemble(model, n_samples_per_combo=7)
+    assert pytest.approx(ens.ensemble_weights[0].sum()) == 1.0
+
+
+def test_cpe_n_samples_per_combo_equal_weight_within_combo():
+    """Within each categorical combo all replicates share equal weight w_combo / N."""
+    season = CategoricalIndex("season", {"summer": 0.6, "winter": 0.4})
+    model = _simple_model(season)
+    N = 5
+    ens = CrossProductEnsemble(model, n_samples_per_combo=N)
+    weights = ens.ensemble_weights[0]
+    cat_arr = ens.assignments()[season]
+    for value, expected_combo_weight in [("summer", 0.6), ("winter", 0.4)]:
+        mask = cat_arr == value
+        replicate_weights = weights[mask]
+        assert len(replicate_weights) == N
+        np.testing.assert_allclose(replicate_weights, expected_combo_weight / N, rtol=1e-9)
+
+
+def test_cpe_n_samples_per_combo_cat_values_repeated():
+    """Categorical assignments contain each combo value exactly n_samples_per_combo times."""
+    season = CategoricalIndex("season", {"summer": 0.5, "winter": 0.5})
+    model = _simple_model(season)
+    N = 4
+    ens = CrossProductEnsemble(model, n_samples_per_combo=N)
+    cat_arr = ens.assignments()[season].tolist()
+    assert cat_arr.count("summer") == N
+    assert cat_arr.count("winter") == N
+
+
+def test_cpe_n_samples_per_combo_dist_samples_vary():
+    """Distribution samples are drawn independently for each replicate (not all equal)."""
+    season = CategoricalIndex("season", {"summer": 1.0})  # single combo
+    cap = DistributionIndex("cap", stats.norm, {"loc": 100.0, "scale": 10.0})
+    model = _simple_model(season, cap)
+    N = 50
+    ens = CrossProductEnsemble(model, n_samples_per_combo=N, rng=np.random.default_rng(0))
+    assert ens.size == N
+    # All samples should not be identical (astronomically unlikely with N=50).
+    assert len(set(ens.assignments()[cap].tolist())) > 1
+
+
+def test_cpe_n_samples_per_combo_reduces_variance():
+    """Larger n_samples_per_combo reduces variance of the weighted-mean estimate."""
+    season = CategoricalIndex("season", {"a": 1.0})  # single combo
+    cap = DistributionIndex("cap", stats.norm, {"loc": 0.0, "scale": 1.0})
+    model = _simple_model(season, cap)
+
+    def weighted_mean(ens: CrossProductEnsemble) -> float:
+        w = ens.ensemble_weights[0]
+        v = ens.assignments()[cap]
+        return float(np.dot(w, v))
+
+    rng_seed = 12345
+    n_trials = 200
+    means_small = [
+        weighted_mean(CrossProductEnsemble(model, n_samples_per_combo=1, rng=np.random.default_rng(rng_seed + i)))
+        for i in range(n_trials)
+    ]
+    means_large = [
+        weighted_mean(CrossProductEnsemble(model, n_samples_per_combo=100, rng=np.random.default_rng(rng_seed + i)))
+        for i in range(n_trials)
+    ]
+    # Variance with N=100 should be ~100× smaller than with N=1.
+    assert np.var(means_large) < np.var(means_small) / 10
+
+
+def test_cpe_n_samples_per_combo_conditional_dist_per_categorical():
+    """ConditionalDistributionIndex gets N independent samples per categorical combo."""
+    weather = CategoricalIndex("weather", {"hot": 0.5, "cold": 0.5})
+    temp = ConditionalDistributionIndex(
+        "temp",
+        parents=[weather],
+        factory=lambda weather: stats.norm(loc=30.0, scale=1.0) if weather == "hot" else stats.norm(loc=5.0, scale=1.0),
+    )
+    model = _simple_model(weather, temp)
+    N = 20
+    ens = CrossProductEnsemble(model, n_samples_per_combo=N, rng=np.random.default_rng(7))
+    assert ens.size == 2 * N
+    a = ens.assignments()
+    # Hot replicates should cluster near 30; cold near 5.
+    hot_mask = a[weather] == "hot"
+    cold_mask = a[weather] == "cold"
+    assert np.all((a[temp][hot_mask] > 25.0) & (a[temp][hot_mask] < 35.0))
+    assert np.all((a[temp][cold_mask] > 0.0) & (a[temp][cold_mask] < 10.0))
+
+
+def test_cpe_n_samples_per_combo_dist_parent_uses_replicate_value():
+    """When a ConditionalDistributionIndex has a DistributionIndex parent.
+
+    Each replicate uses that replicate's parent sample, not a shared one.
+    """
+    season = CategoricalIndex("season", {"summer": 1.0})  # one combo
+    base = DistributionIndex("base", stats.uniform, {"loc": 0.0, "scale": 1.0})
+    derived = ConditionalDistributionIndex(
+        "derived",
+        parents=[season, base],
+        # derived = base + tiny noise; so derived ≈ base per replicate
+        factory=lambda **kw: stats.norm(loc=float(kw["base"]), scale=1e-6),
+    )
+    model = _simple_model(season, base, derived)
+    N = 30
+    ens = CrossProductEnsemble(model, n_samples_per_combo=N, rng=np.random.default_rng(42))
+    a = ens.assignments()
+    assert a[base].shape == (N,)
+    assert a[derived].shape == (N,)
+    # Each derived value should be very close to its corresponding base value.
+    np.testing.assert_allclose(a[derived], a[base], atol=1e-4)
+
+
+def test_cpe_n_samples_per_combo_one_is_default():
+    """n_samples_per_combo=1 (default) matches behaviour of omitting the parameter."""
+    season = CategoricalIndex("season", {"summer": 0.6, "winter": 0.4})
+    cap = DistributionIndex("cap", stats.norm, {"loc": 0.0, "scale": 1.0})
+    model = _simple_model(season, cap)
+    rng = np.random.default_rng(0)
+    ens_default = CrossProductEnsemble(model, rng=np.random.default_rng(0))
+    ens_explicit = CrossProductEnsemble(model, n_samples_per_combo=1, rng=np.random.default_rng(0))
+    assert ens_default.size == ens_explicit.size
+    np.testing.assert_array_equal(ens_default.ensemble_weights[0], ens_explicit.ensemble_weights[0])
+    np.testing.assert_array_equal(ens_default.assignments()[season], ens_explicit.assignments()[season])
+    np.testing.assert_array_equal(ens_default.assignments()[cap], ens_explicit.assignments()[cap])
+    del rng  # unused; silence linter
+
+
+def test_cpe_n_samples_per_combo_invalid_raises():
+    """n_samples_per_combo < 1 raises ValueError."""
+    season = CategoricalIndex("season", {"summer": 0.5, "winter": 0.5})
+    model = _simple_model(season)
+    with pytest.raises(ValueError, match="n_samples_per_combo"):
+        CrossProductEnsemble(model, n_samples_per_combo=0)
+
+
+# ---------------------------------------------------------------------------
 # Public export
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes a conceptual gap in `CrossProductEnsemble`: when distribution-backed indexes are retained in the ensemble (i.e. not passed to `exclude=`), each categorical combination previously received exactly one sample from those distributions. With small categorical cross-products (e.g. 3 weather × 2 seasons = 6 combinations), this gave very few distribution samples and high run-to-run variance with no way to increase the sampling budget independently.

## Changes

New `n_samples_per_combo: int = 1` parameter on `CrossProductEnsemble`. Total ensemble size becomes `|categorical cross-product| × n_samples_per_combo`, with each combo's weight split equally across its replicates so ensemble weights still sum to 1.0. Default `n_samples_per_combo=1` preserves existing behaviour exactly — no breaking change.

## Notes

The primary overtourism workflow (`exclude=model.pvs`) is unaffected — when all distribution-backed indexes are excluded, `n_samples_per_combo` has no effect and the behaviour is identical to before.

## Closed issues

Closes #192.