### PR TITLE
feat(model): @define decorator with compute() hook and full example standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `@define` decorator — declare a leaf `Model` subclass via a `compute()`
+  method instead of a hand-written `__init__`.  `@define("Name")` generates
+  `__init__(self, inputs: Inputs)` (plus `fns: Functions` when a `@functions`
+  inner class is declared), calls `compute()`, and wires the result into
+  `super().__init__()` automatically.  `compute()` returns `Outputs` for the
+  common case, or `tuple[Outputs, Expose]` when an `@expose` inner class is
+  also declared — the decorator detects the form from the return annotation
+  at decoration time.  `Model.__init_subclass__` now emits `DeprecationWarning`
+  for subclasses that define `__init__` directly; composite models that cannot
+  use `compute()` opt out with `legacy=True`.  Exported from
+  `civic_digital_twins.dt_model`.  Closes #190.
+- The four Molveno concern sub-models (`ParkingModel`, `BeachModel`,
+  `AccommodationModel`, `FoodModel`) and the three Bologna sub-models
+  (`InflowModel`, `TrafficModel`, `EmissionsModel`) are migrated to
+  `@define` + `compute()`.
 - `@functions` decorator — declare the custom functions a `Model` subclass
   requires as part of its typed signature.  Each annotated field is a required
   `Functor`; pass the completed `Functions` instance to `super().__init__()` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for subclasses that define `__init__` directly; composite models that cannot
   use `compute()` opt out with `legacy=True`.  Exported from
   `civic_digital_twins.dt_model`.  Closes #190.
-- The four Molveno concern sub-models (`ParkingModel`, `BeachModel`,
-  `AccommodationModel`, `FoodModel`) and the three Bologna sub-models
-  (`InflowModel`, `TrafficModel`, `EmissionsModel`) are migrated to
-  `@define` + `compute()`.
+- All example models migrated to `@define` + `compute()`. `BolognaModel` gains
+  `default_inputs() → Inputs` and `default_fns() → Functions` classmethods;
+  callers use `BolognaModel(inputs=BolognaModel.default_inputs(),
+  fns=BolognaModel.default_fns())` with `dataclasses.replace()` for
+  per-scenario overrides.  `MolvenoModel` exposes all domain parameters as
+  named `Inputs` fields (CVs, PVs, distribution-backed uncertainty
+  parameters, per-concern formula parameters, presence-transformation
+  parameters); `default_inputs()` supplies the defaults; `compute()` is pure
+  wiring with no local index construction.
+- `@define` auto-constructs `Inputs()` when the declared `Inputs` class has
+  no fields, so `Model()` can be called with no arguments in that case.
 - `@functions` decorator — declare the custom functions a `Model` subclass
   requires as part of its typed signature.  Each annotated field is a required
   `Functor`; pass the completed `Functions` instance to `super().__init__()` at

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -28,6 +28,7 @@ from .model import (
     expose,
     functions,
     inputs,
+    model,
     outputs,
 )
 from .simulation import (
@@ -90,6 +91,7 @@ __all__ = [
     "expose",
     "functions",
     "inputs",
+    "model",
     "outputs",
     "Model",
     "ModelContractWarning",

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -25,10 +25,10 @@ from .model import (
     ModelContractWarning,
     ModelVariant,
     TimeseriesIndex,
+    define,
     expose,
     functions,
     inputs,
-    model,
     outputs,
 )
 from .simulation import (
@@ -88,10 +88,10 @@ __all__ = [
     "Index",
     "InputsContractWarning",
     "IncompatibleResultError",
+    "define",
     "expose",
     "functions",
     "inputs",
-    "model",
     "outputs",
     "Model",
     "ModelContractWarning",

--- a/civic_digital_twins/dt_model/model/__init__.py
+++ b/civic_digital_twins/dt_model/model/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .axis import DOMAIN, ENSEMBLE, PARAMETER, Axis, AxisRole
-from .contracts import expose, functions, inputs, model, outputs
+from .contracts import define, expose, functions, inputs, outputs
 from .index import (
     CategoricalIndex,
     ConditionalCategoricalIndex,
@@ -22,10 +22,10 @@ from .model_variant import ModelVariant
 __all__ = [
     "AbstractIndexNotInInputsWarning",
     "Axis",
+    "define",
     "expose",
     "functions",
     "inputs",
-    "model",
     "outputs",
     "AxisRole",
     "CategoricalIndex",

--- a/civic_digital_twins/dt_model/model/__init__.py
+++ b/civic_digital_twins/dt_model/model/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .axis import DOMAIN, ENSEMBLE, PARAMETER, Axis, AxisRole
-from .contracts import expose, functions, inputs, outputs
+from .contracts import expose, functions, inputs, model, outputs
 from .index import (
     CategoricalIndex,
     ConditionalCategoricalIndex,
@@ -25,6 +25,7 @@ __all__ = [
     "expose",
     "functions",
     "inputs",
+    "model",
     "outputs",
     "AxisRole",
     "CategoricalIndex",

--- a/civic_digital_twins/dt_model/model/contracts.py
+++ b/civic_digital_twins/dt_model/model/contracts.py
@@ -1,6 +1,6 @@
 """Contract decorators for :class:`~.model.Model` subclasses.
 
-``@model``, ``@functions``, ``@inputs``, ``@outputs``, and ``@expose`` replace
+``@define``, ``@functions``, ``@inputs``, ``@outputs``, and ``@expose`` replace
 the bare ``@dataclass`` convention with purpose-specific decorators that make
 intent explicit and validate field types at construction time.
 """
@@ -18,7 +18,7 @@ from typing import Any, Literal
 
 from .index import GenericIndex
 
-__all__ = ["expose", "functions", "inputs", "model", "outputs"]
+__all__ = ["define", "expose", "functions", "inputs", "outputs"]
 
 _MISSING = object()
 
@@ -252,11 +252,11 @@ Passing a plain ``@dataclass`` instance as ``expose=`` to
 
 
 # ---------------------------------------------------------------------------
-# @model
+# @define
 # ---------------------------------------------------------------------------
 
 
-def model(name: str) -> Any:
+def define(name: str) -> Any:
     """Declare a leaf :class:`~.model.Model` subclass via a ``compute()`` method.
 
     Generates a typed ``__init__(self, inp: Inputs)`` (plus ``fns: Functions``
@@ -273,7 +273,7 @@ def model(name: str) -> Any:
     -----
     Leaf model without ``Expose``::
 
-        @model("Parking")
+        @define("Parking")
         class ParkingModel(Model):
 
             @inputs
@@ -290,7 +290,7 @@ def model(name: str) -> Any:
 
     With ``@functions`` and ``Expose``::
 
-        @model("Traffic")
+        @define("Traffic")
         class TrafficModel(Model):
 
             @inputs
@@ -339,11 +339,11 @@ def model(name: str) -> Any:
         # Validate class structure at decoration time.
         if "compute" not in cls.__dict__:
             raise TypeError(
-                f"@model({name!r}) requires {cls.__name__} to define a compute() method."
+                f"@define({name!r}) requires {cls.__name__} to define a compute() method."
             )
         if "__init__" in cls.__dict__:
             raise TypeError(
-                f"@model class {cls.__name__} must not define __init__. "
+                f"@define class {cls.__name__} must not define __init__. "
                 f"Implement compute() instead."
             )
 
@@ -377,13 +377,13 @@ def model(name: str) -> Any:
         # Consistency check: @expose declared → must appear in return annotation.
         if has_expose_cls and not returns_expose:
             raise TypeError(
-                f"@model class {cls.__name__} declares an @expose Expose inner class "
+                f"@define class {cls.__name__} declares an @expose Expose inner class "
                 f"but compute() return annotation is not tuple[Outputs, Expose]. "
                 f"Update the return annotation to include Expose, or remove the Expose declaration."
             )
 
         # Capture for closure so the generated __init__ uses the right class in
-        # super() even if the @model class is later subclassed.
+        # super() even if the @define class is later subclassed.
         _cls = cls
         _name = name
         _returns_expose = returns_expose

--- a/civic_digital_twins/dt_model/model/contracts.py
+++ b/civic_digital_twins/dt_model/model/contracts.py
@@ -1,8 +1,8 @@
 """Contract decorators for :class:`~.model.Model` subclasses.
 
-``@functions``, ``@inputs``, ``@outputs``, and ``@expose`` replace the bare
-``@dataclass`` convention with purpose-specific decorators that make intent
-explicit and validate field types at construction time.
+``@model``, ``@functions``, ``@inputs``, ``@outputs``, and ``@expose`` replace
+the bare ``@dataclass`` convention with purpose-specific decorators that make
+intent explicit and validate field types at construction time.
 """
 
 # SPDX-License-Identifier: Apache-2.0
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import sys
+import typing
 from collections.abc import Iterator
 from typing import Any, Literal
 
 from .index import GenericIndex
 
-__all__ = ["expose", "functions", "inputs", "outputs"]
+__all__ = ["expose", "functions", "inputs", "model", "outputs"]
 
 _MISSING = object()
 
@@ -247,3 +249,168 @@ mapping strings to them.
 Passing a plain ``@dataclass`` instance as ``expose=`` to
 :class:`~.model.Model` is deprecated; use ``@expose`` instead.
 """
+
+
+# ---------------------------------------------------------------------------
+# @model
+# ---------------------------------------------------------------------------
+
+
+def model(name: str) -> Any:
+    """Declare a leaf :class:`~.model.Model` subclass via a ``compute()`` method.
+
+    Generates a typed ``__init__(self, inp: Inputs)`` (plus ``fns: Functions``
+    when a ``@functions`` inner class is declared) and wires the result of
+    :meth:`compute` into ``super().__init__()`` automatically.
+
+    Parameters
+    ----------
+    name:
+        Human-readable model name forwarded to
+        :class:`~.model.Model.__init__`.
+
+    Usage
+    -----
+    Leaf model without ``Expose``::
+
+        @model("Parking")
+        class ParkingModel(Model):
+
+            @inputs
+            class Inputs:
+                pv_tourists: ConditionalDistributionIndex
+
+            @outputs
+            class Outputs:
+                i_u_parking: Index
+
+            def compute(self, inp: Inputs) -> Outputs:
+                i_u_parking = Index("parking_usage", inp.pv_tourists * ...)
+                return ParkingModel.Outputs(i_u_parking=i_u_parking)
+
+    With ``@functions`` and ``Expose``::
+
+        @model("Traffic")
+        class TrafficModel(Model):
+
+            @inputs
+            class Inputs:
+                ts_inflow: TimeseriesIndex
+
+            @functions
+            class Functions:
+                ts_solve: Functor
+
+            @outputs
+            class Outputs:
+                ts_traffic: TimeseriesIndex
+
+            @expose
+            class Expose:
+                ts_raw: TimeseriesIndex
+
+            def compute(self, inp: Inputs, *, fns: Functions) -> tuple[Outputs, Expose]:
+                ts_raw     = TimeseriesIndex("raw", graph.function_call("ts_solve", inp.ts_inflow))
+                ts_traffic = TimeseriesIndex("traffic", ts_raw * ...)
+                return (
+                    TrafficModel.Outputs(ts_traffic=ts_traffic),
+                    TrafficModel.Expose(ts_raw=ts_raw),
+                )
+
+    Composite / root models that assign sub-model attributes before calling
+    ``super().__init__()`` cannot use ``compute()`` and should declare
+    ``legacy=True``::
+
+        class BolognaModel(Model, legacy=True):
+            def __init__(self) -> None:
+                self.traffic = TrafficModel(...)
+                super().__init__("Bologna mobility", ...)
+
+    Raises
+    ------
+    TypeError
+        At decoration time if ``compute()`` is absent, if both ``compute``
+        and ``__init__`` are defined, or if an ``@expose Expose`` class is
+        declared but the ``compute`` return annotation does not include
+        ``Expose``.
+    """
+
+    def decorator(cls: type) -> type:
+        # Validate class structure at decoration time.
+        if "compute" not in cls.__dict__:
+            raise TypeError(
+                f"@model({name!r}) requires {cls.__name__} to define a compute() method."
+            )
+        if "__init__" in cls.__dict__:
+            raise TypeError(
+                f"@model class {cls.__name__} must not define __init__. "
+                f"Implement compute() instead."
+            )
+
+        # Detect @functions inner class via its role marker.
+        has_functions = (
+            "Functions" in cls.__dict__
+            and getattr(cls.__dict__["Functions"], "_is_functions", False)
+        )
+
+        # Detect @expose Expose inner class declared directly on this class.
+        has_expose_cls = (
+            "Expose" in cls.__dict__
+            and getattr(cls.__dict__["Expose"], "_is_expose", False)
+        )
+
+        # Resolve compute()'s return annotation.  Using typing.get_type_hints()
+        # rather than .__annotations__ handles `from __future__ import annotations`,
+        # which otherwise stores all annotations as strings.
+        try:
+            hints = typing.get_type_hints(
+                cls.compute,
+                globalns=vars(sys.modules[cls.__module__]),
+                localns=vars(cls),
+            )
+        except Exception:
+            hints = getattr(cls.compute, "__annotations__", {})
+
+        return_hint = hints.get("return", None)
+        returns_expose = return_hint is not None and getattr(return_hint, "__origin__", None) is tuple
+
+        # Consistency check: @expose declared → must appear in return annotation.
+        if has_expose_cls and not returns_expose:
+            raise TypeError(
+                f"@model class {cls.__name__} declares an @expose Expose inner class "
+                f"but compute() return annotation is not tuple[Outputs, Expose]. "
+                f"Update the return annotation to include Expose, or remove the Expose declaration."
+            )
+
+        # Capture for closure so the generated __init__ uses the right class in
+        # super() even if the @model class is later subclassed.
+        _cls = cls
+        _name = name
+        _returns_expose = returns_expose
+
+        # Use distinct names to avoid Pyright reportRedeclaration in the if/else.
+        if has_functions:
+            def _init_with_fns(self: Any, inp: Any, *, fns: Any) -> None:
+                if _returns_expose:
+                    out, exp = self.compute(inp, fns=fns)
+                    super(_cls, self).__init__(_name, inputs=inp, outputs=out, expose=exp, functions=fns)  # type: ignore[misc]
+                else:
+                    out = self.compute(inp, fns=fns)
+                    super(_cls, self).__init__(_name, inputs=inp, outputs=out, functions=fns)  # type: ignore[misc]
+
+            cls.__init__ = _init_with_fns  # type: ignore[assignment]
+        else:
+            def _init_no_fns(self: Any, inp: Any) -> None:
+                if _returns_expose:
+                    out, exp = self.compute(inp)
+                    super(_cls, self).__init__(_name, inputs=inp, outputs=out, expose=exp)  # type: ignore[misc]
+                else:
+                    out = self.compute(inp)
+                    super(_cls, self).__init__(_name, inputs=inp, outputs=out)  # type: ignore[misc]
+
+            cls.__init__ = _init_no_fns  # type: ignore[assignment]
+
+        cls._is_model_decorated = True
+        return cls
+
+    return decorator

--- a/civic_digital_twins/dt_model/model/contracts.py
+++ b/civic_digital_twins/dt_model/model/contracts.py
@@ -318,13 +318,14 @@ def define(name: str) -> Any:
                 )
 
     Composite / root models that assign sub-model attributes before calling
-    ``super().__init__()`` cannot use ``compute()`` and should declare
-    ``legacy=True``::
+    ``super().__init__()`` can remain on the direct-``__init__`` path by
+    declaring ``legacy=True``::
 
-        class BolognaModel(Model, legacy=True):
+        class CompositeModel(Model, legacy=True):
             def __init__(self) -> None:
-                self.traffic = TrafficModel(...)
-                super().__init__("Bologna mobility", ...)
+                self.leaf = LeafModel(...)
+                ...
+                super().__init__("composite", ...)
 
     Raises
     ------
@@ -388,9 +389,20 @@ def define(name: str) -> Any:
         _name = name
         _returns_expose = returns_expose
 
+        # If Inputs has no declared fields it can be auto-constructed, so
+        # make the `inputs` parameter optional (default None → Inputs()).
+        _inputs_cls = cls.__dict__.get("Inputs")
+        _inputs_is_empty = (
+            _inputs_cls is not None
+            and dataclasses.is_dataclass(_inputs_cls)
+            and len(dataclasses.fields(_inputs_cls)) == 0  # type: ignore[arg-type]
+        )
+
         # Use distinct names to avoid Pyright reportRedeclaration in the if/else.
         if has_functions:
-            def _init_with_fns(self: Any, inputs: Any, *, fns: Any) -> None:
+            def _init_with_fns(self: Any, inputs: Any = None, *, fns: Any) -> None:  # type: ignore[misc]
+                if _inputs_is_empty and inputs is None and _inputs_cls is not None:
+                    inputs = _inputs_cls()  # type: ignore[operator]
                 if _returns_expose:
                     out, exp = self.compute(inputs, fns=fns)
                     super(_cls, self).__init__(_name, inputs=inputs, outputs=out, expose=exp, functions=fns)  # type: ignore[misc]
@@ -400,7 +412,9 @@ def define(name: str) -> Any:
 
             cls.__init__ = _init_with_fns  # type: ignore[assignment]
         else:
-            def _init_no_fns(self: Any, inputs: Any) -> None:
+            def _init_no_fns(self: Any, inputs: Any = None) -> None:
+                if _inputs_is_empty and inputs is None and _inputs_cls is not None:
+                    inputs = _inputs_cls()  # type: ignore[operator]
                 if _returns_expose:
                     out, exp = self.compute(inputs)
                     super(_cls, self).__init__(_name, inputs=inputs, outputs=out, expose=exp)  # type: ignore[misc]

--- a/civic_digital_twins/dt_model/model/contracts.py
+++ b/civic_digital_twins/dt_model/model/contracts.py
@@ -339,26 +339,15 @@ def define(name: str) -> Any:
     def decorator(cls: type) -> type:
         # Validate class structure at decoration time.
         if "compute" not in cls.__dict__:
-            raise TypeError(
-                f"@define({name!r}) requires {cls.__name__} to define a compute() method."
-            )
+            raise TypeError(f"@define({name!r}) requires {cls.__name__} to define a compute() method.")
         if "__init__" in cls.__dict__:
-            raise TypeError(
-                f"@define class {cls.__name__} must not define __init__. "
-                f"Implement compute() instead."
-            )
+            raise TypeError(f"@define class {cls.__name__} must not define __init__. Implement compute() instead.")
 
         # Detect @functions inner class via its role marker.
-        has_functions = (
-            "Functions" in cls.__dict__
-            and getattr(cls.__dict__["Functions"], "_is_functions", False)
-        )
+        has_functions = "Functions" in cls.__dict__ and getattr(cls.__dict__["Functions"], "_is_functions", False)
 
         # Detect @expose Expose inner class declared directly on this class.
-        has_expose_cls = (
-            "Expose" in cls.__dict__
-            and getattr(cls.__dict__["Expose"], "_is_expose", False)
-        )
+        has_expose_cls = "Expose" in cls.__dict__ and getattr(cls.__dict__["Expose"], "_is_expose", False)
 
         # Resolve compute()'s return annotation.  Using typing.get_type_hints()
         # rather than .__annotations__ handles `from __future__ import annotations`,
@@ -400,6 +389,7 @@ def define(name: str) -> Any:
 
         # Use distinct names to avoid Pyright reportRedeclaration in the if/else.
         if has_functions:
+
             def _init_with_fns(self: Any, inputs: Any = None, *, fns: Any) -> None:  # type: ignore[misc]
                 if _inputs_is_empty and inputs is None and _inputs_cls is not None:
                     inputs = _inputs_cls()  # type: ignore[operator]
@@ -412,6 +402,7 @@ def define(name: str) -> Any:
 
             cls.__init__ = _init_with_fns  # type: ignore[assignment]
         else:
+
             def _init_no_fns(self: Any, inputs: Any = None) -> None:
                 if _inputs_is_empty and inputs is None and _inputs_cls is not None:
                     inputs = _inputs_cls()  # type: ignore[operator]

--- a/civic_digital_twins/dt_model/model/contracts.py
+++ b/civic_digital_twins/dt_model/model/contracts.py
@@ -68,12 +68,12 @@ def functions(
             class Functions:
                 ts_solve: Functor     # required explicit function
 
-            def __init__(self, inp: Inputs, *, fns: Functions) -> None:
+            def __init__(self, inputs: Inputs, *, fns: Functions) -> None:
                 traffic = TimeseriesIndex(
                     "traffic",
-                    graph.function_call("ts_solve", inp.ts_inflow.node),
+                    graph.function_call("ts_solve", inputs.ts_inflow.node),
                 )
-                super().__init__("Traffic", inputs=inp, functions=fns)
+                super().__init__("Traffic", inputs=inputs, functions=fns)
 
         model = TrafficModel(
             TrafficModel.Inputs(ts_inflow=ts_inflow),
@@ -83,15 +83,15 @@ def functions(
     Promote an implicit function from a parent::
 
         class MobilityModel(Model):
-            def __init__(self, inp: TrafficModel.Inputs) -> None:
+            def __init__(self, inputs: TrafficModel.Inputs) -> None:
                 self.traffic = TrafficModel(
-                    inp,
+                    inputs,
                     fns=TrafficModel.Functions(
                         ts_solve=NumpyBackend.adapt(_ts_solve),
                         smooth=NumpyBackend.adapt(_smooth),   # implicit, goes into _extra
                     ),
                 )
-                super().__init__("Mobility", inputs=inp)
+                super().__init__("Mobility", inputs=inputs)
     """
 
     def decorator(cls: type) -> type:
@@ -221,9 +221,9 @@ Examples
         class Outputs:
             traffic: TimeseriesIndex
 
-        def __init__(self, inp: Inputs) -> None:
+        def __init__(self, inputs: Inputs) -> None:
             ...
-            super().__init__("MyModel", inputs=inp, outputs=...)
+            super().__init__("MyModel", inputs=inputs, outputs=...)
 """
 
 outputs = _make_io_decorator("_is_outputs")
@@ -259,7 +259,7 @@ Passing a plain ``@dataclass`` instance as ``expose=`` to
 def define(name: str) -> Any:
     """Declare a leaf :class:`~.model.Model` subclass via a ``compute()`` method.
 
-    Generates a typed ``__init__(self, inp: Inputs)`` (plus ``fns: Functions``
+    Generates a typed ``__init__(self, inputs: Inputs)`` (plus ``fns: Functions``
     when a ``@functions`` inner class is declared) and wires the result of
     :meth:`compute` into ``super().__init__()`` automatically.
 
@@ -284,8 +284,8 @@ def define(name: str) -> Any:
             class Outputs:
                 i_u_parking: Index
 
-            def compute(self, inp: Inputs) -> Outputs:
-                i_u_parking = Index("parking_usage", inp.pv_tourists * ...)
+            def compute(self, inputs: Inputs) -> Outputs:
+                i_u_parking = Index("parking_usage", inputs.pv_tourists * ...)
                 return ParkingModel.Outputs(i_u_parking=i_u_parking)
 
     With ``@functions`` and ``Expose``::
@@ -309,8 +309,8 @@ def define(name: str) -> Any:
             class Expose:
                 ts_raw: TimeseriesIndex
 
-            def compute(self, inp: Inputs, *, fns: Functions) -> tuple[Outputs, Expose]:
-                ts_raw     = TimeseriesIndex("raw", graph.function_call("ts_solve", inp.ts_inflow))
+            def compute(self, inputs: Inputs, *, fns: Functions) -> tuple[Outputs, Expose]:
+                ts_raw     = TimeseriesIndex("raw", graph.function_call("ts_solve", inputs.ts_inflow))
                 ts_traffic = TimeseriesIndex("traffic", ts_raw * ...)
                 return (
                     TrafficModel.Outputs(ts_traffic=ts_traffic),
@@ -390,23 +390,23 @@ def define(name: str) -> Any:
 
         # Use distinct names to avoid Pyright reportRedeclaration in the if/else.
         if has_functions:
-            def _init_with_fns(self: Any, inp: Any, *, fns: Any) -> None:
+            def _init_with_fns(self: Any, inputs: Any, *, fns: Any) -> None:
                 if _returns_expose:
-                    out, exp = self.compute(inp, fns=fns)
-                    super(_cls, self).__init__(_name, inputs=inp, outputs=out, expose=exp, functions=fns)  # type: ignore[misc]
+                    out, exp = self.compute(inputs, fns=fns)
+                    super(_cls, self).__init__(_name, inputs=inputs, outputs=out, expose=exp, functions=fns)  # type: ignore[misc]
                 else:
-                    out = self.compute(inp, fns=fns)
-                    super(_cls, self).__init__(_name, inputs=inp, outputs=out, functions=fns)  # type: ignore[misc]
+                    out = self.compute(inputs, fns=fns)
+                    super(_cls, self).__init__(_name, inputs=inputs, outputs=out, functions=fns)  # type: ignore[misc]
 
             cls.__init__ = _init_with_fns  # type: ignore[assignment]
         else:
-            def _init_no_fns(self: Any, inp: Any) -> None:
+            def _init_no_fns(self: Any, inputs: Any) -> None:
                 if _returns_expose:
-                    out, exp = self.compute(inp)
-                    super(_cls, self).__init__(_name, inputs=inp, outputs=out, expose=exp)  # type: ignore[misc]
+                    out, exp = self.compute(inputs)
+                    super(_cls, self).__init__(_name, inputs=inputs, outputs=out, expose=exp)  # type: ignore[misc]
                 else:
-                    out = self.compute(inp)
-                    super(_cls, self).__init__(_name, inputs=inp, outputs=out)  # type: ignore[misc]
+                    out = self.compute(inputs)
+                    super(_cls, self).__init__(_name, inputs=inputs, outputs=out)  # type: ignore[misc]
 
             cls.__init__ = _init_no_fns  # type: ignore[assignment]
 

--- a/civic_digital_twins/dt_model/model/model.py
+++ b/civic_digital_twins/dt_model/model/model.py
@@ -454,65 +454,70 @@ def _build_proxy(
 class Model:
     """A named collection of :class:`~.index.GenericIndex` objects with an optional I/O contract.
 
-    Two APIs are supported:
+    Three APIs are supported, from most to least recommended:
 
-    **New dataclass-based API** (recommended)
-        Declare ``Inputs``, ``Outputs``, and/or ``Expose`` as inner
-        ``@dataclass`` classes on the subclass.  Construct instances of them
-        and pass to ``super().__init__()``::
+    **`@define` + `compute()` (recommended for leaf models)**
+        Declare ``Inputs``, ``Outputs``, and optionally ``Expose`` and
+        ``Functions`` as inner classes decorated with :func:`~.contracts.inputs`,
+        :func:`~.contracts.outputs`, :func:`~.contracts.expose`, and
+        :func:`~.contracts.functions`.  Implement ``compute()`` to return the
+        outputs; :func:`~.contracts.define` generates the ``__init__``
+        automatically::
 
-            from dataclasses import dataclass
+            from civic_digital_twins.dt_model import Index, Model, define, inputs, outputs
 
+            @define("My Model")
             class MyModel(Model):
 
-                @dataclass
+                @inputs
                 class Inputs:
                     inflow: TimeseriesIndex
 
-                @dataclass
+                @outputs
                 class Outputs:
                     traffic: TimeseriesIndex
                     total:   Index
 
-                @dataclass
-                class Expose:
-                    ratio: Index   # inspectable but not contractual
-
-                def __init__(self, inflow: TimeseriesIndex) -> None:
-                    Inputs  = MyModel.Inputs
-                    Outputs = MyModel.Outputs
-                    Expose  = MyModel.Expose
-
+                def compute(self, inp: Inputs) -> Outputs:
                     traffic = TimeseriesIndex("traffic", ...)
                     total   = Index("total", traffic.sum())
-                    ratio   = Index("ratio", ...)
+                    return MyModel.Outputs(traffic=traffic, total=total)
 
-                    super().__init__(
-                        "My Model",
-                        inputs=Inputs(inflow=inflow),
-                        outputs=Outputs(traffic=traffic, total=total),
-                        expose=Expose(ratio=ratio),
-                    )
-
-            m = MyModel(inflow_ts)
+            m = MyModel(inp=MyModel.Inputs(inflow=inflow_ts))
             m.inputs.inflow    # the wired inflow index
             m.outputs.traffic  # contractual output
-            m.expose.ratio     # inspectable, non-contractual
 
-        The local aliases (``Inputs = MyModel.Inputs``, etc.) avoid the
-        fully-qualified form inside ``__init__`` and keep the construction
-        calls concise.
+    **Contract decorators + `__init__` (composite / root models)**
+        Use :func:`~.contracts.inputs`, :func:`~.contracts.outputs`, and
+        :func:`~.contracts.expose` on the inner classes, then write ``__init__``
+        manually and call ``super().__init__()``.  Required for models that
+        assign sub-model attributes before ``super().__init__()`` is called.
+        Pass ``legacy=True`` to suppress the ``DeprecationWarning``::
 
-        ``Inputs`` and ``Outputs`` are plural because they name a *collection*
-        of fields.  ``Expose`` is a verb-derived noun (like ``Meta`` or
-        ``Config``) — "Exposes" would be grammatically wrong — so it stays
-        singular by design.
+            from civic_digital_twins.dt_model import Model, inputs, outputs
+
+            class RootModel(Model, legacy=True):
+
+                @inputs
+                class Inputs:
+                    inflow: TimeseriesIndex
+
+                @outputs
+                class Outputs:
+                    traffic: TimeseriesIndex
+
+                def __init__(self) -> None:
+                    self.leaf = LeafModel(...)
+                    super().__init__(
+                        "Root",
+                        inputs=RootModel.Inputs(inflow=...),
+                        outputs=RootModel.Outputs(traffic=...),
+                    )
 
         Dataclass fields may hold a single :class:`~.index.GenericIndex`, a
         ``list`` of them, or a ``dict`` mapping strings to them.  The flat
-        ``indexes`` list is derived automatically by collecting and
-        deduplicating all scalar indexes from ``inputs``, ``outputs``, and
-        ``expose``.
+        ``indexes`` list is derived automatically from ``inputs``, ``outputs``,
+        and ``expose``.
 
     **Legacy API** (deprecated)
         Pass a flat ``indexes`` list directly, along with optional
@@ -578,17 +583,17 @@ class Model:
     """
 
     def __init_subclass__(cls, *, legacy: bool = False, **kwargs: Any) -> None:
-        """Warn when a subclass defines ``__init__`` directly instead of using ``@model``.
+        """Warn when a subclass defines ``__init__`` directly instead of using ``@define``.
 
         Fired at class-definition time (before class decorators run), so
-        ``@model``-decorated classes — which have no ``__init__`` at that point
+        ``@define``-decorated classes — which have no ``__init__`` at that point
         — are not affected.
 
         Parameters
         ----------
         legacy:
             Pass ``True`` to suppress the warning for models that cannot be
-            expressed with :func:`~.contracts.model` + ``compute()`` (e.g.
+            expressed with :func:`~.contracts.define` + ``compute()`` (e.g.
             composite models that assign sub-model attributes before calling
             ``super().__init__()``).
         """
@@ -596,7 +601,7 @@ class Model:
         if "__init__" in cls.__dict__ and not legacy:
             warnings.warn(
                 f"{cls.__name__} defines __init__ directly. "
-                "Use @model with compute() instead, or pass legacy=True to suppress this warning.",
+                "Use @define with compute() instead, or pass legacy=True to suppress this warning.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/civic_digital_twins/dt_model/model/model.py
+++ b/civic_digital_twins/dt_model/model/model.py
@@ -577,6 +577,30 @@ class Model:
     work while the contract is incrementally tightened.
     """
 
+    def __init_subclass__(cls, *, legacy: bool = False, **kwargs: Any) -> None:
+        """Warn when a subclass defines ``__init__`` directly instead of using ``@model``.
+
+        Fired at class-definition time (before class decorators run), so
+        ``@model``-decorated classes — which have no ``__init__`` at that point
+        — are not affected.
+
+        Parameters
+        ----------
+        legacy:
+            Pass ``True`` to suppress the warning for models that cannot be
+            expressed with :func:`~.contracts.model` + ``compute()`` (e.g.
+            composite models that assign sub-model attributes before calling
+            ``super().__init__()``).
+        """
+        super().__init_subclass__(**kwargs)
+        if "__init__" in cls.__dict__ and not legacy:
+            warnings.warn(
+                f"{cls.__name__} defines __init__ directly. "
+                "Use @model with compute() instead, or pass legacy=True to suppress this warning.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
     def __init__(
         self,
         name: str,

--- a/civic_digital_twins/dt_model/model/model.py
+++ b/civic_digital_twins/dt_model/model/model.py
@@ -478,12 +478,12 @@ class Model:
                     traffic: TimeseriesIndex
                     total:   Index
 
-                def compute(self, inp: Inputs) -> Outputs:
+                def compute(self, inputs: Inputs) -> Outputs:
                     traffic = TimeseriesIndex("traffic", ...)
                     total   = Index("total", traffic.sum())
                     return MyModel.Outputs(traffic=traffic, total=total)
 
-            m = MyModel(inp=MyModel.Inputs(inflow=inflow_ts))
+            m = MyModel(inputs=MyModel.Inputs(inflow=inflow_ts))
             m.inputs.inflow    # the wired inflow index
             m.outputs.traffic  # contractual output
 

--- a/examples/mobility_bologna/bologna_model.py
+++ b/examples/mobility_bologna/bologna_model.py
@@ -22,6 +22,7 @@ from civic_digital_twins.dt_model import (
     NumpyBackend,
     Scenario,
     TimeseriesIndex,
+    define,
     expose,
     functions,
     graph,
@@ -76,6 +77,7 @@ def _ts_solve(ts: np.ndarray) -> np.ndarray:
 # ---------------------------------------------------------------------------
 
 
+@define("Inflow")
 class InflowModel(Model):
     """Sub-model that computes modified vehicle inflow under a pricing policy.
 
@@ -139,42 +141,8 @@ class InflowModel(Model):
         i_total_anticipated: Index
         i_total_postponed: Index
 
-    def __init__(
-        self,
-        ts_inflow: TimeseriesIndex,
-        ts_starting: TimeseriesIndex,
-        ts: TimeseriesIndex,
-        i_p_start_time: Index,
-        i_p_end_time: Index,
-        i_p_cost: list[Index],
-        i_p_fraction_exempted: Index,
-        i_b_p50_cost: DistributionIndex,
-        i_b_p50_anticipating: Index,
-        i_b_p50_anticipation: Index,
-        i_b_p50_postponing: Index,
-        i_b_p50_postponement: Index,
-        i_b_starting_modified_factor: Index,
-    ) -> None:
-        Inputs = InflowModel.Inputs
-        Outputs = InflowModel.Outputs
-        Expose = InflowModel.Expose
-
-        inputs = Inputs(
-            ts_inflow=ts_inflow,
-            ts_starting=ts_starting,
-            ts=ts,
-            i_p_start_time=i_p_start_time,
-            i_p_end_time=i_p_end_time,
-            i_p_cost=i_p_cost,
-            i_p_fraction_exempted=i_p_fraction_exempted,
-            i_b_p50_cost=i_b_p50_cost,
-            i_b_p50_anticipating=i_b_p50_anticipating,
-            i_b_p50_anticipation=i_b_p50_anticipation,
-            i_b_p50_postponing=i_b_p50_postponing,
-            i_b_p50_postponement=i_b_p50_postponement,
-            i_b_starting_modified_factor=i_b_starting_modified_factor,
-        )
-
+    def compute(self, inputs: Inputs) -> tuple[Outputs, Expose]:
+        """Compute modified inflow, payment stats, and exposed intermediates."""
         avg_cost = Index(
             "average cost",
             inputs.i_p_cost[0] * euro_class_split["euro_0"]
@@ -337,10 +305,8 @@ class InflowModel(Model):
         # TODO: fix, compute real value!
         total_paid = Index("total paid fees", total_paying * avg_cost)
 
-        super().__init__(
-            "Inflow",
-            inputs=inputs,
-            outputs=Outputs(
+        return (
+            InflowModel.Outputs(
                 modified_inflow=modified_inflow,
                 modified_starting=modified_starting,
                 total_base_inflow=total_base_inflow,
@@ -353,7 +319,7 @@ class InflowModel(Model):
                 total_paid=total_paid,
                 total_shifted=total_shifted,
             ),
-            expose=Expose(
+            InflowModel.Expose(
                 i_fraction_rigid_euro=i_fraction_rigid_euro,
                 i_delta_from_start=i_delta_from_start,
                 i_fraction_anticipating=i_fraction_anticipating,
@@ -374,6 +340,7 @@ class InflowModel(Model):
         )
 
 
+@define("Traffic")
 class TrafficModel(Model):
     """Sub-model that computes both baseline and modified circulating traffic.
 
@@ -408,25 +375,8 @@ class TrafficModel(Model):
 
         ts_solve: Functor
 
-    def __init__(
-        self,
-        ts_inflow: TimeseriesIndex,
-        ts_starting: TimeseriesIndex,
-        modified_inflow: Index,
-        modified_starting: Index,
-        *,
-        functions: TrafficModel.Functions,
-    ) -> None:
-        Inputs = TrafficModel.Inputs
-        Outputs = TrafficModel.Outputs
-
-        inputs = Inputs(
-            ts_inflow=ts_inflow,
-            ts_starting=ts_starting,
-            modified_inflow=modified_inflow,
-            modified_starting=modified_starting,
-        )
-
+    def compute(self, inputs: Inputs, *, fns: Functions) -> Outputs:
+        """Compute steady-state traffic for baseline and modified scenarios."""
         traffic = TimeseriesIndex(
             "reference traffic",
             graph.function_call("ts_solve", inputs.ts_inflow + inputs.ts_starting),
@@ -445,22 +395,17 @@ class TrafficModel(Model):
             "ratio between modified traffic and base traffic",
             traffic / modified_traffic,
         )
-
-        super().__init__(
-            "Traffic",
-            inputs=inputs,
-            outputs=Outputs(
-                traffic=traffic,
-                modified_traffic=modified_traffic,
-                total_modified_traffic=total_modified_traffic,
-                inflow_ratio=inflow_ratio,
-                starting_ratio=starting_ratio,
-                traffic_ratio=traffic_ratio,
-            ),
-            functions=functions,
+        return TrafficModel.Outputs(
+            traffic=traffic,
+            modified_traffic=modified_traffic,
+            total_modified_traffic=total_modified_traffic,
+            inflow_ratio=inflow_ratio,
+            starting_ratio=starting_ratio,
+            traffic_ratio=traffic_ratio,
         )
 
 
+@define("Emissions")
 class EmissionsModel(Model):
     """Sub-model that computes both baseline and modified emissions.
 
@@ -490,27 +435,8 @@ class EmissionsModel(Model):
         total_emissions: Index
         total_modified_emissions: Index
 
-    def __init__(
-        self,
-        ts: TimeseriesIndex,
-        i_p_start_time: Index,
-        i_p_end_time: Index,
-        traffic: TimeseriesIndex,
-        modified_traffic: TimeseriesIndex,
-        modified_euro_class_split: list[Index],
-    ) -> None:
-        Inputs = EmissionsModel.Inputs
-        Outputs = EmissionsModel.Outputs
-
-        inputs = Inputs(
-            ts=ts,
-            i_p_start_time=i_p_start_time,
-            i_p_end_time=i_p_end_time,
-            traffic=traffic,
-            modified_traffic=modified_traffic,
-            modified_euro_class_split=modified_euro_class_split,
-        )
-
+    def compute(self, inputs: Inputs) -> Outputs:
+        """Compute baseline and modified vehicle emissions."""
         average_emissions = ConstIndex(
             "average emissions (per vehicle, per km)",
             euro_class_emission["euro_0"] * euro_class_split["euro_0"]
@@ -555,16 +481,12 @@ class EmissionsModel(Model):
         total_emissions = Index("total emissions", emissions.sum())
         total_modified_emissions = Index("total modified emissions", modified_emissions.sum())
 
-        super().__init__(
-            "Emissions",
-            inputs=inputs,
-            outputs=Outputs(
-                average_emissions=average_emissions,
-                emissions=emissions,
-                modified_emissions=modified_emissions,
-                total_emissions=total_emissions,
-                total_modified_emissions=total_modified_emissions,
-            ),
+        return EmissionsModel.Outputs(
+            average_emissions=average_emissions,
+            emissions=emissions,
+            modified_emissions=modified_emissions,
+            total_emissions=total_emissions,
+            total_modified_emissions=total_modified_emissions,
         )
 
 
@@ -573,7 +495,7 @@ class EmissionsModel(Model):
 # ---------------------------------------------------------------------------
 
 
-class BolognaModel(Model):
+class BolognaModel(Model, legacy=True):
     """Root model for the Bologna mobility example.
 
     Composes three sub-models:
@@ -704,7 +626,7 @@ class BolognaModel(Model):
         ts_inflow = ConstTimeseriesIndex("inflow", vehicle_inflow)
         ts_starting = ConstTimeseriesIndex("staring", vehicle_starting)
 
-        _inflow = InflowModel(
+        _inflow = InflowModel(inputs=InflowModel.Inputs(  # type: ignore[call-arg]
             ts_inflow=ts_inflow,
             ts_starting=ts_starting,
             ts=ts,
@@ -718,24 +640,26 @@ class BolognaModel(Model):
             i_b_p50_postponing=i_b_p50_postponing,
             i_b_p50_postponement=i_b_p50_postponement,
             i_b_starting_modified_factor=i_b_starting_modified_factor,
+        ))
+
+        _traffic = TrafficModel(  # type: ignore[call-arg]
+            inputs=TrafficModel.Inputs(
+                ts_inflow=ts_inflow,
+                ts_starting=ts_starting,
+                modified_inflow=_inflow.outputs.modified_inflow,
+                modified_starting=_inflow.outputs.modified_starting,
+            ),
+            fns=TrafficModel.Functions(ts_solve=fns.ts_solve),
         )
 
-        _traffic = TrafficModel(
-            ts_inflow=ts_inflow,
-            ts_starting=ts_starting,
-            modified_inflow=_inflow.outputs.modified_inflow,
-            modified_starting=_inflow.outputs.modified_starting,
-            functions=TrafficModel.Functions(ts_solve=fns.ts_solve),
-        )
-
-        _emissions = EmissionsModel(
+        _emissions = EmissionsModel(inputs=EmissionsModel.Inputs(  # type: ignore[call-arg]
             ts=ts,
             i_p_start_time=i_p_start_time,
             i_p_end_time=i_p_end_time,
             traffic=_traffic.outputs.traffic,
             modified_traffic=_traffic.outputs.modified_traffic,
             modified_euro_class_split=_inflow.outputs.modified_euro_class_split,
-        )
+        ))
 
         super().__init__(
             "Bologna mobility",

--- a/examples/mobility_bologna/bologna_model.py
+++ b/examples/mobility_bologna/bologna_model.py
@@ -572,9 +572,7 @@ class BolognaModel(Model):
             )
         """
         return cls.Inputs(
-            i_p_start_time=Index(
-                "start time", (pd.Timestamp("07:30:00") - pd.Timestamp("00:00:00")).total_seconds()
-            ),
+            i_p_start_time=Index("start time", (pd.Timestamp("07:30:00") - pd.Timestamp("00:00:00")).total_seconds()),
             i_p_end_time=Index("end time", (pd.Timestamp("19:30:00") - pd.Timestamp("00:00:00")).total_seconds()),
             i_p_cost=[Index(f"cost euro {e}", 5.00 - e * 0.25) for e in range(7)],
             i_p_fraction_exempted=Index("exempted vehicles %", 0.15),
@@ -605,21 +603,23 @@ class BolognaModel(Model):
         ts_inflow = ConstTimeseriesIndex("inflow", vehicle_inflow)
         ts_starting = ConstTimeseriesIndex("staring", vehicle_starting)
 
-        _inflow = InflowModel(inputs=InflowModel.Inputs(  # type: ignore[call-arg]
-            ts_inflow=ts_inflow,
-            ts_starting=ts_starting,
-            ts=ts,
-            i_p_start_time=inputs.i_p_start_time,
-            i_p_end_time=inputs.i_p_end_time,
-            i_p_cost=inputs.i_p_cost,
-            i_p_fraction_exempted=inputs.i_p_fraction_exempted,
-            i_b_p50_cost=inputs.i_b_p50_cost,
-            i_b_p50_anticipating=inputs.i_b_p50_anticipating,
-            i_b_p50_anticipation=inputs.i_b_p50_anticipation,
-            i_b_p50_postponing=inputs.i_b_p50_postponing,
-            i_b_p50_postponement=inputs.i_b_p50_postponement,
-            i_b_starting_modified_factor=inputs.i_b_starting_modified_factor,
-        ))
+        _inflow = InflowModel(
+            inputs=InflowModel.Inputs(  # type: ignore[call-arg]
+                ts_inflow=ts_inflow,
+                ts_starting=ts_starting,
+                ts=ts,
+                i_p_start_time=inputs.i_p_start_time,
+                i_p_end_time=inputs.i_p_end_time,
+                i_p_cost=inputs.i_p_cost,
+                i_p_fraction_exempted=inputs.i_p_fraction_exempted,
+                i_b_p50_cost=inputs.i_b_p50_cost,
+                i_b_p50_anticipating=inputs.i_b_p50_anticipating,
+                i_b_p50_anticipation=inputs.i_b_p50_anticipation,
+                i_b_p50_postponing=inputs.i_b_p50_postponing,
+                i_b_p50_postponement=inputs.i_b_p50_postponement,
+                i_b_starting_modified_factor=inputs.i_b_starting_modified_factor,
+            )
+        )
 
         _traffic = TrafficModel(  # type: ignore[call-arg]
             inputs=TrafficModel.Inputs(
@@ -631,14 +631,16 @@ class BolognaModel(Model):
             fns=TrafficModel.Functions(ts_solve=fns.ts_solve),
         )
 
-        _emissions = EmissionsModel(inputs=EmissionsModel.Inputs(  # type: ignore[call-arg]
-            ts=ts,
-            i_p_start_time=inputs.i_p_start_time,
-            i_p_end_time=inputs.i_p_end_time,
-            traffic=_traffic.outputs.traffic,
-            modified_traffic=_traffic.outputs.modified_traffic,
-            modified_euro_class_split=_inflow.outputs.modified_euro_class_split,
-        ))
+        _emissions = EmissionsModel(
+            inputs=EmissionsModel.Inputs(  # type: ignore[call-arg]
+                ts=ts,
+                i_p_start_time=inputs.i_p_start_time,
+                i_p_end_time=inputs.i_p_end_time,
+                traffic=_traffic.outputs.traffic,
+                modified_traffic=_traffic.outputs.modified_traffic,
+                modified_euro_class_split=_inflow.outputs.modified_euro_class_split,
+            )
+        )
 
         return (
             BolognaModel.Outputs(

--- a/examples/mobility_bologna/bologna_model.py
+++ b/examples/mobility_bologna/bologna_model.py
@@ -495,7 +495,8 @@ class EmissionsModel(Model):
 # ---------------------------------------------------------------------------
 
 
-class BolognaModel(Model, legacy=True):
+@define("Bologna mobility")
+class BolognaModel(Model):
     """Root model for the Bologna mobility example.
 
     Composes three sub-models:
@@ -558,62 +559,40 @@ class BolognaModel(Model, legacy=True):
         ts_solve: Functor
 
     @classmethod
-    def default_inputs(cls) -> dict:
-        """Return the reference-scenario input parameters as a keyword-argument dict.
+    def default_inputs(cls) -> Inputs:
+        """Return the reference-scenario inputs as an :class:`~.Inputs` instance.
 
-        Pass directly to :class:`BolognaModel` or override individual entries::
+        Pass to :class:`BolognaModel` or override individual fields with
+        :func:`dataclasses.replace`::
 
-            m = BolognaModel(**BolognaModel.default_inputs())
-            m_alt = BolognaModel(**{**BolognaModel.default_inputs(), "i_p_cost": [...]})
+            m = BolognaModel(inputs=BolognaModel.default_inputs(), fns=BolognaModel.default_fns())
+            m_alt = BolognaModel(
+                inputs=dataclasses.replace(BolognaModel.default_inputs(), i_p_cost=[...]),
+                fns=BolognaModel.default_fns(),
+            )
         """
-        return {
-            "i_p_start_time": Index(
+        return cls.Inputs(
+            i_p_start_time=Index(
                 "start time", (pd.Timestamp("07:30:00") - pd.Timestamp("00:00:00")).total_seconds()
             ),
-            "i_p_end_time": Index("end time", (pd.Timestamp("19:30:00") - pd.Timestamp("00:00:00")).total_seconds()),
-            "i_p_cost": [Index(f"cost euro {e}", 5.00 - e * 0.25) for e in range(7)],
-            "i_p_fraction_exempted": Index("exempted vehicles %", 0.15),
-            "i_b_p50_cost": DistributionIndex("cost 50% threshold", stats.uniform, {"loc": 4.00, "scale": 7.00}),
-            "i_b_p50_anticipating": Index("anticipation 50% likelihood", 0.5),
-            "i_b_p50_anticipation": Index("anticipation distribution 50% threshold", 0.25),
-            "i_b_p50_postponing": Index("postponement 50% likelihood", 0.8),
-            "i_b_p50_postponement": Index("postponement distribution 50% threshold", 0.50),
-            "i_b_starting_modified_factor": Index("starting modified factor", 1.00),
-        }
-
-    def __init__(
-        self,
-        *,
-        i_p_start_time: Index,
-        i_p_end_time: Index,
-        i_p_cost: list[Index],
-        i_p_fraction_exempted: Index,
-        i_b_p50_cost: DistributionIndex,
-        i_b_p50_anticipating: Index,
-        i_b_p50_anticipation: Index,
-        i_b_p50_postponing: Index,
-        i_b_p50_postponement: Index,
-        i_b_starting_modified_factor: Index,
-        functions: BolognaModel.Functions | None = None,
-    ) -> None:
-        fns = functions or BolognaModel.Functions(ts_solve=NumpyBackend.adapt(_ts_solve))
-        Inputs = BolognaModel.Inputs
-        Outputs = BolognaModel.Outputs
-        Expose = BolognaModel.Expose
-
-        inputs = Inputs(
-            i_p_start_time=i_p_start_time,
-            i_p_end_time=i_p_end_time,
-            i_p_cost=i_p_cost,
-            i_p_fraction_exempted=i_p_fraction_exempted,
-            i_b_p50_cost=i_b_p50_cost,
-            i_b_p50_anticipating=i_b_p50_anticipating,
-            i_b_p50_anticipation=i_b_p50_anticipation,
-            i_b_p50_postponing=i_b_p50_postponing,
-            i_b_p50_postponement=i_b_p50_postponement,
-            i_b_starting_modified_factor=i_b_starting_modified_factor,
+            i_p_end_time=Index("end time", (pd.Timestamp("19:30:00") - pd.Timestamp("00:00:00")).total_seconds()),
+            i_p_cost=[Index(f"cost euro {e}", 5.00 - e * 0.25) for e in range(7)],
+            i_p_fraction_exempted=Index("exempted vehicles %", 0.15),
+            i_b_p50_cost=DistributionIndex("cost 50% threshold", stats.uniform, {"loc": 4.00, "scale": 7.00}),
+            i_b_p50_anticipating=Index("anticipation 50% likelihood", 0.5),
+            i_b_p50_anticipation=Index("anticipation distribution 50% threshold", 0.25),
+            i_b_p50_postponing=Index("postponement 50% likelihood", 0.8),
+            i_b_p50_postponement=Index("postponement distribution 50% threshold", 0.50),
+            i_b_starting_modified_factor=Index("starting modified factor", 1.00),
         )
 
+    @classmethod
+    def default_fns(cls) -> Functions:
+        """Return the default :class:`~.Functions` using the built-in traffic solver."""
+        return cls.Functions(ts_solve=NumpyBackend.adapt(_ts_solve))
+
+    def compute(self, inputs: Inputs, *, fns: Functions) -> tuple[Outputs, Expose]:
+        """Compose sub-models from inputs and return KPI outputs with expose timeseries."""
         ts = ConstTimeseriesIndex(
             "time range",
             np.array(
@@ -630,16 +609,16 @@ class BolognaModel(Model, legacy=True):
             ts_inflow=ts_inflow,
             ts_starting=ts_starting,
             ts=ts,
-            i_p_start_time=i_p_start_time,
-            i_p_end_time=i_p_end_time,
-            i_p_cost=i_p_cost,
-            i_p_fraction_exempted=i_p_fraction_exempted,
-            i_b_p50_cost=i_b_p50_cost,
-            i_b_p50_anticipating=i_b_p50_anticipating,
-            i_b_p50_anticipation=i_b_p50_anticipation,
-            i_b_p50_postponing=i_b_p50_postponing,
-            i_b_p50_postponement=i_b_p50_postponement,
-            i_b_starting_modified_factor=i_b_starting_modified_factor,
+            i_p_start_time=inputs.i_p_start_time,
+            i_p_end_time=inputs.i_p_end_time,
+            i_p_cost=inputs.i_p_cost,
+            i_p_fraction_exempted=inputs.i_p_fraction_exempted,
+            i_b_p50_cost=inputs.i_b_p50_cost,
+            i_b_p50_anticipating=inputs.i_b_p50_anticipating,
+            i_b_p50_anticipation=inputs.i_b_p50_anticipation,
+            i_b_p50_postponing=inputs.i_b_p50_postponing,
+            i_b_p50_postponement=inputs.i_b_p50_postponement,
+            i_b_starting_modified_factor=inputs.i_b_starting_modified_factor,
         ))
 
         _traffic = TrafficModel(  # type: ignore[call-arg]
@@ -654,17 +633,15 @@ class BolognaModel(Model, legacy=True):
 
         _emissions = EmissionsModel(inputs=EmissionsModel.Inputs(  # type: ignore[call-arg]
             ts=ts,
-            i_p_start_time=i_p_start_time,
-            i_p_end_time=i_p_end_time,
+            i_p_start_time=inputs.i_p_start_time,
+            i_p_end_time=inputs.i_p_end_time,
             traffic=_traffic.outputs.traffic,
             modified_traffic=_traffic.outputs.modified_traffic,
             modified_euro_class_split=_inflow.outputs.modified_euro_class_split,
         ))
 
-        super().__init__(
-            "Bologna mobility",
-            inputs=inputs,
-            outputs=Outputs(
+        return (
+            BolognaModel.Outputs(
                 total_base_inflow=_inflow.outputs.total_base_inflow,
                 total_modified_inflow=_inflow.outputs.total_modified_inflow,
                 total_shifted=_inflow.outputs.total_shifted,
@@ -674,7 +651,7 @@ class BolognaModel(Model, legacy=True):
                 total_emissions=_emissions.outputs.total_emissions,
                 total_modified_emissions=_emissions.outputs.total_modified_emissions,
             ),
-            expose=Expose(
+            BolognaModel.Expose(
                 ts_inflow=ts_inflow,
                 modified_inflow=_inflow.outputs.modified_inflow,
                 traffic=_traffic.outputs.traffic,
@@ -682,7 +659,6 @@ class BolognaModel(Model, legacy=True):
                 emissions=_emissions.outputs.emissions,
                 modified_emissions=_emissions.outputs.modified_emissions,
             ),
-            functions=fns,
         )
 
 

--- a/examples/mobility_bologna/mobility_bologna.py
+++ b/examples/mobility_bologna/mobility_bologna.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import math
 from pathlib import Path
 
@@ -144,7 +145,7 @@ if __name__ == "__main__":
     _config = EvaluationConfig(ensemble_size=20)
 
     # ── Reference scenario (default parameters) ──────────────────────────────
-    _m = BolognaModel(**BolognaModel.default_inputs())
+    _m = BolognaModel(inputs=BolognaModel.default_inputs(), fns=BolognaModel.default_fns())
     _evaluator = BolognaEvaluator(_m)
     _output = _evaluator.evaluate(Scenario(_m), _config)
     _save_scenario_plots("reference", _m, _output, _out)
@@ -157,10 +158,11 @@ if __name__ == "__main__":
     # Higher fees with a steeper Euro-class gradient: older/more polluting
     # vehicles pay substantially more, incentivising fleet-mix shifts.
     _m_strict = BolognaModel(
-        **{
-            **BolognaModel.default_inputs(),
-            "i_p_cost": [Index(f"cost euro {e}", 8.00 - e * 0.50) for e in range(7)],
-        }
+        inputs=dataclasses.replace(
+            BolognaModel.default_inputs(),
+            i_p_cost=[Index(f"cost euro {e}", 8.00 - e * 0.50) for e in range(7)],
+        ),
+        fns=BolognaModel.default_fns(),
     )
     _evaluator_strict = BolognaEvaluator(_m_strict)
     _output_strict = _evaluator_strict.evaluate(Scenario(_m_strict), _config)

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -87,6 +87,7 @@ from civic_digital_twins.dt_model import (
     Index,
     Model,
     define,
+    expose,
     graph,
     inputs,
     outputs,
@@ -348,39 +349,28 @@ class FoodModel(Model):
 # ---------------------------------------------------------------------------
 
 
-class MolvenoModel(Model, legacy=True):
+@define("base model")
+class MolvenoModel(Model):
     """Root overtourism model that wires the four concern sub-models.
 
-    ``MolvenoModel`` owns:
+    Supply the domain parameters via :meth:`default_inputs`, or override
+    individual fields with :func:`dataclasses.replace`::
 
-    * the three context variables (``cv_weekday``, ``cv_season``, ``cv_weather``);
-    * the two presence variables (``pv_tourists``, ``pv_excursionists``);
-    * the default values for every ``i_*`` parameter.
-
-    Callers who need to override a parameter can subclass ``MolvenoModel``
-    or construct the concern sub-models directly with different values.
-
-    The ``cvs``, ``pvs``, and ``constraints`` attributes are required by
-    :class:`~dt_model.CrossProductEnsemble`.
-
-    CVs, PVs, and sub-models are accessible as named attributes::
-
-        m = MolvenoModel()
-        m.cv_weather                      # CategoricalIndex
-        m.pv_tourists                     # ConditionalDistributionIndex
-        m.parking.inputs.i_c_parking      # capacity DistributionIndex
-        m.beach.inputs.i_xo_tourists_beach  # rotation DistributionIndex
-        m.parking.outputs.i_u_parking     # usage formula Index
-        m.parking.constraint              # Constraint object
+        m = MolvenoModel(inputs=MolvenoModel.default_inputs())
+        m.inputs.cvs                        # list of CategoricalIndex (weekday, season, weather)
+        m.inputs.pvs                        # list of ConditionalDistributionIndex
+        m.cv_weather                        # named alias set by compute()
+        m.parking.inputs.i_c_parking        # capacity DistributionIndex
+        m.parking.outputs.i_u_parking       # usage formula Index
+        m.parking.constraint                # Constraint object
     """
 
     @inputs
     class Inputs:
-        """Contractual inputs of :class:`MolvenoModel`."""
+        """CVs, PVs, and distribution-backed parameters of :class:`MolvenoModel`."""
 
         cvs: list[CategoricalIndex]
         pvs: list[ConditionalDistributionIndex]
-        domain_indexes: list[GenericIndex]
         capacities: list[GenericIndex]
 
     @outputs
@@ -389,14 +379,28 @@ class MolvenoModel(Model, legacy=True):
 
         usage_indexes: list[GenericIndex]
 
-    def __init__(self) -> None:
-        # ------------------------------------------------------------------
-        # Stage 1 — context and presence variables
-        # ------------------------------------------------------------------
+    @expose
+    class Expose:
+        """Sub-model formula indexes (for evaluation state) and presence-transformation parameters."""
+
+        domain_indexes: list[GenericIndex]
+        i_p_tourists_reduction_factor: Index
+        i_p_excursionists_reduction_factor: Index
+        i_p_tourists_saturation_level: Index
+        i_p_excursionists_saturation_level: Index
+
+    @classmethod
+    def default_inputs(cls) -> Inputs:
+        """Return the default domain inputs: CVs, PVs, and distribution-backed parameters.
+
+        Pass to :class:`MolvenoModel` or override individual fields with
+        :func:`dataclasses.replace`::
+
+            m = MolvenoModel(inputs=MolvenoModel.default_inputs())
+        """
         cv_weekday = CategoricalIndex("weekday", {d: 1.0 / len(weekday) for d in weekday})
         cv_season = CategoricalIndex("season", {v: season[v] for v in season})
         cv_weather = CategoricalIndex("weather", {v: weather[v] for v in weather})
-
         pv_tourists = ConditionalDistributionIndex(
             "tourists",
             [cv_weekday, cv_season, cv_weather],
@@ -407,9 +411,45 @@ class MolvenoModel(Model, legacy=True):
             [cv_weekday, cv_season, cv_weather],
             excursionist_presences_stats,
         )
+        return cls.Inputs(
+            cvs=[cv_weekday, cv_season, cv_weather],
+            pvs=[pv_tourists, pv_excursionists],
+            capacities=[
+                DistributionIndex("parking capacity", stats.uniform, {"loc": 350.0, "scale": 100.0}),
+                DistributionIndex("beach capacity", stats.uniform, {"loc": 6000.0, "scale": 1000.0}),
+                DistributionIndex(
+                    "accommodation capacity",
+                    stats.lognorm,
+                    {"s": 0.125, "loc": 0.0, "scale": 5000.0},
+                ),
+                DistributionIndex(
+                    "food service capacity",
+                    stats.triang,
+                    {"loc": 3000.0, "scale": 1000.0, "c": 0.5},
+                ),
+                DistributionIndex(
+                    "tourists on beach rotation factor",
+                    stats.uniform,
+                    {"loc": 1.0, "scale": 2.0},
+                ),
+            ],
+        )
+
+    def compute(self, inputs: Inputs) -> tuple[Outputs, Expose]:
+        """Compose concern sub-models from inputs and return usage outputs."""
+        cv_weekday, cv_season, cv_weather = inputs.cvs
+        pv_tourists, pv_excursionists = inputs.pvs
+        i_c_parking, i_c_beach, i_c_accommodation, i_c_food, i_xo_tourists_beach = inputs.capacities
+
+        # Side effects — named attribute access used by evaluators and scenarios.
+        self.cv_weekday = cv_weekday
+        self.cv_season = cv_season
+        self.cv_weather = cv_weather
+        self.pv_tourists = pv_tourists
+        self.pv_excursionists = pv_excursionists
 
         # ------------------------------------------------------------------
-        # Default i_* parameters — created here so callers can override them
+        # Default i_* parameters
         # ------------------------------------------------------------------
 
         # Parking parameters
@@ -422,7 +462,6 @@ class MolvenoModel(Model, legacy=True):
         i_xa_excursionists_per_vehicle = Index("excursionists per vehicle allocation factor", 2.5)
         i_xo_tourists_parking = Index("tourists in parking rotation factor", 1.02)
         i_xo_excursionists_parking = Index("excursionists in parking rotation factor", 3.5)
-        i_c_parking = DistributionIndex("parking capacity", stats.uniform, {"loc": 350.0, "scale": 100.0})
 
         # Beach parameters
         i_u_tourists_beach = Index(
@@ -433,22 +472,11 @@ class MolvenoModel(Model, legacy=True):
             "excursionist beach usage factor",
             graph.piecewise((0.35, cv_weather == "bad"), (0.80, True)),
         )
-        i_xo_tourists_beach = DistributionIndex(
-            "tourists on beach rotation factor",
-            stats.uniform,
-            {"loc": 1.0, "scale": 2.0},
-        )
         i_xo_excursionists_beach = Index("excursionists on beach rotation factor", 1.02)
-        i_c_beach = DistributionIndex("beach capacity", stats.uniform, {"loc": 6000.0, "scale": 1000.0})
 
         # Accommodation parameters
         i_u_tourists_accommodation = Index("tourist accommodation usage factor", 0.90)
         i_xa_tourists_accommodation = Index("tourists per accommodation allocation factor", 1.05)
-        i_c_accommodation = DistributionIndex(
-            "accommodation capacity",
-            stats.lognorm,
-            {"s": 0.125, "loc": 0.0, "scale": 5000.0},
-        )
 
         # Food parameters
         i_u_tourists_food = Index("tourist food service usage factor", 0.20)
@@ -458,11 +486,6 @@ class MolvenoModel(Model, legacy=True):
         )
         i_xa_visitors_food = Index("visitors in food service allocation factor", 0.9)
         i_xo_visitors_food = Index("visitors in food service rotation factor", 2.0)
-        i_c_food = DistributionIndex(
-            "food service capacity",
-            stats.triang,
-            {"loc": 3000.0, "scale": 1000.0, "c": 0.5},
-        )
 
         # Presence-transformation parameters (used in overtourism_molveno.py)
         i_p_tourists_reduction_factor = Index("tourists reduction factor", 1.0)
@@ -471,7 +494,7 @@ class MolvenoModel(Model, legacy=True):
         i_p_excursionists_saturation_level = Index("excursionists saturation level", 10000)
 
         # ------------------------------------------------------------------
-        # Stage 2 / 3 — concern sub-models
+        # Concern sub-models
         # ------------------------------------------------------------------
         parking = ParkingModel(inputs=ParkingModel.Inputs(  # type: ignore[call-arg]
             pv_tourists=pv_tourists,
@@ -512,90 +535,34 @@ class MolvenoModel(Model, legacy=True):
             i_c_food=i_c_food,
         ))
 
-        # ------------------------------------------------------------------
-        # Collect domain lists consumed by CrossProductEnsemble
-        # ------------------------------------------------------------------
-        cvs: list[CategoricalIndex] = [cv_weekday, cv_season, cv_weather]
-        pvs: list[ConditionalDistributionIndex] = [pv_tourists, pv_excursionists]
-        constraints = [
+        self.constraints = [
             parking.constraint,
             beach.constraint,
             accommodation.constraint,
             food.constraint,
         ]
-        capacities: list[GenericIndex] = [i_c_parking, i_c_beach, i_c_accommodation, i_c_food]
-
-        # Collect and deduplicate all indexes from sub-models plus the root
-        # presence-transformation parameters.  Identity-based deduplication
-        # ensures shared indexes (pv_*, cv_*) are not registered twice.
-        seen: set[int] = set()
-        all_indexes: list[GenericIndex] = []
-        for idx in (
-            list(parking.indexes)
-            + list(beach.indexes)
-            + list(accommodation.indexes)
-            + list(food.indexes)
-            + [
-                i_p_tourists_reduction_factor,
-                i_p_excursionists_reduction_factor,
-                i_p_tourists_saturation_level,
-                i_p_excursionists_saturation_level,
-            ]
-        ):
-            if id(idx) not in seen:
-                seen.add(id(idx))
-                all_indexes.append(idx)
-
-        # domain_indexes: everything that is not a CV, PV, capacity, or usage-formula index.
-        cv_pv_ids = {id(x) for x in cvs + pvs}
-        cap_ids = {id(x) for x in capacities}
-        usage_ids = {id(c.usage) for c in constraints}
-        domain_indexes: list[GenericIndex] = [
-            idx
-            for idx in all_indexes
-            if id(idx) not in cv_pv_ids and id(idx) not in cap_ids and id(idx) not in usage_ids
-        ]
-
-        # ------------------------------------------------------------------
-        # Initialise Model with the declarative Inputs/Outputs API
-        # ------------------------------------------------------------------
-        Inputs = MolvenoModel.Inputs
-        Outputs = MolvenoModel.Outputs
-        super().__init__(
-            "base model",
-            inputs=Inputs(
-                cvs=cvs,
-                pvs=pvs,
-                domain_indexes=domain_indexes,
-                capacities=capacities,
-            ),
-            outputs=Outputs(usage_indexes=[c.usage for c in constraints]),
-        )
-
-        self.cvs = cvs
-        self.pvs = pvs
-        self.domain_indexes = domain_indexes
-        self.capacities = capacities
-        self.constraints = constraints
-
-        # ------------------------------------------------------------------
-        # Attach CVs, PVs, and sub-models as named attributes
-        # ------------------------------------------------------------------
-        self.cv_weekday = cv_weekday
-        self.cv_season = cv_season
-        self.cv_weather = cv_weather
-        self.pv_tourists = pv_tourists
-        self.pv_excursionists = pv_excursionists
-
         self.parking = parking
         self.beach = beach
         self.accommodation = accommodation
         self.food = food
 
-        self.i_p_tourists_reduction_factor = i_p_tourists_reduction_factor
-        self.i_p_excursionists_reduction_factor = i_p_excursionists_reduction_factor
-        self.i_p_tourists_saturation_level = i_p_tourists_saturation_level
-        self.i_p_excursionists_saturation_level = i_p_excursionists_saturation_level
+        domain_indexes = (
+            list(parking.indexes)
+            + list(beach.indexes)
+            + list(accommodation.indexes)
+            + list(food.indexes)
+        )
+
+        return (
+            MolvenoModel.Outputs(usage_indexes=[c.usage for c in self.constraints]),
+            MolvenoModel.Expose(
+                domain_indexes=domain_indexes,
+                i_p_tourists_reduction_factor=i_p_tourists_reduction_factor,
+                i_p_excursionists_reduction_factor=i_p_excursionists_reduction_factor,
+                i_p_tourists_saturation_level=i_p_tourists_saturation_level,
+                i_p_excursionists_saturation_level=i_p_excursionists_saturation_level,
+            ),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1002,7 +969,7 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         sampling_ensemble = CrossProductEnsemble(
             type(scenario)(model),
             max_categorical_size=config.ensemble_size,
-            exclude=model.pvs,
+            exclude=model.inputs.pvs,
         )
         pv_samples = sample_across(
             sampling_ensemble, [model.pv_tourists, model.pv_excursionists], total=self._target_presence_samples
@@ -1039,10 +1006,10 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         """
         model = self._model
         field, field_elements = compute_sustainability_field(model, result)
-        rf_t = float(np.mean(result[model.i_p_tourists_reduction_factor]))
-        sl_t = float(np.mean(result[model.i_p_tourists_saturation_level]))
-        rf_e = float(np.mean(result[model.i_p_excursionists_reduction_factor]))
-        sl_e = float(np.mean(result[model.i_p_excursionists_saturation_level]))
+        rf_t = float(np.mean(result[model.expose.i_p_tourists_reduction_factor]))
+        sl_t = float(np.mean(result[model.expose.i_p_tourists_saturation_level]))
+        rf_e = float(np.mean(result[model.expose.i_p_excursionists_reduction_factor]))
+        sl_e = float(np.mean(result[model.expose.i_p_excursionists_saturation_level]))
         sample_tourists = [_presence_transformation(s, rf_t, sl_t) for s in pv_samples[model.pv_tourists]]
         sample_excursionists = [_presence_transformation(s, rf_e, sl_e) for s in pv_samples[model.pv_excursionists]]
         output = MolvenoOutput(
@@ -1089,7 +1056,7 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         ensemble = CrossProductEnsemble(
             scenario,
             max_categorical_size=config.ensemble_size,
-            exclude=model.pvs,
+            exclude=model.inputs.pvs,
         )
         result = Evaluation(scenario).evaluate(
             ensemble=ensemble,
@@ -1131,7 +1098,7 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         ensemble = CrossProductEnsemble(
             scenario,
             max_categorical_size=config.ensemble_size,
-            exclude=model.pvs,
+            exclude=model.inputs.pvs,
         )
         future = _get_default_executor().submit(
             Evaluation(scenario).evaluate,
@@ -1164,8 +1131,8 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         """
         model = self._model
         schema: dict[str, dict[str, Any]] = {}
-        for cv in model.cvs:
+        for cv in model.inputs.cvs:
             schema[cv.name] = {"type": "categorical", "support": list(cv.support)}
-        for cap in model.capacities:
+        for cap in model.inputs.capacities:
             schema[cap.name] = {"type": "distribution"}
         return schema

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -499,44 +499,52 @@ class MolvenoModel(Model):
 
     def compute(self, inputs: Inputs) -> Outputs:
         """Wire concern sub-models from inputs."""
-        parking = ParkingModel(inputs=ParkingModel.Inputs(  # type: ignore[call-arg]
-            pv_tourists=inputs.pv_tourists,
-            pv_excursionists=inputs.pv_excursionists,
-            cv_weather=inputs.cv_weather,
-            i_u_tourists_parking=inputs.i_u_tourists_parking,
-            i_u_excursionists_parking=inputs.i_u_excursionists_parking,
-            i_xa_tourists_per_vehicle=inputs.i_xa_tourists_per_vehicle,
-            i_xa_excursionists_per_vehicle=inputs.i_xa_excursionists_per_vehicle,
-            i_xo_tourists_parking=inputs.i_xo_tourists_parking,
-            i_xo_excursionists_parking=inputs.i_xo_excursionists_parking,
-            i_c_parking=inputs.i_c_parking,
-        ))
-        beach = BeachModel(inputs=BeachModel.Inputs(  # type: ignore[call-arg]
-            pv_tourists=inputs.pv_tourists,
-            pv_excursionists=inputs.pv_excursionists,
-            cv_weather=inputs.cv_weather,
-            i_u_tourists_beach=inputs.i_u_tourists_beach,
-            i_u_excursionists_beach=inputs.i_u_excursionists_beach,
-            i_xo_tourists_beach=inputs.i_xo_tourists_beach,
-            i_xo_excursionists_beach=inputs.i_xo_excursionists_beach,
-            i_c_beach=inputs.i_c_beach,
-        ))
-        accommodation = AccommodationModel(inputs=AccommodationModel.Inputs(  # type: ignore[call-arg]
-            pv_tourists=inputs.pv_tourists,
-            i_u_tourists_accommodation=inputs.i_u_tourists_accommodation,
-            i_xa_tourists_accommodation=inputs.i_xa_tourists_accommodation,
-            i_c_accommodation=inputs.i_c_accommodation,
-        ))
-        food = FoodModel(inputs=FoodModel.Inputs(  # type: ignore[call-arg]
-            pv_tourists=inputs.pv_tourists,
-            pv_excursionists=inputs.pv_excursionists,
-            cv_weather=inputs.cv_weather,
-            i_u_tourists_food=inputs.i_u_tourists_food,
-            i_u_excursionists_food=inputs.i_u_excursionists_food,
-            i_xa_visitors_food=inputs.i_xa_visitors_food,
-            i_xo_visitors_food=inputs.i_xo_visitors_food,
-            i_c_food=inputs.i_c_food,
-        ))
+        parking = ParkingModel(
+            inputs=ParkingModel.Inputs(  # type: ignore[call-arg]
+                pv_tourists=inputs.pv_tourists,
+                pv_excursionists=inputs.pv_excursionists,
+                cv_weather=inputs.cv_weather,
+                i_u_tourists_parking=inputs.i_u_tourists_parking,
+                i_u_excursionists_parking=inputs.i_u_excursionists_parking,
+                i_xa_tourists_per_vehicle=inputs.i_xa_tourists_per_vehicle,
+                i_xa_excursionists_per_vehicle=inputs.i_xa_excursionists_per_vehicle,
+                i_xo_tourists_parking=inputs.i_xo_tourists_parking,
+                i_xo_excursionists_parking=inputs.i_xo_excursionists_parking,
+                i_c_parking=inputs.i_c_parking,
+            )
+        )
+        beach = BeachModel(
+            inputs=BeachModel.Inputs(  # type: ignore[call-arg]
+                pv_tourists=inputs.pv_tourists,
+                pv_excursionists=inputs.pv_excursionists,
+                cv_weather=inputs.cv_weather,
+                i_u_tourists_beach=inputs.i_u_tourists_beach,
+                i_u_excursionists_beach=inputs.i_u_excursionists_beach,
+                i_xo_tourists_beach=inputs.i_xo_tourists_beach,
+                i_xo_excursionists_beach=inputs.i_xo_excursionists_beach,
+                i_c_beach=inputs.i_c_beach,
+            )
+        )
+        accommodation = AccommodationModel(
+            inputs=AccommodationModel.Inputs(  # type: ignore[call-arg]
+                pv_tourists=inputs.pv_tourists,
+                i_u_tourists_accommodation=inputs.i_u_tourists_accommodation,
+                i_xa_tourists_accommodation=inputs.i_xa_tourists_accommodation,
+                i_c_accommodation=inputs.i_c_accommodation,
+            )
+        )
+        food = FoodModel(
+            inputs=FoodModel.Inputs(  # type: ignore[call-arg]
+                pv_tourists=inputs.pv_tourists,
+                pv_excursionists=inputs.pv_excursionists,
+                cv_weather=inputs.cv_weather,
+                i_u_tourists_food=inputs.i_u_tourists_food,
+                i_u_excursionists_food=inputs.i_u_excursionists_food,
+                i_xa_visitors_food=inputs.i_xa_visitors_food,
+                i_xo_visitors_food=inputs.i_xo_visitors_food,
+                i_c_food=inputs.i_c_food,
+            )
+        )
 
         self.constraints = [
             parking.constraint,
@@ -959,7 +967,9 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
             exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
         )
         pv_samples = sample_across(
-            sampling_ensemble, [model.inputs.pv_tourists, model.inputs.pv_excursionists], total=self._target_presence_samples
+            sampling_ensemble,
+            [model.inputs.pv_tourists, model.inputs.pv_excursionists],
+            total=self._target_presence_samples,
         )
         return tt, ee, pv_samples
 
@@ -998,7 +1008,9 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         rf_e = float(np.mean(result[model.inputs.i_p_excursionists_reduction_factor]))
         sl_e = float(np.mean(result[model.inputs.i_p_excursionists_saturation_level]))
         sample_tourists = [_presence_transformation(s, rf_t, sl_t) for s in pv_samples[model.inputs.pv_tourists]]
-        sample_excursionists = [_presence_transformation(s, rf_e, sl_e) for s in pv_samples[model.inputs.pv_excursionists]]
+        sample_excursionists = [
+            _presence_transformation(s, rf_e, sl_e) for s in pv_samples[model.inputs.pv_excursionists]
+        ]
         output = MolvenoOutput(
             field=field,
             field_elements=field_elements,

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -87,7 +87,6 @@ from civic_digital_twins.dt_model import (
     Index,
     Model,
     define,
-    expose,
     graph,
     inputs,
     outputs,
@@ -353,25 +352,60 @@ class FoodModel(Model):
 class MolvenoModel(Model):
     """Root overtourism model that wires the four concern sub-models.
 
-    Supply the domain parameters via :meth:`default_inputs`, or override
-    individual fields with :func:`dataclasses.replace`::
+    All domain parameters are declared as ``Inputs``; supply defaults via
+    :meth:`default_inputs` or override individual fields with
+    :func:`dataclasses.replace`::
 
         m = MolvenoModel(inputs=MolvenoModel.default_inputs())
         m.inputs.cvs                        # list of CategoricalIndex (weekday, season, weather)
         m.inputs.pvs                        # list of ConditionalDistributionIndex
+        m.inputs.i_u_tourists_parking       # overridable parameter Index
         m.cv_weather                        # named alias set by compute()
-        m.parking.inputs.i_c_parking        # capacity DistributionIndex
         m.parking.outputs.i_u_parking       # usage formula Index
         m.parking.constraint                # Constraint object
     """
 
     @inputs
     class Inputs:
-        """CVs, PVs, and distribution-backed parameters of :class:`MolvenoModel`."""
+        """All domain parameters of :class:`MolvenoModel`."""
 
-        cvs: list[CategoricalIndex]
-        pvs: list[ConditionalDistributionIndex]
-        capacities: list[GenericIndex]
+        # Context variables
+        cv_weekday: CategoricalIndex
+        cv_season: CategoricalIndex
+        cv_weather: CategoricalIndex
+        # Presence distributions
+        pv_tourists: ConditionalDistributionIndex
+        pv_excursionists: ConditionalDistributionIndex
+        # Distribution-backed uncertainty parameters
+        i_c_parking: DistributionIndex
+        i_c_beach: DistributionIndex
+        i_c_accommodation: DistributionIndex
+        i_c_food: DistributionIndex
+        i_xo_tourists_beach: DistributionIndex
+        # Parking parameters
+        i_u_tourists_parking: Index
+        i_u_excursionists_parking: Index
+        i_xa_tourists_per_vehicle: Index
+        i_xa_excursionists_per_vehicle: Index
+        i_xo_tourists_parking: Index
+        i_xo_excursionists_parking: Index
+        # Beach parameters
+        i_u_tourists_beach: Index
+        i_u_excursionists_beach: Index
+        i_xo_excursionists_beach: Index
+        # Accommodation parameters
+        i_u_tourists_accommodation: Index
+        i_xa_tourists_accommodation: Index
+        # Food parameters
+        i_u_tourists_food: Index
+        i_u_excursionists_food: Index
+        i_xa_visitors_food: Index
+        i_xo_visitors_food: Index
+        # Presence-transformation parameters
+        i_p_tourists_reduction_factor: Index
+        i_p_excursionists_reduction_factor: Index
+        i_p_tourists_saturation_level: Index
+        i_p_excursionists_saturation_level: Index
 
     @outputs
     class Outputs:
@@ -379,19 +413,9 @@ class MolvenoModel(Model):
 
         usage_indexes: list[GenericIndex]
 
-    @expose
-    class Expose:
-        """Sub-model formula indexes (for evaluation state) and presence-transformation parameters."""
-
-        domain_indexes: list[GenericIndex]
-        i_p_tourists_reduction_factor: Index
-        i_p_excursionists_reduction_factor: Index
-        i_p_tourists_saturation_level: Index
-        i_p_excursionists_saturation_level: Index
-
     @classmethod
     def default_inputs(cls) -> Inputs:
-        """Return the default domain inputs: CVs, PVs, and distribution-backed parameters.
+        """Return the default domain inputs for all parameters.
 
         Pass to :class:`MolvenoModel` or override individual fields with
         :func:`dataclasses.replace`::
@@ -412,127 +436,106 @@ class MolvenoModel(Model):
             excursionist_presences_stats,
         )
         return cls.Inputs(
-            cvs=[cv_weekday, cv_season, cv_weather],
-            pvs=[pv_tourists, pv_excursionists],
-            capacities=[
-                DistributionIndex("parking capacity", stats.uniform, {"loc": 350.0, "scale": 100.0}),
-                DistributionIndex("beach capacity", stats.uniform, {"loc": 6000.0, "scale": 1000.0}),
-                DistributionIndex(
-                    "accommodation capacity",
-                    stats.lognorm,
-                    {"s": 0.125, "loc": 0.0, "scale": 5000.0},
-                ),
-                DistributionIndex(
-                    "food service capacity",
-                    stats.triang,
-                    {"loc": 3000.0, "scale": 1000.0, "c": 0.5},
-                ),
-                DistributionIndex(
-                    "tourists on beach rotation factor",
-                    stats.uniform,
-                    {"loc": 1.0, "scale": 2.0},
-                ),
-            ],
-        )
-
-    def compute(self, inputs: Inputs) -> tuple[Outputs, Expose]:
-        """Compose concern sub-models from inputs and return usage outputs."""
-        cv_weekday, cv_season, cv_weather = inputs.cvs
-        pv_tourists, pv_excursionists = inputs.pvs
-        i_c_parking, i_c_beach, i_c_accommodation, i_c_food, i_xo_tourists_beach = inputs.capacities
-
-        # Side effects — named attribute access used by evaluators and scenarios.
-        self.cv_weekday = cv_weekday
-        self.cv_season = cv_season
-        self.cv_weather = cv_weather
-        self.pv_tourists = pv_tourists
-        self.pv_excursionists = pv_excursionists
-
-        # ------------------------------------------------------------------
-        # Default i_* parameters
-        # ------------------------------------------------------------------
-
-        # Parking parameters
-        i_u_tourists_parking = Index("tourist parking usage factor", 0.02)
-        i_u_excursionists_parking = Index(
-            "excursionist parking usage factor",
-            graph.piecewise((0.55, cv_weather == "bad"), (0.80, True)),
-        )
-        i_xa_tourists_per_vehicle = Index("tourists per vehicle allocation factor", 2.5)
-        i_xa_excursionists_per_vehicle = Index("excursionists per vehicle allocation factor", 2.5)
-        i_xo_tourists_parking = Index("tourists in parking rotation factor", 1.02)
-        i_xo_excursionists_parking = Index("excursionists in parking rotation factor", 3.5)
-
-        # Beach parameters
-        i_u_tourists_beach = Index(
-            "tourist beach usage factor",
-            graph.piecewise((0.25, cv_weather == "bad"), (0.50, True)),
-        )
-        i_u_excursionists_beach = Index(
-            "excursionist beach usage factor",
-            graph.piecewise((0.35, cv_weather == "bad"), (0.80, True)),
-        )
-        i_xo_excursionists_beach = Index("excursionists on beach rotation factor", 1.02)
-
-        # Accommodation parameters
-        i_u_tourists_accommodation = Index("tourist accommodation usage factor", 0.90)
-        i_xa_tourists_accommodation = Index("tourists per accommodation allocation factor", 1.05)
-
-        # Food parameters
-        i_u_tourists_food = Index("tourist food service usage factor", 0.20)
-        i_u_excursionists_food = Index(
-            "excursionist food service usage factor",
-            graph.piecewise((0.80, cv_weather == "bad"), (0.40, True)),
-        )
-        i_xa_visitors_food = Index("visitors in food service allocation factor", 0.9)
-        i_xo_visitors_food = Index("visitors in food service rotation factor", 2.0)
-
-        # Presence-transformation parameters (used in overtourism_molveno.py)
-        i_p_tourists_reduction_factor = Index("tourists reduction factor", 1.0)
-        i_p_excursionists_reduction_factor = Index("excursionists reduction factor", 1.0)
-        i_p_tourists_saturation_level = Index("tourists saturation level", 10000)
-        i_p_excursionists_saturation_level = Index("excursionists saturation level", 10000)
-
-        # ------------------------------------------------------------------
-        # Concern sub-models
-        # ------------------------------------------------------------------
-        parking = ParkingModel(inputs=ParkingModel.Inputs(  # type: ignore[call-arg]
+            cv_weekday=cv_weekday,
+            cv_season=cv_season,
+            cv_weather=cv_weather,
             pv_tourists=pv_tourists,
             pv_excursionists=pv_excursionists,
-            cv_weather=cv_weather,
-            i_u_tourists_parking=i_u_tourists_parking,
-            i_u_excursionists_parking=i_u_excursionists_parking,
-            i_xa_tourists_per_vehicle=i_xa_tourists_per_vehicle,
-            i_xa_excursionists_per_vehicle=i_xa_excursionists_per_vehicle,
-            i_xo_tourists_parking=i_xo_tourists_parking,
-            i_xo_excursionists_parking=i_xo_excursionists_parking,
-            i_c_parking=i_c_parking,
+            # Distribution-backed uncertainty parameters
+            i_c_parking=DistributionIndex("parking capacity", stats.uniform, {"loc": 350.0, "scale": 100.0}),
+            i_c_beach=DistributionIndex("beach capacity", stats.uniform, {"loc": 6000.0, "scale": 1000.0}),
+            i_c_accommodation=DistributionIndex(
+                "accommodation capacity",
+                stats.lognorm,
+                {"s": 0.125, "loc": 0.0, "scale": 5000.0},
+            ),
+            i_c_food=DistributionIndex(
+                "food service capacity",
+                stats.triang,
+                {"loc": 3000.0, "scale": 1000.0, "c": 0.5},
+            ),
+            i_xo_tourists_beach=DistributionIndex(
+                "tourists on beach rotation factor",
+                stats.uniform,
+                {"loc": 1.0, "scale": 2.0},
+            ),
+            # Parking parameters
+            i_u_tourists_parking=Index("tourist parking usage factor", 0.02),
+            i_u_excursionists_parking=Index(
+                "excursionist parking usage factor",
+                graph.piecewise((0.55, cv_weather == "bad"), (0.80, True)),
+            ),
+            i_xa_tourists_per_vehicle=Index("tourists per vehicle allocation factor", 2.5),
+            i_xa_excursionists_per_vehicle=Index("excursionists per vehicle allocation factor", 2.5),
+            i_xo_tourists_parking=Index("tourists in parking rotation factor", 1.02),
+            i_xo_excursionists_parking=Index("excursionists in parking rotation factor", 3.5),
+            # Beach parameters
+            i_u_tourists_beach=Index(
+                "tourist beach usage factor",
+                graph.piecewise((0.25, cv_weather == "bad"), (0.50, True)),
+            ),
+            i_u_excursionists_beach=Index(
+                "excursionist beach usage factor",
+                graph.piecewise((0.35, cv_weather == "bad"), (0.80, True)),
+            ),
+            i_xo_excursionists_beach=Index("excursionists on beach rotation factor", 1.02),
+            # Accommodation parameters
+            i_u_tourists_accommodation=Index("tourist accommodation usage factor", 0.90),
+            i_xa_tourists_accommodation=Index("tourists per accommodation allocation factor", 1.05),
+            # Food parameters
+            i_u_tourists_food=Index("tourist food service usage factor", 0.20),
+            i_u_excursionists_food=Index(
+                "excursionist food service usage factor",
+                graph.piecewise((0.80, cv_weather == "bad"), (0.40, True)),
+            ),
+            i_xa_visitors_food=Index("visitors in food service allocation factor", 0.9),
+            i_xo_visitors_food=Index("visitors in food service rotation factor", 2.0),
+            # Presence-transformation parameters
+            i_p_tourists_reduction_factor=Index("tourists reduction factor", 1.0),
+            i_p_excursionists_reduction_factor=Index("excursionists reduction factor", 1.0),
+            i_p_tourists_saturation_level=Index("tourists saturation level", 10000),
+            i_p_excursionists_saturation_level=Index("excursionists saturation level", 10000),
+        )
+
+    def compute(self, inputs: Inputs) -> Outputs:
+        """Wire concern sub-models from inputs."""
+        parking = ParkingModel(inputs=ParkingModel.Inputs(  # type: ignore[call-arg]
+            pv_tourists=inputs.pv_tourists,
+            pv_excursionists=inputs.pv_excursionists,
+            cv_weather=inputs.cv_weather,
+            i_u_tourists_parking=inputs.i_u_tourists_parking,
+            i_u_excursionists_parking=inputs.i_u_excursionists_parking,
+            i_xa_tourists_per_vehicle=inputs.i_xa_tourists_per_vehicle,
+            i_xa_excursionists_per_vehicle=inputs.i_xa_excursionists_per_vehicle,
+            i_xo_tourists_parking=inputs.i_xo_tourists_parking,
+            i_xo_excursionists_parking=inputs.i_xo_excursionists_parking,
+            i_c_parking=inputs.i_c_parking,
         ))
         beach = BeachModel(inputs=BeachModel.Inputs(  # type: ignore[call-arg]
-            pv_tourists=pv_tourists,
-            pv_excursionists=pv_excursionists,
-            cv_weather=cv_weather,
-            i_u_tourists_beach=i_u_tourists_beach,
-            i_u_excursionists_beach=i_u_excursionists_beach,
-            i_xo_tourists_beach=i_xo_tourists_beach,
-            i_xo_excursionists_beach=i_xo_excursionists_beach,
-            i_c_beach=i_c_beach,
+            pv_tourists=inputs.pv_tourists,
+            pv_excursionists=inputs.pv_excursionists,
+            cv_weather=inputs.cv_weather,
+            i_u_tourists_beach=inputs.i_u_tourists_beach,
+            i_u_excursionists_beach=inputs.i_u_excursionists_beach,
+            i_xo_tourists_beach=inputs.i_xo_tourists_beach,
+            i_xo_excursionists_beach=inputs.i_xo_excursionists_beach,
+            i_c_beach=inputs.i_c_beach,
         ))
         accommodation = AccommodationModel(inputs=AccommodationModel.Inputs(  # type: ignore[call-arg]
-            pv_tourists=pv_tourists,
-            i_u_tourists_accommodation=i_u_tourists_accommodation,
-            i_xa_tourists_accommodation=i_xa_tourists_accommodation,
-            i_c_accommodation=i_c_accommodation,
+            pv_tourists=inputs.pv_tourists,
+            i_u_tourists_accommodation=inputs.i_u_tourists_accommodation,
+            i_xa_tourists_accommodation=inputs.i_xa_tourists_accommodation,
+            i_c_accommodation=inputs.i_c_accommodation,
         ))
         food = FoodModel(inputs=FoodModel.Inputs(  # type: ignore[call-arg]
-            pv_tourists=pv_tourists,
-            pv_excursionists=pv_excursionists,
-            cv_weather=cv_weather,
-            i_u_tourists_food=i_u_tourists_food,
-            i_u_excursionists_food=i_u_excursionists_food,
-            i_xa_visitors_food=i_xa_visitors_food,
-            i_xo_visitors_food=i_xo_visitors_food,
-            i_c_food=i_c_food,
+            pv_tourists=inputs.pv_tourists,
+            pv_excursionists=inputs.pv_excursionists,
+            cv_weather=inputs.cv_weather,
+            i_u_tourists_food=inputs.i_u_tourists_food,
+            i_u_excursionists_food=inputs.i_u_excursionists_food,
+            i_xa_visitors_food=inputs.i_xa_visitors_food,
+            i_xo_visitors_food=inputs.i_xo_visitors_food,
+            i_c_food=inputs.i_c_food,
         ))
 
         self.constraints = [
@@ -546,23 +549,7 @@ class MolvenoModel(Model):
         self.accommodation = accommodation
         self.food = food
 
-        domain_indexes = (
-            list(parking.indexes)
-            + list(beach.indexes)
-            + list(accommodation.indexes)
-            + list(food.indexes)
-        )
-
-        return (
-            MolvenoModel.Outputs(usage_indexes=[c.usage for c in self.constraints]),
-            MolvenoModel.Expose(
-                domain_indexes=domain_indexes,
-                i_p_tourists_reduction_factor=i_p_tourists_reduction_factor,
-                i_p_excursionists_reduction_factor=i_p_excursionists_reduction_factor,
-                i_p_tourists_saturation_level=i_p_tourists_saturation_level,
-                i_p_excursionists_saturation_level=i_p_excursionists_saturation_level,
-            ),
-        )
+        return MolvenoModel.Outputs(usage_indexes=[c.usage for c in self.constraints])
 
 
 # ---------------------------------------------------------------------------
@@ -771,8 +758,8 @@ def compute_sustainability_field(
     """
     field = np.ones(
         (
-            result.parameter_values[model.pv_tourists].size,
-            result.parameter_values[model.pv_excursionists].size,
+            result.parameter_values[model.inputs.pv_tourists].size,
+            result.parameter_values[model.inputs.pv_excursionists].size,
         )
     )
     field_elements: dict = {}
@@ -969,10 +956,10 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         sampling_ensemble = CrossProductEnsemble(
             type(scenario)(model),
             max_categorical_size=config.ensemble_size,
-            exclude=model.inputs.pvs,
+            exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
         )
         pv_samples = sample_across(
-            sampling_ensemble, [model.pv_tourists, model.pv_excursionists], total=self._target_presence_samples
+            sampling_ensemble, [model.inputs.pv_tourists, model.inputs.pv_excursionists], total=self._target_presence_samples
         )
         return tt, ee, pv_samples
 
@@ -1006,12 +993,12 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         """
         model = self._model
         field, field_elements = compute_sustainability_field(model, result)
-        rf_t = float(np.mean(result[model.expose.i_p_tourists_reduction_factor]))
-        sl_t = float(np.mean(result[model.expose.i_p_tourists_saturation_level]))
-        rf_e = float(np.mean(result[model.expose.i_p_excursionists_reduction_factor]))
-        sl_e = float(np.mean(result[model.expose.i_p_excursionists_saturation_level]))
-        sample_tourists = [_presence_transformation(s, rf_t, sl_t) for s in pv_samples[model.pv_tourists]]
-        sample_excursionists = [_presence_transformation(s, rf_e, sl_e) for s in pv_samples[model.pv_excursionists]]
+        rf_t = float(np.mean(result[model.inputs.i_p_tourists_reduction_factor]))
+        sl_t = float(np.mean(result[model.inputs.i_p_tourists_saturation_level]))
+        rf_e = float(np.mean(result[model.inputs.i_p_excursionists_reduction_factor]))
+        sl_e = float(np.mean(result[model.inputs.i_p_excursionists_saturation_level]))
+        sample_tourists = [_presence_transformation(s, rf_t, sl_t) for s in pv_samples[model.inputs.pv_tourists]]
+        sample_excursionists = [_presence_transformation(s, rf_e, sl_e) for s in pv_samples[model.inputs.pv_excursionists]]
         output = MolvenoOutput(
             field=field,
             field_elements=field_elements,
@@ -1056,11 +1043,11 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         ensemble = CrossProductEnsemble(
             scenario,
             max_categorical_size=config.ensemble_size,
-            exclude=model.inputs.pvs,
+            exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
         )
         result = Evaluation(scenario).evaluate(
             ensemble=ensemble,
-            parameters={model.pv_tourists: tt, model.pv_excursionists: ee},
+            parameters={model.inputs.pv_tourists: tt, model.inputs.pv_excursionists: ee},
         )
         return self._build_output(result, tt, ee, pv_samples)
 
@@ -1098,12 +1085,12 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         ensemble = CrossProductEnsemble(
             scenario,
             max_categorical_size=config.ensemble_size,
-            exclude=model.inputs.pvs,
+            exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
         )
         future = _get_default_executor().submit(
             Evaluation(scenario).evaluate,
             ensemble=ensemble,
-            parameters={model.pv_tourists: tt, model.pv_excursionists: ee},
+            parameters={model.inputs.pv_tourists: tt, model.inputs.pv_excursionists: ee},
         )
 
         def _post(result: EvaluationResult) -> MolvenoOutput:
@@ -1131,8 +1118,9 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         """
         model = self._model
         schema: dict[str, dict[str, Any]] = {}
-        for cv in model.inputs.cvs:
-            schema[cv.name] = {"type": "categorical", "support": list(cv.support)}
-        for cap in model.inputs.capacities:
-            schema[cap.name] = {"type": "distribution"}
+        for idx in model.inputs:
+            if isinstance(idx, CategoricalIndex):
+                schema[idx.name] = {"type": "categorical", "support": list(idx.support)}
+            elif isinstance(idx, DistributionIndex):
+                schema[idx.name] = {"type": "distribution"}
         return schema

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -86,6 +86,7 @@ from civic_digital_twins.dt_model import (
     GenericIndex,
     Index,
     Model,
+    define,
     graph,
     inputs,
     outputs,
@@ -147,6 +148,7 @@ class Constraint:
 # ---------------------------------------------------------------------------
 
 
+@define("Parking")
 class ParkingModel(Model):
     """Concern sub-model — parking usage.
 
@@ -158,29 +160,6 @@ class ParkingModel(Model):
     The usage formula ``i_u_parking`` is the single contractual ``Output``.
     The :class:`~overtourism_molveno.molveno_model.Constraint` is
     stored as a plain instance attribute ``self.constraint``.
-
-    Parameters
-    ----------
-    pv_tourists : ConditionalDistributionIndex
-        Tourist presence (wired from :class:`MolvenoModel`).
-    pv_excursionists : ConditionalDistributionIndex
-        Excursionist presence (wired from :class:`MolvenoModel`).
-    cv_weather : CategoricalIndex
-        Weather context variable (needed for the piecewise usage factor).
-    i_u_tourists_parking : Index
-        Tourist parking usage factor.
-    i_u_excursionists_parking : Index
-        Excursionist parking usage factor (piecewise on weather).
-    i_xa_tourists_per_vehicle : Index
-        Tourists per vehicle allocation factor.
-    i_xa_excursionists_per_vehicle : Index
-        Excursionists per vehicle allocation factor.
-    i_xo_tourists_parking : Index
-        Tourists in parking rotation factor.
-    i_xo_excursionists_parking : Index
-        Excursionists in parking rotation factor.
-    i_c_parking : DistributionIndex
-        Parking capacity (uncertain).
 
     Attributes
     ----------
@@ -209,35 +188,8 @@ class ParkingModel(Model):
 
         i_u_parking: Index
 
-    def __init__(
-        self,
-        pv_tourists: ConditionalDistributionIndex,
-        pv_excursionists: ConditionalDistributionIndex,
-        cv_weather: CategoricalIndex,
-        i_u_tourists_parking: Index,
-        i_u_excursionists_parking: Index,
-        i_xa_tourists_per_vehicle: Index,
-        i_xa_excursionists_per_vehicle: Index,
-        i_xo_tourists_parking: Index,
-        i_xo_excursionists_parking: Index,
-        i_c_parking: DistributionIndex,
-    ) -> None:
-        Inputs = ParkingModel.Inputs
-        Outputs = ParkingModel.Outputs
-
-        inputs = Inputs(
-            pv_tourists=pv_tourists,
-            pv_excursionists=pv_excursionists,
-            cv_weather=cv_weather,
-            i_u_tourists_parking=i_u_tourists_parking,
-            i_u_excursionists_parking=i_u_excursionists_parking,
-            i_xa_tourists_per_vehicle=i_xa_tourists_per_vehicle,
-            i_xa_excursionists_per_vehicle=i_xa_excursionists_per_vehicle,
-            i_xo_tourists_parking=i_xo_tourists_parking,
-            i_xo_excursionists_parking=i_xo_excursionists_parking,
-            i_c_parking=i_c_parking,
-        )
-
+    def compute(self, inputs: Inputs) -> Outputs:
+        """Compute parking usage from inputs."""
         i_u_parking = Index(
             "parking usage",
             inputs.pv_tourists
@@ -247,15 +199,9 @@ class ParkingModel(Model):
             * inputs.i_u_excursionists_parking
             / (inputs.i_xa_excursionists_per_vehicle * inputs.i_xo_excursionists_parking),
         )
-
-        super().__init__(
-            "Parking",
-            inputs=inputs,
-            outputs=Outputs(i_u_parking=i_u_parking),
-        )
-
         # Constraint stored as a plain attribute — not a GenericIndex.
         self.constraint = Constraint(name="parking", usage=i_u_parking, capacity=inputs.i_c_parking)
+        return ParkingModel.Outputs(i_u_parking=i_u_parking)
 
 
 # ---------------------------------------------------------------------------
@@ -263,6 +209,7 @@ class ParkingModel(Model):
 # ---------------------------------------------------------------------------
 
 
+@define("Beach")
 class BeachModel(Model):
     """Concern sub-model — beach usage.
 
@@ -271,25 +218,6 @@ class BeachModel(Model):
     passed in from :class:`MolvenoModel` so it appears in the root
     ``model.indexes`` and is sampled by
     :class:`~dt_model.CrossProductEnsemble`.
-
-    Parameters
-    ----------
-    pv_tourists : ConditionalDistributionIndex
-        Tourist presence (wired from :class:`MolvenoModel`).
-    pv_excursionists : ConditionalDistributionIndex
-        Excursionist presence (wired from :class:`MolvenoModel`).
-    cv_weather : CategoricalIndex
-        Weather context variable (needed for the piecewise usage factors).
-    i_u_tourists_beach : Index
-        Tourist beach usage factor (piecewise on weather).
-    i_u_excursionists_beach : Index
-        Excursionist beach usage factor (piecewise on weather).
-    i_xo_tourists_beach : DistributionIndex
-        Tourists on beach rotation factor (uncertain).
-    i_xo_excursionists_beach : Index
-        Excursionists on beach rotation factor.
-    i_c_beach : DistributionIndex
-        Beach capacity (uncertain).
 
     Attributes
     ----------
@@ -316,45 +244,16 @@ class BeachModel(Model):
 
         i_u_beach: Index
 
-    def __init__(
-        self,
-        pv_tourists: ConditionalDistributionIndex,
-        pv_excursionists: ConditionalDistributionIndex,
-        cv_weather: CategoricalIndex,
-        i_u_tourists_beach: Index,
-        i_u_excursionists_beach: Index,
-        i_xo_tourists_beach: DistributionIndex,
-        i_xo_excursionists_beach: Index,
-        i_c_beach: DistributionIndex,
-    ) -> None:
-        Inputs = BeachModel.Inputs
-        Outputs = BeachModel.Outputs
-
-        inputs = Inputs(
-            pv_tourists=pv_tourists,
-            pv_excursionists=pv_excursionists,
-            cv_weather=cv_weather,
-            i_u_tourists_beach=i_u_tourists_beach,
-            i_u_excursionists_beach=i_u_excursionists_beach,
-            i_xo_tourists_beach=i_xo_tourists_beach,
-            i_xo_excursionists_beach=i_xo_excursionists_beach,
-            i_c_beach=i_c_beach,
-        )
-
+    def compute(self, inputs: Inputs) -> Outputs:
+        """Compute beach usage from inputs."""
         i_u_beach = Index(
             "beach usage",
             inputs.pv_tourists * inputs.i_u_tourists_beach / inputs.i_xo_tourists_beach
             + inputs.pv_excursionists * inputs.i_u_excursionists_beach / inputs.i_xo_excursionists_beach,
         )
-
-        super().__init__(
-            "Beach",
-            inputs=inputs,
-            outputs=Outputs(i_u_beach=i_u_beach),
-        )
-
         # Constraint stored as a plain attribute — not a GenericIndex.
         self.constraint = Constraint(name="beach", usage=i_u_beach, capacity=inputs.i_c_beach)
+        return BeachModel.Outputs(i_u_beach=i_u_beach)
 
 
 # ---------------------------------------------------------------------------
@@ -362,19 +261,9 @@ class BeachModel(Model):
 # ---------------------------------------------------------------------------
 
 
+@define("Accommodation")
 class AccommodationModel(Model):
     """Concern sub-model — accommodation usage.
-
-    Parameters
-    ----------
-    pv_tourists : ConditionalDistributionIndex
-        Tourist presence (wired from :class:`MolvenoModel`).
-    i_u_tourists_accommodation : Index
-        Tourist accommodation usage factor.
-    i_xa_tourists_accommodation : Index
-        Tourists per accommodation allocation factor.
-    i_c_accommodation : DistributionIndex
-        Accommodation capacity (uncertain).
 
     Attributes
     ----------
@@ -397,40 +286,15 @@ class AccommodationModel(Model):
 
         i_u_accommodation: Index
 
-    def __init__(
-        self,
-        pv_tourists: ConditionalDistributionIndex,
-        i_u_tourists_accommodation: Index,
-        i_xa_tourists_accommodation: Index,
-        i_c_accommodation: DistributionIndex,
-    ) -> None:
-        Inputs = AccommodationModel.Inputs
-        Outputs = AccommodationModel.Outputs
-
-        inputs = Inputs(
-            pv_tourists=pv_tourists,
-            i_u_tourists_accommodation=i_u_tourists_accommodation,
-            i_xa_tourists_accommodation=i_xa_tourists_accommodation,
-            i_c_accommodation=i_c_accommodation,
-        )
-
+    def compute(self, inputs: Inputs) -> Outputs:
+        """Compute accommodation usage from inputs."""
         i_u_accommodation = Index(
             "accommodation usage",
             inputs.pv_tourists * inputs.i_u_tourists_accommodation / inputs.i_xa_tourists_accommodation,
         )
-
-        super().__init__(
-            "Accommodation",
-            inputs=inputs,
-            outputs=Outputs(i_u_accommodation=i_u_accommodation),
-        )
-
         # Constraint stored as a plain attribute — not a GenericIndex.
-        self.constraint = Constraint(
-            name="accommodation",
-            usage=i_u_accommodation,
-            capacity=inputs.i_c_accommodation,
-        )
+        self.constraint = Constraint(name="accommodation", usage=i_u_accommodation, capacity=inputs.i_c_accommodation)
+        return AccommodationModel.Outputs(i_u_accommodation=i_u_accommodation)
 
 
 # ---------------------------------------------------------------------------
@@ -438,27 +302,9 @@ class AccommodationModel(Model):
 # ---------------------------------------------------------------------------
 
 
+@define("Food")
 class FoodModel(Model):
     """Concern sub-model — food-service usage.
-
-    Parameters
-    ----------
-    pv_tourists : ConditionalDistributionIndex
-        Tourist presence (wired from :class:`MolvenoModel`).
-    pv_excursionists : ConditionalDistributionIndex
-        Excursionist presence (wired from :class:`MolvenoModel`).
-    cv_weather : CategoricalIndex
-        Weather context variable (needed for the piecewise usage factor).
-    i_u_tourists_food : Index
-        Tourist food-service usage factor.
-    i_u_excursionists_food : Index
-        Excursionist food-service usage factor (piecewise on weather).
-    i_xa_visitors_food : Index
-        Visitors in food-service allocation factor.
-    i_xo_visitors_food : Index
-        Visitors in food-service rotation factor.
-    i_c_food : DistributionIndex
-        Food-service capacity (uncertain).
 
     Attributes
     ----------
@@ -485,45 +331,16 @@ class FoodModel(Model):
 
         i_u_food: Index
 
-    def __init__(
-        self,
-        pv_tourists: ConditionalDistributionIndex,
-        pv_excursionists: ConditionalDistributionIndex,
-        cv_weather: CategoricalIndex,
-        i_u_tourists_food: Index,
-        i_u_excursionists_food: Index,
-        i_xa_visitors_food: Index,
-        i_xo_visitors_food: Index,
-        i_c_food: DistributionIndex,
-    ) -> None:
-        Inputs = FoodModel.Inputs
-        Outputs = FoodModel.Outputs
-
-        inputs = Inputs(
-            pv_tourists=pv_tourists,
-            pv_excursionists=pv_excursionists,
-            cv_weather=cv_weather,
-            i_u_tourists_food=i_u_tourists_food,
-            i_u_excursionists_food=i_u_excursionists_food,
-            i_xa_visitors_food=i_xa_visitors_food,
-            i_xo_visitors_food=i_xo_visitors_food,
-            i_c_food=i_c_food,
-        )
-
+    def compute(self, inputs: Inputs) -> Outputs:
+        """Compute food-service usage from inputs."""
         i_u_food = Index(
             "food usage",
             (inputs.pv_tourists * inputs.i_u_tourists_food + inputs.pv_excursionists * inputs.i_u_excursionists_food)
             / (inputs.i_xa_visitors_food * inputs.i_xo_visitors_food),
         )
-
-        super().__init__(
-            "Food",
-            inputs=inputs,
-            outputs=Outputs(i_u_food=i_u_food),
-        )
-
         # Constraint stored as a plain attribute — not a GenericIndex.
         self.constraint = Constraint(name="food", usage=i_u_food, capacity=inputs.i_c_food)
+        return FoodModel.Outputs(i_u_food=i_u_food)
 
 
 # ---------------------------------------------------------------------------
@@ -531,7 +348,7 @@ class FoodModel(Model):
 # ---------------------------------------------------------------------------
 
 
-class MolvenoModel(Model):
+class MolvenoModel(Model, legacy=True):
     """Root overtourism model that wires the four concern sub-models.
 
     ``MolvenoModel`` owns:
@@ -656,7 +473,7 @@ class MolvenoModel(Model):
         # ------------------------------------------------------------------
         # Stage 2 / 3 — concern sub-models
         # ------------------------------------------------------------------
-        parking = ParkingModel(
+        parking = ParkingModel(inputs=ParkingModel.Inputs(  # type: ignore[call-arg]
             pv_tourists=pv_tourists,
             pv_excursionists=pv_excursionists,
             cv_weather=cv_weather,
@@ -667,8 +484,8 @@ class MolvenoModel(Model):
             i_xo_tourists_parking=i_xo_tourists_parking,
             i_xo_excursionists_parking=i_xo_excursionists_parking,
             i_c_parking=i_c_parking,
-        )
-        beach = BeachModel(
+        ))
+        beach = BeachModel(inputs=BeachModel.Inputs(  # type: ignore[call-arg]
             pv_tourists=pv_tourists,
             pv_excursionists=pv_excursionists,
             cv_weather=cv_weather,
@@ -677,14 +494,14 @@ class MolvenoModel(Model):
             i_xo_tourists_beach=i_xo_tourists_beach,
             i_xo_excursionists_beach=i_xo_excursionists_beach,
             i_c_beach=i_c_beach,
-        )
-        accommodation = AccommodationModel(
+        ))
+        accommodation = AccommodationModel(inputs=AccommodationModel.Inputs(  # type: ignore[call-arg]
             pv_tourists=pv_tourists,
             i_u_tourists_accommodation=i_u_tourists_accommodation,
             i_xa_tourists_accommodation=i_xa_tourists_accommodation,
             i_c_accommodation=i_c_accommodation,
-        )
-        food = FoodModel(
+        ))
+        food = FoodModel(inputs=FoodModel.Inputs(  # type: ignore[call-arg]
             pv_tourists=pv_tourists,
             pv_excursionists=pv_excursionists,
             cv_weather=cv_weather,
@@ -693,7 +510,7 @@ class MolvenoModel(Model):
             i_xa_visitors_food=i_xa_visitors_food,
             i_xo_visitors_food=i_xo_visitors_food,
             i_c_food=i_c_food,
-        )
+        ))
 
         # ------------------------------------------------------------------
         # Collect domain lists consumed by CrossProductEnsemble

--- a/examples/overtourism_molveno/overtourism_molveno.py
+++ b/examples/overtourism_molveno/overtourism_molveno.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     from molveno_model import MolvenoEvaluator, MolvenoModel, MolvenoOutput
 
-model = MolvenoModel()
+model = MolvenoModel(inputs=MolvenoModel.default_inputs())
 
 # PLOTTING
 

--- a/examples/overtourism_molveno/overtourism_molveno.py
+++ b/examples/overtourism_molveno/overtourism_molveno.py
@@ -106,13 +106,13 @@ if __name__ == "__main__":
     plt.close(fig_base)
 
     output_good = evaluator.evaluate(
-        Scenario(model, overrides={model.cv_weather: {"good": 0.5, "unsettled": 0.5}}), config
+        Scenario(model, overrides={model.inputs.cv_weather: {"good": 0.5, "unsettled": 0.5}}), config
     )
     fig_good_weather = plot_scenario(output_good, "Good weather")
     fig_good_weather.savefig(_out / "good_weather.png", dpi=150)
     plt.close(fig_good_weather)
 
-    output_bad = evaluator.evaluate(Scenario(model, overrides={model.cv_weather: "bad"}), config)
+    output_bad = evaluator.evaluate(Scenario(model, overrides={model.inputs.cv_weather: "bad"}), config)
     fig_bad_weather = plot_scenario(output_bad, "Bad weather")
     fig_bad_weather.savefig(_out / "bad_weather.png", dpi=150)
     plt.close(fig_bad_weather)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pytest session configuration."""
+
+import warnings
+
+# Suppress the DeprecationWarning emitted by Model.__init_subclass__ for
+# classes that define __init__ directly.  Test models routinely use the old
+# pattern; tagging each one legacy=True would be mechanical noise.  The filter
+# is scoped to the exact message so that other deprecation warnings (e.g. the
+# @dataclass-for-inputs warning asserted in test_io_contracts.py) are unaffected.
+warnings.filterwarnings(
+    "ignore",
+    message=r".*Use @model with compute\(\).*",
+    category=DeprecationWarning,
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,6 @@ import warnings
 # @dataclass-for-inputs warning asserted in test_io_contracts.py) are unaffected.
 warnings.filterwarnings(
     "ignore",
-    message=r".*Use @model with compute\(\).*",
+    message=r".*Use @define with compute\(\).*",
     category=DeprecationWarning,
 )

--- a/tests/dt_model/examples/test_bologna_runner.py
+++ b/tests/dt_model/examples/test_bologna_runner.py
@@ -30,7 +30,7 @@ _EXPOSE_NAMES = (
 @pytest.fixture(scope="module")
 def model() -> BolognaModel:
     """Shared BolognaModel — graph construction is the expensive part."""
-    return BolognaModel(**BolognaModel.default_inputs())
+    return BolognaModel(inputs=BolognaModel.default_inputs(), fns=BolognaModel.default_fns())
 
 
 @pytest.fixture(scope="module")

--- a/tests/dt_model/examples/test_mobility_bologna.py
+++ b/tests/dt_model/examples/test_mobility_bologna.py
@@ -19,7 +19,7 @@ _ENSEMBLE_SIZE = 5
 @pytest.fixture(scope="module")
 def model() -> BolognaModel:
     """Shared BolognaModel instance (graph construction is the expensive part)."""
-    return BolognaModel(**BolognaModel.default_inputs())
+    return BolognaModel(inputs=BolognaModel.default_inputs(), fns=BolognaModel.default_fns())
 
 
 @pytest.fixture(scope="module")

--- a/tests/dt_model/examples/test_molveno_runner.py
+++ b/tests/dt_model/examples/test_molveno_runner.py
@@ -32,7 +32,7 @@ _ENSEMBLE_SIZE = 3
 @pytest.fixture(scope="module")
 def model() -> MolvenoModel:
     """Shared MolvenoModel instance (graph construction is the expensive part)."""
-    return MolvenoModel()
+    return MolvenoModel(inputs=MolvenoModel.default_inputs())
 
 
 @pytest.fixture(scope="module")
@@ -318,7 +318,7 @@ def test_structure_returns_non_empty_dict(evaluator: MolvenoEvaluator) -> None:
 def test_structure_contains_categorical_cvs(evaluator: MolvenoEvaluator, model: MolvenoModel) -> None:
     """structure() must include all three categorical context variables."""
     schema = evaluator.input_schema()
-    for cv in model.cvs:
+    for cv in model.inputs.cvs:
         assert cv.name in schema, f"Missing CV {cv.name!r} in structure()"
         assert schema[cv.name]["type"] == "categorical"
         assert "support" in schema[cv.name]
@@ -327,7 +327,7 @@ def test_structure_contains_categorical_cvs(evaluator: MolvenoEvaluator, model: 
 def test_structure_contains_capacity_parameters(evaluator: MolvenoEvaluator, model: MolvenoModel) -> None:
     """structure() must include all capacity parameters."""
     schema = evaluator.input_schema()
-    for cap in model.capacities:
+    for cap in model.inputs.capacities:
         assert cap.name in schema, f"Missing capacity {cap.name!r} in structure()"
         assert schema[cap.name]["type"] == "distribution"
 

--- a/tests/dt_model/examples/test_molveno_runner.py
+++ b/tests/dt_model/examples/test_molveno_runner.py
@@ -318,16 +318,22 @@ def test_structure_returns_non_empty_dict(evaluator: MolvenoEvaluator) -> None:
 def test_structure_contains_categorical_cvs(evaluator: MolvenoEvaluator, model: MolvenoModel) -> None:
     """structure() must include all three categorical context variables."""
     schema = evaluator.input_schema()
-    for cv in model.inputs.cvs:
+    for cv in (model.inputs.cv_weekday, model.inputs.cv_season, model.inputs.cv_weather):
         assert cv.name in schema, f"Missing CV {cv.name!r} in structure()"
         assert schema[cv.name]["type"] == "categorical"
         assert "support" in schema[cv.name]
 
 
 def test_structure_contains_capacity_parameters(evaluator: MolvenoEvaluator, model: MolvenoModel) -> None:
-    """structure() must include all capacity parameters."""
+    """structure() must include all distribution-backed parameters."""
     schema = evaluator.input_schema()
-    for cap in model.inputs.capacities:
+    for cap in (
+        model.inputs.i_c_parking,
+        model.inputs.i_c_beach,
+        model.inputs.i_c_accommodation,
+        model.inputs.i_c_food,
+        model.inputs.i_xo_tourists_beach,
+    ):
         assert cap.name in schema, f"Missing capacity {cap.name!r} in structure()"
         assert schema[cap.name]["type"] == "distribution"
 
@@ -343,7 +349,7 @@ def test_evaluate_with_str_override(
     config: EvaluationConfig,
 ) -> None:
     """evaluate() must work with a str override on a CategoricalIndex."""
-    scenario = Scenario(model, overrides={model.cv_weather: "good"})
+    scenario = Scenario(model, overrides={model.inputs.cv_weather: "good"})
     out = evaluator.evaluate(scenario, config)
     assert isinstance(out, MolvenoOutput)
     assert out.field.shape == (_T_SAMPLE + 1, _E_SAMPLE + 1)
@@ -355,7 +361,7 @@ def test_evaluate_with_dict_override(
     config: EvaluationConfig,
 ) -> None:
     """evaluate() must work with a dict override on a CategoricalIndex."""
-    scenario = Scenario(model, overrides={model.cv_weather: {"good": 0.7, "unsettled": 0.3}})
+    scenario = Scenario(model, overrides={model.inputs.cv_weather: {"good": 0.7, "unsettled": 0.3}})
     out = evaluator.evaluate(scenario, config)
     assert isinstance(out, MolvenoOutput)
     assert out.field.shape == (_T_SAMPLE + 1, _E_SAMPLE + 1)

--- a/tests/dt_model/examples/test_overtourism_molveno.py
+++ b/tests/dt_model/examples/test_overtourism_molveno.py
@@ -24,7 +24,7 @@ from civic_digital_twins.dt_model import (
 )
 from civic_digital_twins.dt_model.model.index import Distribution, DistributionIndex, GenericIndex, Index
 
-model = MolvenoModel()
+model = MolvenoModel(inputs=MolvenoModel.default_inputs())
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -128,7 +128,7 @@ def good_weather_scenarios():
             model.cv_season: ["high"],
             model.cv_weather: ["good"],
         },
-        exclude=model.pvs,
+        exclude=model.inputs.pvs,
     )
 
 
@@ -175,7 +175,7 @@ def test_evaluate_axes_high_presence_is_unsustainable(good_weather_scenarios):
 def test_ensemble_based_evaluation(tourists, excursionists):
     """CrossProductEnsemble-based evaluation produces a valid sustainability field."""
     scenario: dict[CategoricalIndex, list[str]] = {model.cv_weather: ["good", "bad"]}
-    ensemble = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=5, exclude=model.pvs)
+    ensemble = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=5, exclude=model.inputs.pvs)
 
     field, field_elements, _ = compute_field(model, ensemble, tourists, excursionists)
 
@@ -205,7 +205,7 @@ def test_fixed_ensemble():
             model.cv_season: ["high"],
             model.cv_weather: ["good"],
         },
-        exclude=model.pvs,
+        exclude=model.inputs.pvs,
         rng=np.random.default_rng(4),
     )
     _, got, _ = compute_field(model, ensemble, tourists, excursionists)
@@ -228,8 +228,8 @@ def test_fixed_ensemble():
                 [1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
                 [1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
                 [1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
-                [1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
-                [1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 0.82080114, 0.0, 0.0, 0.0],
+                [1.0, 0.91611209, 0.0, 0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             ]
         ),
@@ -265,7 +265,7 @@ def test_fixed_ensemble():
 def test_multiple_ensemble_members():
     """Test with multiple ensemble members to catch shape issues."""
     scenario: dict[CategoricalIndex, list[str]] = {model.cv_weather: ["good", "bad"]}
-    ens = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=10, exclude=model.pvs)
+    ens = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=10, exclude=model.inputs.pvs)
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])
 
@@ -283,7 +283,7 @@ def test_multiple_ensemble_members():
 
 def test_molveno_model_has_four_sub_models():
     """MolvenoModel exposes all four concern sub-models as named attributes."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert isinstance(m.parking, ParkingModel)
     assert isinstance(m.beach, BeachModel)
     assert isinstance(m.accommodation, AccommodationModel)
@@ -292,7 +292,7 @@ def test_molveno_model_has_four_sub_models():
 
 def test_molveno_model_exposes_pvs():
     """MolvenoModel exposes pv_tourists and pv_excursionists as attributes."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert isinstance(m.pv_tourists, ConditionalDistributionIndex)
     assert isinstance(m.pv_excursionists, ConditionalDistributionIndex)
     assert m.pv_tourists.name == "tourists"
@@ -301,7 +301,7 @@ def test_molveno_model_exposes_pvs():
 
 def test_molveno_model_exposes_context_variables():
     """MolvenoModel exposes the three context variables as attributes."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert isinstance(m.cv_weekday, CategoricalIndex)
     assert isinstance(m.cv_season, CategoricalIndex)
     assert isinstance(m.cv_weather, CategoricalIndex)
@@ -312,7 +312,7 @@ def test_molveno_model_exposes_context_variables():
 
 def test_cv_probabilities_sum_to_one():
     """Each CategoricalIndex CV has outcomes summing to 1.0."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     for cv in (m.cv_weekday, m.cv_season, m.cv_weather):
         total = sum(cv.outcomes.values())
         assert abs(total - 1.0) < 1e-9, f"{cv.name}: outcomes sum to {total}"
@@ -320,7 +320,7 @@ def test_cv_probabilities_sum_to_one():
 
 def test_parking_model_inputs_wired_from_root():
     """ParkingModel presence inputs are the same objects as MolvenoModel attributes."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert m.parking.inputs.pv_tourists is m.pv_tourists
     assert m.parking.inputs.pv_excursionists is m.pv_excursionists
     assert m.parking.inputs.cv_weather is m.cv_weather
@@ -328,7 +328,7 @@ def test_parking_model_inputs_wired_from_root():
 
 def test_beach_model_inputs_wired_from_root():
     """BeachModel presence inputs are the same objects as MolvenoModel attributes."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert m.beach.inputs.pv_tourists is m.pv_tourists
     assert m.beach.inputs.pv_excursionists is m.pv_excursionists
     assert m.beach.inputs.cv_weather is m.cv_weather
@@ -336,13 +336,13 @@ def test_beach_model_inputs_wired_from_root():
 
 def test_accommodation_model_inputs_wired_from_root():
     """AccommodationModel.inputs.pv_tourists is the same object as MolvenoModel attribute."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert m.accommodation.inputs.pv_tourists is m.pv_tourists
 
 
 def test_food_model_inputs_wired_from_root():
     """FoodModel presence inputs are the same objects as MolvenoModel attributes."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert m.food.inputs.pv_tourists is m.pv_tourists
     assert m.food.inputs.pv_excursionists is m.pv_excursionists
     assert m.food.inputs.cv_weather is m.cv_weather
@@ -350,7 +350,7 @@ def test_food_model_inputs_wired_from_root():
 
 def test_concern_model_outputs_are_generic_indexes_only():
     """Outputs dataclasses contain only GenericIndex instances (no Constraint)."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     for submodel in (m.parking, m.beach, m.accommodation, m.food):
         for idx in submodel.outputs:
             assert isinstance(idx, GenericIndex), (
@@ -360,7 +360,7 @@ def test_concern_model_outputs_are_generic_indexes_only():
 
 def test_concern_model_inputs_include_all_i_parameters():
     """All i_* parameters are Inputs to the concern sub-model that uses them."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
 
     # Parking: 7 i_* params + 3 presence/cv inputs
     assert isinstance(m.parking.inputs.i_u_tourists_parking, Index)
@@ -393,21 +393,21 @@ def test_concern_model_inputs_include_all_i_parameters():
 
 def test_concern_models_have_no_expose():
     """Concern sub-models have no Expose — no internal uncertain parameters."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     for submodel in (m.parking, m.beach, m.accommodation, m.food):
         assert len(submodel.expose) == 0, f"{type(submodel).__name__}.expose is not empty: {submodel.expose}"
 
 
 def test_concern_model_constraint_is_plain_attribute():
     """Each concern sub-model exposes its Constraint as a plain instance attribute."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     for submodel in (m.parking, m.beach, m.accommodation, m.food):
         assert isinstance(submodel.constraint, Constraint), f"{type(submodel).__name__}.constraint is not a Constraint"
 
 
 def test_parking_outputs_index_types():
     """ParkingModel.outputs contains only the usage formula index."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert isinstance(m.parking.outputs.i_u_parking, Index)
     assert len(m.parking.outputs) == 1
     assert m.parking.constraint.name == "parking"
@@ -415,7 +415,7 @@ def test_parking_outputs_index_types():
 
 def test_beach_outputs_index_types():
     """BeachModel.outputs contains only the usage formula index."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert isinstance(m.beach.outputs.i_u_beach, Index)
     assert len(m.beach.outputs) == 1
     assert m.beach.constraint.name == "beach"
@@ -423,7 +423,7 @@ def test_beach_outputs_index_types():
 
 def test_accommodation_outputs_index_types():
     """AccommodationModel.outputs contains only the usage formula index."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert isinstance(m.accommodation.outputs.i_u_accommodation, Index)
     assert len(m.accommodation.outputs) == 1
     assert m.accommodation.constraint.name == "accommodation"
@@ -431,7 +431,7 @@ def test_accommodation_outputs_index_types():
 
 def test_food_outputs_index_types():
     """FoodModel.outputs contains only the usage formula index."""
-    m = MolvenoModel()
+    m = MolvenoModel(inputs=MolvenoModel.default_inputs())
     assert isinstance(m.food.outputs.i_u_food, Index)
     assert len(m.food.outputs) == 1
     assert m.food.constraint.name == "food"
@@ -447,7 +447,7 @@ def test_molveno_model_construction_is_warning_free():
     with warnings.catch_warnings():
         warnings.simplefilter("error", ModelContractWarning)
         warnings.simplefilter("error", DeprecationWarning)
-        MolvenoModel()
+        MolvenoModel(inputs=MolvenoModel.default_inputs())
 
 
 # ---------------------------------------------------------------------------
@@ -518,8 +518,8 @@ def test_beach_rotation_factor_is_abstract():
 
 def test_molveno_model_cvs_list():
     """model.cvs contains exactly the three context variables."""
-    assert len(model.cvs) == 3
-    cv_ids = {id(cv) for cv in model.cvs}
+    assert len(model.inputs.cvs) == 3
+    cv_ids = {id(cv) for cv in model.inputs.cvs}
     assert id(model.cv_weekday) in cv_ids
     assert id(model.cv_season) in cv_ids
     assert id(model.cv_weather) in cv_ids
@@ -527,8 +527,8 @@ def test_molveno_model_cvs_list():
 
 def test_molveno_model_pvs_list():
     """model.pvs contains exactly the two presence variables."""
-    assert len(model.pvs) == 2
-    pv_ids = {id(pv) for pv in model.pvs}
+    assert len(model.inputs.pvs) == 2
+    pv_ids = {id(pv) for pv in model.inputs.pvs}
     assert id(model.pv_tourists) in pv_ids
     assert id(model.pv_excursionists) in pv_ids
 
@@ -556,10 +556,10 @@ def test_molveno_model_constraints_match_sub_model_attributes():
 def test_presence_transformation_indexes_in_root_indexes():
     """The four presence-transformation indexes appear in model.indexes."""
     pt_ids = {
-        id(model.i_p_tourists_reduction_factor),
-        id(model.i_p_excursionists_reduction_factor),
-        id(model.i_p_tourists_saturation_level),
-        id(model.i_p_excursionists_saturation_level),
+        id(model.expose.i_p_tourists_reduction_factor),
+        id(model.expose.i_p_excursionists_reduction_factor),
+        id(model.expose.i_p_tourists_saturation_level),
+        id(model.expose.i_p_excursionists_saturation_level),
     }
     root_ids = {id(idx) for idx in model.indexes}
     assert pt_ids <= root_ids
@@ -571,7 +571,7 @@ def test_presence_transformation_indexes_in_root_indexes():
 def test_bug_37():
     """Regression for https://github.com/fbk-most/dt-model/issues/37."""
     situation: dict[CategoricalIndex, list[str]] = {model.cv_weather: ["good", "unsettled", "bad"]}
-    ensemble = CrossProductEnsemble(model, restrictions=situation, max_categorical_size=20, exclude=model.pvs)
+    ensemble = CrossProductEnsemble(model, restrictions=situation, max_categorical_size=20, exclude=model.inputs.pvs)
 
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])

--- a/tests/dt_model/examples/test_overtourism_molveno.py
+++ b/tests/dt_model/examples/test_overtourism_molveno.py
@@ -175,7 +175,12 @@ def test_evaluate_axes_high_presence_is_unsustainable(good_weather_scenarios):
 def test_ensemble_based_evaluation(tourists, excursionists):
     """CrossProductEnsemble-based evaluation produces a valid sustainability field."""
     scenario: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "bad"]}
-    ensemble = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=5, exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists])
+    ensemble = CrossProductEnsemble(
+        model,
+        restrictions=scenario,
+        max_categorical_size=5,
+        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
+    )
 
     field, field_elements, _ = compute_field(model, ensemble, tourists, excursionists)
 
@@ -265,7 +270,12 @@ def test_fixed_ensemble():
 def test_multiple_ensemble_members():
     """Test with multiple ensemble members to catch shape issues."""
     scenario: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "bad"]}
-    ens = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=10, exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists])
+    ens = CrossProductEnsemble(
+        model,
+        restrictions=scenario,
+        max_categorical_size=10,
+        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
+    )
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])
 
@@ -572,7 +582,12 @@ def test_presence_transformation_indexes_in_root_indexes():
 def test_bug_37():
     """Regression for https://github.com/fbk-most/dt-model/issues/37."""
     situation: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "unsettled", "bad"]}
-    ensemble = CrossProductEnsemble(model, restrictions=situation, max_categorical_size=20, exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists])
+    ensemble = CrossProductEnsemble(
+        model,
+        restrictions=situation,
+        max_categorical_size=20,
+        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
+    )
 
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])

--- a/tests/dt_model/examples/test_overtourism_molveno.py
+++ b/tests/dt_model/examples/test_overtourism_molveno.py
@@ -40,7 +40,7 @@ def compute_field(model, ensemble, tt, ee):
     - ``result`` is the :class:`~dt_model.simulation.evaluation.EvaluationResult`
     """
     result = Evaluation(model).evaluate(
-        ensemble=ensemble, parameters={model.pv_tourists: tt, model.pv_excursionists: ee}
+        ensemble=ensemble, parameters={model.inputs.pv_tourists: tt, model.inputs.pv_excursionists: ee}
     )
 
     field = np.ones((tt.size, ee.size))
@@ -124,11 +124,11 @@ def good_weather_scenarios():
     return CrossProductEnsemble(
         model,
         restrictions={
-            model.cv_weekday: ["monday"],
-            model.cv_season: ["high"],
-            model.cv_weather: ["good"],
+            model.inputs.cv_weekday: ["monday"],
+            model.inputs.cv_season: ["high"],
+            model.inputs.cv_weather: ["good"],
         },
-        exclude=model.inputs.pvs,
+        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
     )
 
 
@@ -174,8 +174,8 @@ def test_evaluate_axes_high_presence_is_unsustainable(good_weather_scenarios):
 
 def test_ensemble_based_evaluation(tourists, excursionists):
     """CrossProductEnsemble-based evaluation produces a valid sustainability field."""
-    scenario: dict[CategoricalIndex, list[str]] = {model.cv_weather: ["good", "bad"]}
-    ensemble = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=5, exclude=model.inputs.pvs)
+    scenario: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "bad"]}
+    ensemble = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=5, exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists])
 
     field, field_elements, _ = compute_field(model, ensemble, tourists, excursionists)
 
@@ -201,11 +201,11 @@ def test_fixed_ensemble():
     ensemble = CrossProductEnsemble(
         model,
         restrictions={
-            model.cv_weekday: ["monday"],
-            model.cv_season: ["high"],
-            model.cv_weather: ["good"],
+            model.inputs.cv_weekday: ["monday"],
+            model.inputs.cv_season: ["high"],
+            model.inputs.cv_weather: ["good"],
         },
-        exclude=model.inputs.pvs,
+        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
         rng=np.random.default_rng(4),
     )
     _, got, _ = compute_field(model, ensemble, tourists, excursionists)
@@ -264,8 +264,8 @@ def test_fixed_ensemble():
 
 def test_multiple_ensemble_members():
     """Test with multiple ensemble members to catch shape issues."""
-    scenario: dict[CategoricalIndex, list[str]] = {model.cv_weather: ["good", "bad"]}
-    ens = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=10, exclude=model.inputs.pvs)
+    scenario: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "bad"]}
+    ens = CrossProductEnsemble(model, restrictions=scenario, max_categorical_size=10, exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists])
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])
 
@@ -293,27 +293,27 @@ def test_molveno_model_has_four_sub_models():
 def test_molveno_model_exposes_pvs():
     """MolvenoModel exposes pv_tourists and pv_excursionists as attributes."""
     m = MolvenoModel(inputs=MolvenoModel.default_inputs())
-    assert isinstance(m.pv_tourists, ConditionalDistributionIndex)
-    assert isinstance(m.pv_excursionists, ConditionalDistributionIndex)
-    assert m.pv_tourists.name == "tourists"
-    assert m.pv_excursionists.name == "excursionists"
+    assert isinstance(m.inputs.pv_tourists, ConditionalDistributionIndex)
+    assert isinstance(m.inputs.pv_excursionists, ConditionalDistributionIndex)
+    assert m.inputs.pv_tourists.name == "tourists"
+    assert m.inputs.pv_excursionists.name == "excursionists"
 
 
 def test_molveno_model_exposes_context_variables():
     """MolvenoModel exposes the three context variables as attributes."""
     m = MolvenoModel(inputs=MolvenoModel.default_inputs())
-    assert isinstance(m.cv_weekday, CategoricalIndex)
-    assert isinstance(m.cv_season, CategoricalIndex)
-    assert isinstance(m.cv_weather, CategoricalIndex)
-    assert m.cv_weekday.name == "weekday"
-    assert m.cv_season.name == "season"
-    assert m.cv_weather.name == "weather"
+    assert isinstance(m.inputs.cv_weekday, CategoricalIndex)
+    assert isinstance(m.inputs.cv_season, CategoricalIndex)
+    assert isinstance(m.inputs.cv_weather, CategoricalIndex)
+    assert m.inputs.cv_weekday.name == "weekday"
+    assert m.inputs.cv_season.name == "season"
+    assert m.inputs.cv_weather.name == "weather"
 
 
 def test_cv_probabilities_sum_to_one():
     """Each CategoricalIndex CV has outcomes summing to 1.0."""
     m = MolvenoModel(inputs=MolvenoModel.default_inputs())
-    for cv in (m.cv_weekday, m.cv_season, m.cv_weather):
+    for cv in (m.inputs.cv_weekday, m.inputs.cv_season, m.inputs.cv_weather):
         total = sum(cv.outcomes.values())
         assert abs(total - 1.0) < 1e-9, f"{cv.name}: outcomes sum to {total}"
 
@@ -321,31 +321,31 @@ def test_cv_probabilities_sum_to_one():
 def test_parking_model_inputs_wired_from_root():
     """ParkingModel presence inputs are the same objects as MolvenoModel attributes."""
     m = MolvenoModel(inputs=MolvenoModel.default_inputs())
-    assert m.parking.inputs.pv_tourists is m.pv_tourists
-    assert m.parking.inputs.pv_excursionists is m.pv_excursionists
-    assert m.parking.inputs.cv_weather is m.cv_weather
+    assert m.parking.inputs.pv_tourists is m.inputs.pv_tourists
+    assert m.parking.inputs.pv_excursionists is m.inputs.pv_excursionists
+    assert m.parking.inputs.cv_weather is m.inputs.cv_weather
 
 
 def test_beach_model_inputs_wired_from_root():
     """BeachModel presence inputs are the same objects as MolvenoModel attributes."""
     m = MolvenoModel(inputs=MolvenoModel.default_inputs())
-    assert m.beach.inputs.pv_tourists is m.pv_tourists
-    assert m.beach.inputs.pv_excursionists is m.pv_excursionists
-    assert m.beach.inputs.cv_weather is m.cv_weather
+    assert m.beach.inputs.pv_tourists is m.inputs.pv_tourists
+    assert m.beach.inputs.pv_excursionists is m.inputs.pv_excursionists
+    assert m.beach.inputs.cv_weather is m.inputs.cv_weather
 
 
 def test_accommodation_model_inputs_wired_from_root():
     """AccommodationModel.inputs.pv_tourists is the same object as MolvenoModel attribute."""
     m = MolvenoModel(inputs=MolvenoModel.default_inputs())
-    assert m.accommodation.inputs.pv_tourists is m.pv_tourists
+    assert m.accommodation.inputs.pv_tourists is m.inputs.pv_tourists
 
 
 def test_food_model_inputs_wired_from_root():
     """FoodModel presence inputs are the same objects as MolvenoModel attributes."""
     m = MolvenoModel(inputs=MolvenoModel.default_inputs())
-    assert m.food.inputs.pv_tourists is m.pv_tourists
-    assert m.food.inputs.pv_excursionists is m.pv_excursionists
-    assert m.food.inputs.cv_weather is m.cv_weather
+    assert m.food.inputs.pv_tourists is m.inputs.pv_tourists
+    assert m.food.inputs.pv_excursionists is m.inputs.pv_excursionists
+    assert m.food.inputs.cv_weather is m.inputs.cv_weather
 
 
 def test_concern_model_outputs_are_generic_indexes_only():
@@ -457,14 +457,14 @@ def test_molveno_model_construction_is_warning_free():
 
 def test_presence_cvs_in_root_indexes():
     """All three context variables appear in model.indexes."""
-    cv_ids = {id(model.cv_weekday), id(model.cv_season), id(model.cv_weather)}
+    cv_ids = {id(model.inputs.cv_weekday), id(model.inputs.cv_season), id(model.inputs.cv_weather)}
     root_ids = {id(idx) for idx in model.indexes}
     assert cv_ids <= root_ids
 
 
 def test_presence_pvs_in_root_indexes():
     """Both presence variables appear in model.indexes."""
-    pv_ids = {id(model.pv_tourists), id(model.pv_excursionists)}
+    pv_ids = {id(model.inputs.pv_tourists), id(model.inputs.pv_excursionists)}
     root_ids = {id(idx) for idx in model.indexes}
     assert pv_ids <= root_ids
 
@@ -517,20 +517,21 @@ def test_beach_rotation_factor_is_abstract():
 
 
 def test_molveno_model_cvs_list():
-    """model.cvs contains exactly the three context variables."""
-    assert len(model.inputs.cvs) == 3
-    cv_ids = {id(cv) for cv in model.inputs.cvs}
-    assert id(model.cv_weekday) in cv_ids
-    assert id(model.cv_season) in cv_ids
-    assert id(model.cv_weather) in cv_ids
+    """model.Inputs declares the three named context variables."""
+    assert isinstance(model.inputs.cv_weekday, CategoricalIndex)
+    assert isinstance(model.inputs.cv_season, CategoricalIndex)
+    assert isinstance(model.inputs.cv_weather, CategoricalIndex)
+    assert model.inputs.cv_weekday.name == "weekday"
+    assert model.inputs.cv_season.name == "season"
+    assert model.inputs.cv_weather.name == "weather"
 
 
 def test_molveno_model_pvs_list():
-    """model.pvs contains exactly the two presence variables."""
-    assert len(model.inputs.pvs) == 2
-    pv_ids = {id(pv) for pv in model.inputs.pvs}
-    assert id(model.pv_tourists) in pv_ids
-    assert id(model.pv_excursionists) in pv_ids
+    """model.Inputs declares the two named presence variables."""
+    assert isinstance(model.inputs.pv_tourists, ConditionalDistributionIndex)
+    assert isinstance(model.inputs.pv_excursionists, ConditionalDistributionIndex)
+    assert model.inputs.pv_tourists.name == "tourists"
+    assert model.inputs.pv_excursionists.name == "excursionists"
 
 
 def test_molveno_model_constraints_list():
@@ -556,10 +557,10 @@ def test_molveno_model_constraints_match_sub_model_attributes():
 def test_presence_transformation_indexes_in_root_indexes():
     """The four presence-transformation indexes appear in model.indexes."""
     pt_ids = {
-        id(model.expose.i_p_tourists_reduction_factor),
-        id(model.expose.i_p_excursionists_reduction_factor),
-        id(model.expose.i_p_tourists_saturation_level),
-        id(model.expose.i_p_excursionists_saturation_level),
+        id(model.inputs.i_p_tourists_reduction_factor),
+        id(model.inputs.i_p_excursionists_reduction_factor),
+        id(model.inputs.i_p_tourists_saturation_level),
+        id(model.inputs.i_p_excursionists_saturation_level),
     }
     root_ids = {id(idx) for idx in model.indexes}
     assert pt_ids <= root_ids
@@ -570,8 +571,8 @@ def test_presence_transformation_indexes_in_root_indexes():
 
 def test_bug_37():
     """Regression for https://github.com/fbk-most/dt-model/issues/37."""
-    situation: dict[CategoricalIndex, list[str]] = {model.cv_weather: ["good", "unsettled", "bad"]}
-    ensemble = CrossProductEnsemble(model, restrictions=situation, max_categorical_size=20, exclude=model.inputs.pvs)
+    situation: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "unsettled", "bad"]}
+    ensemble = CrossProductEnsemble(model, restrictions=situation, max_categorical_size=20, exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists])
 
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])

--- a/tests/dt_model/model/test_define.py
+++ b/tests/dt_model/model/test_define.py
@@ -1,0 +1,149 @@
+"""Tests for the @define decorator."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import pytest
+
+from civic_digital_twins.dt_model import NumpyBackend, define, expose, functions, inputs, outputs
+from civic_digital_twins.dt_model.model.index import Index
+from civic_digital_twins.dt_model.model.model import Model
+from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
+
+# ---------------------------------------------------------------------------
+# Decoration-time error checks
+# ---------------------------------------------------------------------------
+
+
+def test_define_raises_if_compute_absent():
+    """@define raises TypeError at decoration time when compute() is missing."""
+    with pytest.raises(TypeError, match="requires.*compute"):
+
+        @define("M")
+        class M(Model):
+            @inputs
+            class Inputs:
+                x: Index
+
+            @outputs
+            class Outputs:
+                y: Index
+
+
+def test_define_raises_if_init_defined():
+    """@define raises TypeError when the class also defines __init__."""
+    with pytest.raises(TypeError, match="must not define __init__"):
+
+        @define("M")
+        class M(Model, legacy=True):  # legacy=True suppresses __init_subclass__ warning
+            @inputs
+            class Inputs:
+                x: Index
+
+            @outputs
+            class Outputs:
+                y: Index
+
+            def __init__(self) -> None:  # noqa: D107
+                pass
+
+            def compute(self, inputs: Inputs) -> Outputs:
+                """Return a dummy output."""
+                return M.Outputs(y=Index("y", 1.0))
+
+
+def test_define_raises_if_expose_declared_but_missing_from_return():
+    """@define raises TypeError when @expose Expose is declared but compute returns only Outputs."""
+    with pytest.raises(TypeError, match="declares an @expose Expose inner class"):
+
+        @define("M")
+        class M(Model):
+            @inputs
+            class Inputs:
+                x: Index
+
+            @outputs
+            class Outputs:
+                y: Index
+
+            @expose
+            class Expose:
+                z: Index
+
+            def compute(self, inputs: Inputs) -> Outputs:  # missing Expose in return
+                """Return a dummy output."""
+                return M.Outputs(y=Index("y", 1.0))
+
+
+def test_define_get_type_hints_fallback():
+    """@define falls back to raw __annotations__ when get_type_hints() fails."""
+    # Use a string annotation that cannot be resolved to trigger the except branch.
+    # The decorator should still succeed (falling back to raw annotations, which
+    # yields no 'return' hint), so no Expose-consistency error fires either.
+    @define("M")
+    class M(Model):
+        @inputs
+        class Inputs:
+            x: Index
+
+        @outputs
+        class Outputs:
+            y: Index
+
+        def compute(self, inputs: Inputs) -> "NonExistentType":  # type: ignore[name-defined]  # noqa: F821
+            """Return a dummy output — annotation is deliberately unresolvable."""
+            return M.Outputs(y=Index("y", 1.0))
+
+    # The class was decorated successfully; instantiate to confirm.
+    x = Index("x", 1.0)
+    m = M(inputs=M.Inputs(x=x))  # type: ignore[call-arg]
+    assert m.outputs.y is not None
+
+
+# ---------------------------------------------------------------------------
+# Generated __init__ paths
+# ---------------------------------------------------------------------------
+
+
+def test_define_with_functions_and_expose():
+    """Generated _init_with_fns dispatches correctly when returns_expose=True."""
+    p_x = __import__("civic_digital_twins.dt_model.engine.frontend.graph", fromlist=["placeholder"]).placeholder(
+        "x", default_value=3.0
+    )
+    fc = __import__("civic_digital_twins.dt_model.engine.frontend.graph", fromlist=["function_call"]).function_call(
+        "double", p_x
+    )
+
+    x_idx = Index("x", p_x)
+    y_idx = Index("y", fc)
+    z_idx = Index("z", 1.0)
+
+    @define("M")
+    class M(Model):
+        @inputs
+        class Inputs:
+            x: Index
+
+        @functions
+        class Functions:
+            double: Any
+
+        @outputs
+        class Outputs:
+            y: Index
+
+        @expose
+        class Expose:
+            z: Index
+
+        def compute(self, inputs: Inputs, *, fns: Functions) -> tuple[Outputs, Expose]:
+            """Compute y via function_call, expose z."""
+            return M.Outputs(y=y_idx), M.Expose(z=z_idx)
+
+    functor = NumpyBackend.adapt(lambda x: x * 2)
+    m = M(inputs=M.Inputs(x=x_idx), fns=M.Functions(double=functor))  # type: ignore[call-arg]
+
+    result = Evaluation(m).evaluate(backend=NumpyBackend)
+    assert float(result[y_idx]) == pytest.approx(6.0)
+    assert m.expose.z is z_idx

--- a/tests/dt_model/model/test_define.py
+++ b/tests/dt_model/model/test_define.py
@@ -148,3 +148,49 @@ def test_define_with_functions_and_expose():
     result = Evaluation(m).evaluate(backend=NumpyBackend)
     assert float(result[y_idx]) == pytest.approx(6.0)
     assert m.expose.z is z_idx
+
+
+def test_define_empty_inputs_no_functions():
+    """@define auto-constructs Inputs() when Inputs has no fields and no Functions."""
+
+    @define("M")
+    class M(Model):
+        @inputs
+        class Inputs:
+            pass
+
+        @outputs
+        class Outputs:
+            y: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            """Return a constant output."""
+            return M.Outputs(y=Index("y", 1.0))
+
+    m = M()  # no inputs argument — Inputs() is auto-constructed
+    assert m.outputs.y is not None
+
+
+def test_define_empty_inputs_with_functions():
+    """@define auto-constructs Inputs() when Inputs has no fields and Functions is declared."""
+
+    @define("M")
+    class M(Model):
+        @inputs
+        class Inputs:
+            pass
+
+        @functions
+        class Functions:
+            f: Any
+
+        @outputs
+        class Outputs:
+            y: Index
+
+        def compute(self, inp: Inputs, *, fns: Functions) -> Outputs:
+            """Return a constant output."""
+            return M.Outputs(y=Index("y", 1.0))
+
+    m = M(fns=M.Functions(f=NumpyBackend.adapt(lambda: None)))  # type: ignore[call-arg]
+    assert m.outputs.y is not None

--- a/tests/dt_model/model/test_define.py
+++ b/tests/dt_model/model/test_define.py
@@ -78,6 +78,7 @@ def test_define_raises_if_expose_declared_but_missing_from_return():
 
 def test_define_get_type_hints_fallback():
     """@define falls back to raw __annotations__ when get_type_hints() fails."""
+
     # Use a string annotation that cannot be resolved to trigger the except branch.
     # The decorator should still succeed (falling back to raw annotations, which
     # yields no 'return' hint), so no Expose-consistency error fires either.


### PR DESCRIPTION
## Summary

- Introduces `@define` decorator that generates `__init__` from a `compute()` method,
  eliminating boilerplate in leaf `Model` subclasses; `@inputs`, `@outputs`, `@expose`,
  `@functions` decorators make inter-model contracts explicit and machine-checkable.
  `DeprecationWarning` emitted for direct-`__init__` subclasses; `legacy=True` opt-out.
- All example models migrated to `@define` + `compute()`: seven concern sub-models and
  both root models (`BolognaModel`, `MolvenoModel`); `MolvenoModel` now exposes all
  domain parameters as named `Inputs` fields with a `default_inputs()` factory; filed
  issue #195 (placeholder-value detection at construction time).

## Closed issues

- Closes #190