### PR TITLE
fix(model): detect dropped indexes early (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the distribution sampling budget, reducing Monte Carlo variance for models
   that retain distribution-backed indexes in the ensemble (closing #192).
   Default `n_samples_per_combo=1` preserves existing behaviour exactly.
+- `Scenario.__init__` now raises `ValueError` when an override key is not in
+  the model's `indexes` list.  Previously such overrides were silently dropped
+  by `base_substitutions()` (closing #195).
+- `Evaluation._execute_plan` now raises `ValueError` when a `parameters=` key's
+  node is not reachable in the plan's computation graph.  Previously such
+  parameters would allocate a PARAMETER axis in the result while having no
+  effect on the computation (closing #195).  Indexes referenced only in
+  selector formulas (not in `model.indexes`) remain valid `parameters=` keys.
+- `Model.__init__` now raises `ValueError` at construction time when any
+  `graph.placeholder` or `graph.timeseries_placeholder` node is reachable in
+  the computation graph from the model's internally-built formula outputs but
+  has no corresponding entry in the model's `indexes` list.  This catches both
+  the sub-model pattern (composite model omits sub-model concrete parameters
+  from `Expose`) and the single-model pattern (``Index(name, 0.2)`` used in a
+  formula but absent from `Outputs` / `Expose`).  Formula-backed input nodes
+  are excluded from the traversal boundary, so composed models where sub-model
+  output formulas are wired as inputs to sibling models are not affected.
+  `graph.placeholder` nodes with an explicit `default_value` are also exempt
+  (the executor already has a fallback).  `Scenario.base_substitutions()`
+  iterates `model.indexes` to inject concrete values; absent entries caused a
+  cryptic `PlaceholderValueNotProvided` deep inside the executor — now
+  surfaced early with a clear error message (closing #195).
 
 ### Changed
 

--- a/civic_digital_twins/dt_model/model/model.py
+++ b/civic_digital_twins/dt_model/model/model.py
@@ -694,6 +694,36 @@ class Model:
                 if caller_frame is not None:
                     _check_inputs_contract(caller_frame, concrete_cls, self.inputs)
 
+                # Dropped-index check: any graph.placeholder or
+                # graph.timeseries_placeholder node that is reachable from the
+                # model's internally-built formula nodes but not itself covered
+                # by a declared index will never receive a value at evaluation time.
+                # This catches both sub-model concrete indexes and inline
+                # Index(name, scalar) / TimeseriesIndex(name, array) created
+                # inside compute() but not surfaced via Inputs/Outputs/Expose.
+                # Formula-backed input nodes are excluded from the traversal
+                # boundary: their placeholder dependencies belong to the model
+                # that built them (the parent or a sibling sub-model).
+                _input_formula_nodes: frozenset[graph.Node] = frozenset(
+                    idx.node
+                    for idx in self.inputs
+                    if not isinstance(idx.node, (graph.placeholder, graph.timeseries_placeholder))
+                )
+                _orphaned = _find_orphaned_placeholder_nodes(self.indexes, _input_formula_nodes)
+                if _orphaned:
+                    _names = ", ".join(repr(n.name) for n in _orphaned)
+                    raise ValueError(
+                        f"{concrete_cls.__name__}: the following indexes appear in "
+                        f"the model's formulas but are not declared in Inputs, Outputs, or Expose: "
+                        f"{_names}. "
+                        "Without a declaration the model cannot inject their values at "
+                        "evaluation time and will fail with a missing-value error. "
+                        "Add each index to Inputs (if it is supplied from outside the "
+                        "model), Outputs or Expose (if it is computed inside), or "
+                        "replace it with ConstIndex / ConstTimeseriesIndex if its "
+                        "value is fixed and should never be overridden."
+                    )
+
                 for idx in self.abstract_indexes():
                     if idx not in self.inputs:
                         idx_name = getattr(idx, "name", repr(idx))
@@ -818,6 +848,86 @@ def _collect_submodel_node_functions(instance_dict: dict[str, Any]) -> dict[grap
                 if isinstance(item, Model):
                     claimed.update(item._node_functions)
     return claimed
+
+
+def _find_orphaned_placeholder_nodes(
+    indexes: list[GenericIndex],
+    input_formula_nodes: frozenset["graph.Node"],
+) -> list["graph.Node"]:
+    """Find placeholder nodes reachable from *indexes* but not covered by any index.
+
+    Traverses the computation graph **backward** from the model's internally-
+    built formula nodes (outputs and expose) using :func:`_iter_node_deps`.
+    Any :class:`~engine.frontend.graph.placeholder` or
+    :class:`~engine.frontend.graph.timeseries_placeholder` node that is
+    reachable but whose identity is *not* among ``{idx.node for idx in indexes}``
+    is returned as **orphaned**.
+
+    The traversal is bounded by two stopping conditions:
+
+    * **Covered nodes** — nodes that already have a declared index in
+      *indexes* (they receive their values via
+      :meth:`~simulation.scenario.Scenario.base_substitutions`).
+    * **Formula-backed input nodes** (*input_formula_nodes*) — formula nodes
+      that were built by *another* model and passed to this one as inputs.
+      These nodes' placeholder dependencies belong to that other model;
+      traversing into them would produce false positives.
+
+    An orphaned placeholder node is always a latent bug:
+
+    * If it was created by a concrete-valued ``Index(name, 0.2)``, the value
+      is stored only in the ``Index`` object and is injected by
+      :meth:`~simulation.scenario.Scenario.base_substitutions`, which
+      iterates ``model.indexes``.  A node absent from ``model.indexes`` is
+      never injected → ``PlaceholderValueNotProvided``.
+    * If it was created by an abstract ``Index(name, None)``, it is absent
+      from :meth:`~.model.Model.abstract_indexes` and therefore unknown to
+      the ensemble; evaluation fails for the same reason.
+
+    Parameters
+    ----------
+    indexes:
+        The model's declared indexes (``model.indexes``).
+    input_formula_nodes:
+        Formula-backed ``.node`` values from the model's declared inputs.  The
+        BFS stops when it reaches any of these nodes (their dependencies were
+        built by a different model and are that model's responsibility).
+
+    Returns
+    -------
+    list[graph.Node]
+        Orphaned placeholder nodes in discovery order.  Empty when every
+        reachable placeholder is covered by a declared index.
+    """
+    covered: set[graph.Node] = {idx.node for idx in indexes}
+    # Start only from formula-backed nodes that were *built by this model*:
+    # i.e., nodes that are covered but are NOT formula-backed inputs from another model.
+    internal_formula_starts: list[graph.Node] = [
+        node
+        for node in covered
+        if not isinstance(node, (graph.placeholder, graph.timeseries_placeholder)) and node not in input_formula_nodes
+    ]
+    visited: set[graph.Node] = set()
+    to_visit: list[graph.Node] = internal_formula_starts
+    orphaned: list[graph.Node] = []
+    while to_visit:
+        node = to_visit.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        for dep in _iter_node_deps(node):
+            if dep in visited or dep in covered or dep in input_formula_nodes:
+                continue  # already handled or belongs to another model
+            if isinstance(dep, (graph.placeholder, graph.timeseries_placeholder)):
+                # placeholder nodes with a default_value are self-contained:
+                # the executor falls back to that value when the node is absent
+                # from state.values, so they are not orphaned.
+                if isinstance(dep, graph.placeholder) and dep.default_value is not None:
+                    continue
+                orphaned.append(dep)  # uncovered placeholder — always a bug
+            else:
+                to_visit.append(dep)  # uncovered formula node — traverse further
+    return orphaned
 
 
 def _build_node_functions_map(

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -658,6 +658,27 @@ class Evaluation:
                 "Use Index(name, value) or Index(name, None) for sweep parameters."
             )
 
+        # Membership check: every parameters= key's node must appear in the plan's
+        # computation graph (i.e., in the linearised nodes across all regions).
+        # An index whose node is absent from the plan would contribute a PARAMETER axis
+        # to the result layout but would never influence any computation — a silent bug.
+        # Note: we check node identity in the plan rather than model.indexes membership
+        # because a valid use-case is passing an index that is only referenced in a
+        # selector formula (and therefore not declared in model.indexes but still
+        # present in the linearised graph).
+        all_plan_nodes = {n for r in plan.regions for n in r.nodes}
+        orphan_params = [idx for idx in parameters if idx.node not in all_plan_nodes]
+        if orphan_params:
+            names = ", ".join(repr(getattr(idx, "name", repr(idx))) for idx in orphan_params)
+            raise ValueError(
+                f"parameters= for model {plan.model.name!r}: {names} "
+                f"{'is' if len(orphan_params) == 1 else 'are'} not part of this "
+                "model's computation. Passing "
+                f"{'it' if len(orphan_params) == 1 else 'them'} would add result "
+                "dimensions that have no effect on any output value. Check that "
+                "you are using index objects that belong to this model."
+            )
+
         k = len(parameter_axes)  # named PARAMETER axes
         m = len(array_params)  # anonymous PARAMETER axes
         n_params = k + m

--- a/civic_digital_twins/dt_model/simulation/scenario.py
+++ b/civic_digital_twins/dt_model/simulation/scenario.py
@@ -106,6 +106,22 @@ class Scenario:
     ) -> None:
         self._model = model
         self._overrides: dict[GenericIndex, DomainValue] = dict(overrides or {})
+
+        # Membership check: every override key must belong to this model.
+        # GenericIndex.__eq__ is overloaded to return a new index node, so we
+        # must use identity (id()) rather than equality for containment checks.
+        model_index_ids = {id(i) for i in model.indexes}
+        foreign = [idx for idx in self._overrides if id(idx) not in model_index_ids]
+        if foreign:
+            names = ", ".join(repr(getattr(idx, "name", repr(idx))) for idx in foreign)
+            raise ValueError(
+                f"Scenario for model {model.name!r}: {names} "
+                f"{'is' if len(foreign) == 1 else 'are'} not part of this model. "
+                "Overrides are matched by object identity — check that you are "
+                "passing index objects that were created as part of model "
+                f"{model.name!r}, not indexes from a different model or a copy."
+            )
+
         for idx, val in self._overrides.items():
             # Structural constants cannot be overridden.
             if isinstance(idx, (ConstIndex, ConstTimeseriesIndex)):

--- a/tests/dt_model/model/test_model.py
+++ b/tests/dt_model/model/test_model.py
@@ -604,12 +604,17 @@ def test_inputs_contract_warning_fires_for_undeclared_index():
         class Outputs:
             result: Index
 
+        @dataclasses.dataclass
+        class Expose:
+            received: Index  # tracked so the model is valid, but not in Inputs
+
         def __init__(self, received: Index) -> None:
             result = Index("result", received + 1.0)
-            # received is NOT stored in any Inputs dataclass
+            # received is in Expose (so it's covered), but NOT in any Inputs dataclass
             super().__init__(
                 "Bad",
                 outputs=_Bad.Outputs(result=result),
+                expose=_Bad.Expose(received=received),
             )
 
     received = Index("x", 1.0)
@@ -625,9 +630,13 @@ def test_inputs_contract_warning_fires_for_undeclared_timeseries():
         class Outputs:
             out: Index
 
+        @dataclasses.dataclass
+        class Expose:
+            ts: TimeseriesIndex  # tracked so the model is valid, but not in Inputs
+
         def __init__(self, ts: TimeseriesIndex) -> None:
             out = Index("out", ts.sum())
-            super().__init__("Bad", outputs=_Bad.Outputs(out=out))
+            super().__init__("Bad", outputs=_Bad.Outputs(out=out), expose=_Bad.Expose(ts=ts))
 
     ts = TimeseriesIndex("ts", np.array([1.0, 2.0, 3.0]))
     with pytest.warns(InputsContractWarning, match="'ts'"):
@@ -642,9 +651,13 @@ def test_inputs_contract_warning_fires_for_undeclared_list():
         class Outputs:
             total: Index
 
+        @dataclasses.dataclass
+        class Expose:
+            costs: list  # tracked so the model is valid, but not in Inputs
+
         def __init__(self, costs: list[Index]) -> None:
             total = Index("total", costs[0] + costs[1])
-            super().__init__("Bad", outputs=_Bad.Outputs(total=total))
+            super().__init__("Bad", outputs=_Bad.Outputs(total=total), expose=_Bad.Expose(costs=costs))
 
     costs = [Index("c0", 1.0), Index("c1", 2.0)]
     with pytest.warns(InputsContractWarning) as record:
@@ -725,9 +738,13 @@ def test_model_contract_warning_base_filter_catches_inputs_contract_warning():
         class Outputs:
             result: Index
 
+        @dataclasses.dataclass
+        class Expose:
+            received: Index
+
         def __init__(self, received: Index) -> None:
             result = Index("result", received + 1.0)
-            super().__init__("Bad", outputs=_Bad.Outputs(result=result))
+            super().__init__("Bad", outputs=_Bad.Outputs(result=result), expose=_Bad.Expose(received=received))
 
     received = Index("x", 1.0)
     with pytest.warns(ModelContractWarning):
@@ -807,9 +824,13 @@ def test_inputs_contract_no_crash_when_signature_unavailable():
         class Outputs:
             result: Index
 
+        @dataclasses.dataclass
+        class Expose:
+            x: Index
+
         def __init__(self, x: Index) -> None:
             result = Index("result", x + 1.0)
-            super().__init__("M", outputs=_Model.Outputs(result=result))
+            super().__init__("M", outputs=_Model.Outputs(result=result), expose=_Model.Expose(x=x))
 
     x = Index("x", 1.0)
     # Patch inspect.signature to raise TypeError, simulating a built-in or
@@ -861,3 +882,235 @@ def test_inputs_contract_skips_params_absent_from_locals():
     # No warning fires: x is declared in Inputs; y was deleted before inspection.
     contract_warnings = [w for w in caught if issubclass(w.category, InputsContractWarning)]
     assert len(contract_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Dropped concrete sub-model index detection (issue #195)
+# ---------------------------------------------------------------------------
+
+
+def test_dropped_concrete_submodel_index_raises_at_construction():
+    """Model.__init__ raises ValueError when a sub-model's concrete Index is not in parent.indexes.
+
+    The canonical failure mode: a parent model builds a sub-model with
+    concrete-valued Index parameters (e.g. Index('k', 0.5)), stores the
+    sub-model as self.sub, but does not include those concrete indexes in its
+    own Inputs/Outputs/Expose.  Scenario.base_substitutions() would silently
+    skip them, causing PlaceholderValueNotProvided at evaluation time.  The
+    check here surfaces the problem at model construction.
+    """
+    from civic_digital_twins.dt_model.model.contracts import define, inputs, outputs
+
+    @define("Inner")
+    class InnerModel(Model):
+        @inputs
+        class Inputs:
+            k: Index
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            return InnerModel.Outputs(result=Index("result", inp.k.node * 2.0))
+
+    class OuterModel(Model, legacy=True):
+        @inputs
+        class Inputs:
+            pass  # intentionally empty — k is NOT forwarded to the parent
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        def __init__(self) -> None:
+            k = Index("k", 0.5)  # concrete value, will be in inner.indexes
+            self.inner = InnerModel(InnerModel.Inputs(k=k))
+            super().__init__(
+                "Outer",
+                inputs=OuterModel.Inputs(),
+                outputs=OuterModel.Outputs(result=self.inner.outputs.result),
+            )
+
+    with pytest.raises(ValueError, match="appear in the model's formulas but are not declared"):
+        OuterModel()
+
+
+def test_dropped_concrete_submodel_index_error_names_culprits():
+    """Error message includes the names of the dropped concrete indexes."""
+    from civic_digital_twins.dt_model.model.contracts import define, inputs, outputs
+
+    @define("Inner")
+    class _Inner(Model):
+        @inputs
+        class Inputs:
+            alpha: Index
+            beta: Index
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            return _Inner.Outputs(result=Index("result", inp.alpha.node + inp.beta.node))
+
+    class _Outer(Model, legacy=True):
+        @inputs
+        class Inputs:
+            pass
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        def __init__(self) -> None:
+            alpha = Index("alpha_param", 1.0)
+            beta = Index("beta_param", 2.0)
+            self.inner = _Inner(_Inner.Inputs(alpha=alpha, beta=beta))
+            super().__init__(
+                "Outer2",
+                inputs=_Outer.Inputs(),
+                outputs=_Outer.Outputs(result=self.inner.outputs.result),
+            )
+
+    with pytest.raises(ValueError, match="alpha_param"):
+        _Outer()
+
+
+def test_concrete_submodel_index_in_parent_expose_does_not_raise():
+    """No error when all concrete sub-model indexes are included in parent Expose."""
+    from civic_digital_twins.dt_model.model.contracts import define, expose, inputs, outputs
+
+    @define("Inner")
+    class _InnerOK(Model):
+        @inputs
+        class Inputs:
+            k: Index
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            return _InnerOK.Outputs(result=Index("result", inp.k.node * 3.0))
+
+    @define("Outer")
+    class _OuterOK(Model):
+        @inputs
+        class Inputs:
+            pass
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        @expose
+        class Expose:
+            domain_indexes: list[Index]
+
+        def compute(self, inp: Inputs) -> tuple[Outputs, Expose]:
+            k = Index("k", 0.5)
+            inner = _InnerOK(_InnerOK.Inputs(k=k))
+            self.inner = inner
+            return (
+                _OuterOK.Outputs(result=inner.outputs.result),
+                _OuterOK.Expose(domain_indexes=list(inner.indexes)),
+            )
+
+    # Should construct without error — k is tracked via domain_indexes in Expose.
+    m = _OuterOK()
+    assert any(getattr(i, "name", None) == "k" for i in m.expose.domain_indexes)
+
+
+def test_const_index_in_submodel_does_not_raise():
+    """ConstIndex in a sub-model is exempt: its value is baked into the graph."""
+    from civic_digital_twins.dt_model import ConstIndex
+    from civic_digital_twins.dt_model.model.contracts import define, inputs, outputs
+
+    @define("Inner")
+    class _InnerConst(Model):
+        @inputs
+        class Inputs:
+            k: ConstIndex
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            return _InnerConst.Outputs(result=Index("result", inp.k.node * 1.0))
+
+    class _OuterConst(Model, legacy=True):
+        @inputs
+        class Inputs:
+            pass
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        def __init__(self) -> None:
+            k = ConstIndex("k", 0.5)  # value baked into graph — exempt from check
+            self.inner = _InnerConst(_InnerConst.Inputs(k=k))
+            super().__init__(
+                "OuterConst",
+                inputs=_OuterConst.Inputs(),
+                outputs=_OuterConst.Outputs(result=self.inner.outputs.result),
+            )
+
+    # Should construct without error — ConstIndex values are baked into the graph.
+    m = _OuterConst()
+    assert m is not None
+
+
+def test_inline_concrete_index_not_in_outputs_raises():
+    """Single model: Index(name, scalar) used in a formula but not in Outputs/Expose raises.
+
+    This is the single-model analogue of the sub-model dropped-index bug:
+    Index('a', 0.2) creates a graph.placeholder whose value must be injected
+    by Scenario.base_substitutions().  If the index is absent from model.indexes,
+    the value is silently lost and evaluation raises PlaceholderValueNotProvided.
+    The check in Model.__init__ must catch this at construction time.
+    """
+    from civic_digital_twins.dt_model.model.contracts import define, inputs, outputs
+
+    @define("Single")
+    class _Single(Model):
+        @inputs
+        class Inputs:
+            pass
+
+        @outputs
+        class Outputs:
+            b: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            a = Index("a_factor", 0.2)  # concrete — NOT returned in Outputs or Expose
+            b = Index("b", a.node * 2.0)
+            return _Single.Outputs(b=b)
+
+    with pytest.raises(ValueError, match="a_factor"):
+        _Single()
+
+
+def test_inline_abstract_index_not_in_outputs_raises():
+    """Single model: Index(name, None) in a formula but absent from Inputs/Outputs raises."""
+    from civic_digital_twins.dt_model.model.contracts import define, inputs, outputs
+
+    @define("SingleAbstract")
+    class _SingleAbstract(Model):
+        @inputs
+        class Inputs:
+            pass  # 'x' intentionally omitted from Inputs
+
+        @outputs
+        class Outputs:
+            result: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            x = Index("x_abstract", None)  # abstract placeholder, NOT in Inputs
+            result = Index("result", x.node + 1.0)
+            return _SingleAbstract.Outputs(result=result)
+
+    with pytest.raises(ValueError, match="x_abstract"):
+        _SingleAbstract()

--- a/tests/dt_model/model/test_model.py
+++ b/tests/dt_model/model/test_model.py
@@ -1114,3 +1114,74 @@ def test_inline_abstract_index_not_in_outputs_raises():
 
     with pytest.raises(ValueError, match="x_abstract"):
         _SingleAbstract()
+
+
+def test_orphan_check_visited_guard_diamond_dependency():
+    """BFS visited-guard (line inside the while loop) is exercised by a diamond dependency.
+
+    Two declared outputs both depend on the same intermediate formula node.
+    The BFS adds that node to to_visit twice (once from each output); the
+    second pop must hit the ``if node in visited: continue`` guard.
+    The shared dependency itself has an orphaned concrete-valued input,
+    so the check fires and names it correctly.
+    """
+    from civic_digital_twins.dt_model import graph as _graph
+    from civic_digital_twins.dt_model.model.contracts import define, inputs, outputs
+
+    @define("Diamond")
+    class _Diamond(Model):
+        @inputs
+        class Inputs:
+            pass
+
+        @outputs
+        class Outputs:
+            out_a: Index
+            out_b: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            # shared concrete-valued index (orphaned — not in Outputs)
+            k = Index("k_shared", 0.5)
+            # two outputs that both depend on k
+            out_a = Index("out_a", k.node * 1.0)
+            out_b = Index("out_b", k.node * 2.0)
+            return _Diamond.Outputs(out_a=out_a, out_b=out_b)
+
+    with pytest.raises(ValueError, match="k_shared"):
+        _Diamond()
+
+
+def test_orphan_check_visited_guard_formula_diamond():
+    """BFS ``if node in visited: continue`` guard (L916) is hit by a formula diamond.
+
+    When an uncovered formula node M is a transitive dependency of two separate
+    formula nodes A and B, and A is itself a dependency of B, M is appended to
+    ``to_visit`` twice before it is processed.  On the second pop the visited
+    guard fires.
+
+    Graph:  out.node = A + B
+                A = shared + 0  (shares node with the first dep of out)
+                B = A * 1       (also depends on A)
+    → ``_iter_node_deps(out)`` returns [A, B]; processing B appends A again.
+    """
+    from civic_digital_twins.dt_model.model.contracts import define, inputs, outputs
+
+    @define("FormulaTriangle")
+    class _Tri(Model):
+        @inputs
+        class Inputs:
+            pass
+
+        @outputs
+        class Outputs:
+            out: Index
+
+        def compute(self, inp: Inputs) -> Outputs:
+            k = Index("k_tri", 0.5)  # orphaned concrete index
+            shared = k.node + 0.0  # uncovered formula node A
+            dep_b = shared * 1.0  # uncovered formula node B, depends on A
+            out = Index("out", shared + dep_b)  # out depends on both A and B
+            return _Tri.Outputs(out=out)
+
+    with pytest.raises(ValueError, match="k_tri"):
+        _Tri()

--- a/tests/dt_model/model/test_model.py
+++ b/tests/dt_model/model/test_model.py
@@ -1125,7 +1125,6 @@ def test_orphan_check_visited_guard_diamond_dependency():
     The shared dependency itself has an orphaned concrete-valued input,
     so the check fires and names it correctly.
     """
-    from civic_digital_twins.dt_model import graph as _graph
     from civic_digital_twins.dt_model.model.contracts import define, inputs, outputs
 
     @define("Diamond")

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -766,3 +766,43 @@ def test_parameter_axes_const_index_raises():
 
     with pytest.raises(ValueError, match="constant-node"):
         ev.evaluate(parameters={c: np.array([1.0, 2.0])})
+
+
+# ---------------------------------------------------------------------------
+# Foreign-index checks — parameters= keys not in model.indexes
+# ---------------------------------------------------------------------------
+
+
+def test_parameters_foreign_index_raises():
+    """evaluate() raises ValueError when a parameters= key's node is not in the computation graph."""
+    a = Index("a", 1.0)
+    foreign = Index("foreign", None)  # NOT in the model; node not in graph
+    result = Index("result", a.node * 1.0)
+    model = _make_model(a, result)
+    ev = Evaluation(Scenario(model))
+
+    with pytest.raises(ValueError, match="not part of this model's computation"):
+        ev.evaluate(parameters={foreign: np.array([1.0, 2.0])})
+
+
+def test_parameters_foreign_index_error_names_the_culprit():
+    """Error message includes the name of the foreign index."""
+    a = Index("a", 1.0)
+    foreign = Index("foreign_param", None)  # NOT in the model; node not in graph
+    model = _make_model(a)
+    ev = Evaluation(Scenario(model))
+
+    with pytest.raises(ValueError, match="foreign_param"):
+        ev.evaluate(parameters={foreign: np.array([1.0, 2.0])})
+
+
+def test_parameters_index_in_model_does_not_raise():
+    """evaluate() does not raise when all parameters= keys belong to the model."""
+    a = Index("a", None)  # abstract
+    result = Index("result", a.node * 2.0)
+    model = _make_model(a, result)
+    ev = Evaluation(Scenario(model))
+
+    # a is in the model — no error expected.
+    res = ev.evaluate(parameters={a: np.array([1.0, 2.0])})
+    np.testing.assert_array_almost_equal(res[result], [2.0, 4.0])

--- a/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
+++ b/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
@@ -526,3 +526,36 @@ def test_cross_product_ensemble_explicit_restriction_overrides_dict_keys():
     weights = ens.ensemble_weights[0]
     weight_by_value = {str(v): float(w) for v, w in zip(assignments, weights)}
     assert weight_by_value == pytest.approx({"a": 0.6 / 0.9, "b": 0.3 / 0.9})
+
+
+# ---------------------------------------------------------------------------
+# Foreign-index checks — override keys not in model.indexes
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_override_foreign_index_raises():
+    """Scenario raises ValueError when an override key is not in the model's indexes."""
+    a = Index("a", 1.0)
+    b = Index("b", 2.0)  # NOT added to the model
+    model = _make_model(a)
+    with pytest.raises(ValueError, match="not part of this model"):
+        Scenario(model, overrides={b: 3.0})
+
+
+def test_scenario_override_foreign_index_error_names_the_culprit():
+    """Error message includes the name of the foreign index."""
+    a = Index("a", 1.0)
+    foreign = Index("foreign_idx", 99.0)  # NOT in the model
+    model = _make_model(a)
+    with pytest.raises(ValueError, match="foreign_idx"):
+        Scenario(model, overrides={foreign: 42.0})
+
+
+def test_scenario_override_index_in_model_does_not_raise():
+    """Scenario does not raise when all override keys belong to the model."""
+    a = Index("a", 1.0)
+    b = Index("b", 2.0)
+    model = _make_model(a, b)
+    # Both a and b are in the model — no error expected.
+    scenario = Scenario(model, overrides={a: 10.0, b: 20.0})
+    assert scenario.overrides == {a: 10.0, b: 20.0}


### PR DESCRIPTION
### Problem

Several classes of "dropped index" bugs were previously undetected until deep inside evaluation, producing cryptic internal errors (`PlaceholderValueNotProvided`, or silently wrong results).

Three distinct failure modes existed:

1. **At model construction** — An `Index("k", 0.5)` (or `TimeseriesIndex`) is created inside `compute()` and used in a formula that feeds into `Outputs` or `Expose`, but is not itself declared in `Inputs`, `Outputs`, or `Expose`. The value `0.5` is stored on the `Index` object and injected at evaluation time by `Scenario.base_substitutions()`, which iterates `model.indexes`. Because the index is absent from `model.indexes`, the value is never injected and the executor fails mid-run. Same bug if the concrete parameters live in a sub-model but the parent composite model does not surface them in its own contract.

2. **At `Scenario` construction** — An override `{idx: val}` is passed for an index that does not belong to the model. The override is silently ignored by `base_substitutions()`.

3. **At evaluation** — A `parameters={idx: arr}` entry refers to an index whose node is not part of the model's computation. The parameter creates a PARAMETER axis in the result without affecting any output.

All three produce wrong or crashing results with no clear indication of what went wrong or where.

### Fix

**`Model.__init__`** — graph-level traversal at construction time.
After collecting `self.indexes`, the new `_find_orphaned_placeholder_nodes()` helper traverses the computation graph backward from all internally-built formula nodes (outputs and expose). Any `placeholder` / `timeseries_placeholder` node that is reachable but has no corresponding entry in `self.indexes` raises a `ValueError` immediately, naming the missing indexes and suggesting how to fix them.

**`Scenario.__init__`** — membership check on overrides.
Uses identity (`id()`) rather than `==` (which is overloaded on `GenericIndex`) to verify that every override key belongs to the model. Raises `ValueError` if not.

**`Evaluation._execute_plan`** — membership check on `parameters=`.
Verifies that every `parameters=` key's `.node` appears in the plan's linearised nodes. Raises `ValueError` if not.

### Closed issues

- Closes #195