### PR TITLE
fix(simulation): keep singleton in _merge_results only when both shape-1 values agree

### DIFF
--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -66,8 +66,7 @@ def _merge_results(
     Returns
     -------
     EvaluationResult
-        A new result whose node arrays are concatenated along the ENSEMBLE axis
-        (or kept as singletons when both inputs are singleton on that axis).
+        A new result whose node arrays are concatenated along the ENSEMBLE axis.
 
     Raises
     ------
@@ -134,25 +133,16 @@ def _merge_results(
         while v2.ndim <= ens_pos:
             v2 = v2[np.newaxis]  # pragma: no cover
 
-        if v1.shape[ens_pos] == 1 and v2.shape[ens_pos] == 1:
-            # Node does not vary along ENSEMBLE in either batch — it is constant
-            # (e.g. a parameter-only or fully-concrete node).  Both arrays must
-            # be equal since they come from the same deterministic computation.
-            if __debug__ and not np.array_equal(v1, v2):
-                raise AssertionError(  # pragma: no cover
-                    f"_merge_results: singleton node {getattr(node, 'name', repr(node))!r} "
-                    f"has different values in r1 ({v1!r}) and r2 ({v2!r}). "
-                    "This indicates a non-deterministic computation or mismatched plans."
-                )
+        if v1.shape[ens_pos] == 1 and v2.shape[ens_pos] == 1 and np.array_equal(v1, v2):
             merged_values[node] = v1
         else:
             # Expand singleton dims before concatenation so shapes match.
             if v1.shape[ens_pos] == 1:
-                bcast = v1.shape[:ens_pos] + (S1,) + v1.shape[ens_pos + 1 :]  # pragma: no cover
-                v1 = np.broadcast_to(v1, bcast).copy()  # pragma: no cover
+                bcast = v1.shape[:ens_pos] + (S1,) + v1.shape[ens_pos + 1 :]
+                v1 = np.broadcast_to(v1, bcast).copy()
             if v2.shape[ens_pos] == 1:
-                bcast = v2.shape[:ens_pos] + (S2,) + v2.shape[ens_pos + 1 :]  # pragma: no cover
-                v2 = np.broadcast_to(v2, bcast).copy()  # pragma: no cover
+                bcast = v2.shape[:ens_pos] + (S2,) + v2.shape[ens_pos + 1 :]
+                v2 = np.broadcast_to(v2, bcast).copy()
             merged_values[node] = np.concatenate([v1, v2], axis=ens_pos)
 
     # --- Build merged axis metadata ---

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -244,6 +244,41 @@ def test_extend_constant_node_stays_singleton() -> None:
 
 
 # ---------------------------------------------------------------------------
+# extend() with ensemble_size=1 — stochastic singleton regression (#186)
+# ---------------------------------------------------------------------------
+
+
+def test_extend_with_ensemble_size_1_stochastic() -> None:
+    """extend(1) on a size-1 handle must not raise for stochastic nodes (issue #186).
+
+    When ensemble_size=1 every stochastic node produces a shape-(1,) array.
+    _merge_results must not treat that as a broadcast constant and assert
+    equality — the two draws will almost surely differ.
+    """
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    handle = ev.evaluate_incremental(1, rng=np.random.default_rng(0))
+    # This must not raise AssertionError.
+    result = handle.extend(1)
+    assert result[model.outputs.y].shape == (2,)
+    assert result[model.inputs.x].shape == (2,)
+
+
+def test_extend_single_sample_preserves_both_draws() -> None:
+    """After extend(1) on a size-1 handle, both stochastic draws are in the result."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    rng = np.random.default_rng(42)
+    handle = ev.evaluate_incremental(1, rng=rng)
+    first_draw = handle.result[model.inputs.x].copy()
+    handle.extend(1)
+    merged_x = handle.result[model.inputs.x]
+    assert merged_x.shape == (2,)
+    # The first draw must still be present in the merged array.
+    np.testing.assert_array_equal(merged_x[0:1], first_draw)
+
+
+# ---------------------------------------------------------------------------
 # extra_parameters raises NotImplementedError
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Issue

`_merge_results` kept a shape-1 array as a singleton whenever both batches had `v.shape[ens_pos] == 1`, asserting the values must be equal. With `ensemble_size=1` every stochastic node (`DistributionIndex`, derived formula nodes) produces a shape-`(1,)` array that is indistinguishable by shape from a broadcast constant — but its value is a random draw that differs between calls, so the assertion fired.

## Fix

Keep the singleton only when both arrays are shape-1 **and their values agree**; otherwise broadcast each side to its full `S` size and concatenate. This handles all cases correctly without relying on any assumption about executor shape invariants.

## Closed issues

Closes #186.