### PR TITLE
feat(simulation): incremental parameter/ensemble extension and BatchDrawable protocol (#174, #175, #176, #199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   region, per-branch guarded regions (evaluated only for matching scenarios via
   `np.take` slice + `np.put_along_axis` scatter-back), and a merge region
   (closing #136).
-- `EvaluationHandle.from_evaluation(evaluation, initial_ensemble_size, ...)` →
+- `EvaluationHandle.evaluate(evaluation, initial_ensemble_size, ...)` →
   `EvaluationHandle` — builds a plan, runs the first batch, and returns a
   handle for checkpoint-style ensemble extension without discarding prior
   results (closing #168).
@@ -102,7 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-blocking variant backed by `concurrent.futures.Future`; exposes
   `poll() → (bool, EvaluationResult | None)` and `get() → EvaluationResult`;
   `extend()` delegates to the base class once the future resolves
-  (closing #169).  `AsyncEvaluationHandle.from_evaluation(evaluation,
+  (closing #169).  `AsyncEvaluationHandle.evaluate(evaluation,
   initial_ensemble_size, ..., pool=)` — submits the initial `execute_plan`
   call to a `concurrent.futures.Executor` (defaults to a lazily-created
   module-level `ThreadPoolExecutor`) and returns an `AsyncEvaluationHandle`
@@ -142,8 +142,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   categorical indexes (`{pin: 1.0}` for a concrete pin, override dict or `idx.outcomes`
   for `CategoricalIndex`, `None` for an unresolved `ConditionalCategoricalIndex`).
 - `parameter_axes=` kwarg on `Evaluation.evaluate()`, `execute_plan()`,
-  `EvaluationHandle.from_evaluation()`, and
-  `AsyncEvaluationHandle.from_evaluation()` — declares named PARAMETER axes
+  `EvaluationHandle.evaluate()`, and
+  `AsyncEvaluationHandle.evaluate()` — declares named PARAMETER axes
   for correlated parameter sweeps (closing #154).  Maps axis name to a 1-D
   numpy array.  Callable values in `parameters=` are now supported: each
   callable receives axis arrays by name from its signature and computes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,19 +78,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EvaluationHandle` — builds a plan, runs the first batch, and returns a
   handle for checkpoint-style ensemble extension without discarding prior
   results (closing #168).
-- `EvaluationHandle` in `simulation/handle.py` — incremental handle;
-  `extend(n)` draws *n* additional scenarios from `DistributionEnsemble`
-  using a shared `rng`, executes the plan, and merges via `_merge_results`.
-  Two calls with the same seed are guaranteed to produce the same sequence as
-  one call of the combined size.
+- `EvaluationHandle` in `simulation/handle.py` — incremental handle.
+  `extend(ensemble_size=N)` draws *N* new Monte Carlo samples via the stored
+  `BatchDrawable` recipe, executes the plan, and merges via `_merge_results`.
+  `extend(extra_ensemble={"axis": N})` extends a named ENSEMBLE axis of a
+  multi-axis recipe (e.g. `PartitionedEnsemble`) by *N* samples
+  (closing #175).  `extend(extra_parameters={idx: vals})` re-runs the stored
+  frozen ensemble at new parameter values and merges along the PARAMETER axis
+  (closing #174).  All three forms can be combined in one call.  Two calls
+  from the same seed reproduce the same sequence as one call of the combined
+  size.
+- `FrozenEnsemble` — public class in `simulation/ensemble.py` holding
+  pre-drawn sample arrays for one or more ENSEMBLE axes.  Produced by
+  `BatchDrawable.draw_batch`; held by `EvaluationHandle` as the accumulated
+  sample store.  Supports multi-axis ensembles via `concat_along` and
+  `with_replaced_axis`.
+- `BatchDrawable` — `@runtime_checkable` protocol in `simulation/ensemble.py`;
+  `draw_batch(size, rng, *, axis=None) → FrozenEnsemble` implemented by
+  `DistributionEnsemble`, `CrossProductEnsemble`, and `PartitionedEnsemble`
+  (closing #199).  Decouples `EvaluationHandle` from any concrete ensemble
+  type: any `BatchDrawable` recipe can serve as the extension sampler.
 - `AsyncEvaluationHandle(EvaluationHandle)` in `simulation/handle.py` —
   non-blocking variant backed by `concurrent.futures.Future`; exposes
   `poll() → (bool, EvaluationResult | None)` and `get() → EvaluationResult`;
   `extend()` delegates to the base class once the future resolves
-  (closing #169). `AsyncEvaluationHandle.from_evaluation(evaluation, initial_ensemble_size, ..., pool=)`
-  — submits the initial `execute_plan` call to a `concurrent.futures.Executor`
-  (defaults to a lazily-created module-level `ThreadPoolExecutor`) and returns
-  an `AsyncEvaluationHandle` immediately.
+  (closing #169).  `AsyncEvaluationHandle.from_evaluation(evaluation,
+  initial_ensemble_size, ..., pool=)` — submits the initial `execute_plan`
+  call to a `concurrent.futures.Executor` (defaults to a lazily-created
+  module-level `ThreadPoolExecutor`) and returns an `AsyncEvaluationHandle`
+  immediately.
 - `CategoricalIndex` selector can be passed as a `parameters=` axis to
   `Evaluation.evaluate()` to sweep over variant outcomes deterministically
   (no ensemble required), including in combination with numeric PARAMETER axes
@@ -126,8 +142,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   categorical indexes (`{pin: 1.0}` for a concrete pin, override dict or `idx.outcomes`
   for `CategoricalIndex`, `None` for an unresolved `ConditionalCategoricalIndex`).
 - `parameter_axes=` kwarg on `Evaluation.evaluate()`, `execute_plan()`,
-  `EvaluationHandle.from_evaluation()`, and `AsyncEvaluationHandle.from_evaluation()` — declares named PARAMETER
-  axes for correlated parameter sweeps (closing #154).  Maps axis name to a 1-D
+  `EvaluationHandle.from_evaluation()`, and
+  `AsyncEvaluationHandle.from_evaluation()` — declares named PARAMETER axes
+  for correlated parameter sweeps (closing #154).  Maps axis name to a 1-D
   numpy array.  Callable values in `parameters=` are now supported: each
   callable receives axis arrays by name from its signature and computes the
   substitution value for the corresponding model index (e.g.
@@ -213,7 +230,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Evaluation(model)` and all `Ensemble(model, ...)` constructors — pass a
   `Scenario(model)` instead.  These constructors now auto-wrap the model in a
   base `Scenario` and emit `DeprecationWarning`.  The canonical chain is
-  `Model → Scenario → {DistributionEnsemble | CrossProductEnsemble | PartitionedEnsemble} + Evaluation`.
+  `Model → Scenario → {DistributionEnsemble | CrossProductEnsemble |
+  PartitionedEnsemble} + Evaluation`.
 - Mutable index setters `ConstIndex.v`, `ConstTimeseriesIndex.values`,
   `TimeseriesIndex.values`, and `DistributionIndex.params` — vary index values
   via `Scenario(model, overrides={idx: new_value})` instead.  All setters emit
@@ -226,6 +244,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `graph.AxisOp` — abstract base class for the removed axis management nodes.
 - `graph.NpAxis` — numpy axis type alias; was an implementation detail of the
   former integer-axis interface.
+
+### Fixed
+
+- `_merge_results` — size-proportional weight mixing now correctly preserves
+  non-uniform weight schemes (e.g. `CrossProductEnsemble`).  Previously the
+  merged weights were recomputed as uniform over the combined ensemble,
+  discarding the original per-scenario weights (closing #176).
 
 ## [0.9.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   region, per-branch guarded regions (evaluated only for matching scenarios via
   `np.take` slice + `np.put_along_axis` scatter-back), and a merge region
   (closing #136).
-- `Evaluation.evaluate_incremental(initial_ensemble_size, ...)` →
+- `EvaluationHandle.from_evaluation(evaluation, initial_ensemble_size, ...)` →
   `EvaluationHandle` — builds a plan, runs the first batch, and returns a
   handle for checkpoint-style ensemble extension without discarding prior
   results (closing #168).
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-blocking variant backed by `concurrent.futures.Future`; exposes
   `poll() → (bool, EvaluationResult | None)` and `get() → EvaluationResult`;
   `extend()` delegates to the base class once the future resolves
-  (closing #169). `Evaluation.submit_evaluate(initial_ensemble_size, ..., pool=)`
+  (closing #169). `AsyncEvaluationHandle.from_evaluation(evaluation, initial_ensemble_size, ..., pool=)`
   — submits the initial `execute_plan` call to a `concurrent.futures.Executor`
   (defaults to a lazily-created module-level `ThreadPoolExecutor`) and returns
   an `AsyncEvaluationHandle` immediately.
@@ -126,7 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   categorical indexes (`{pin: 1.0}` for a concrete pin, override dict or `idx.outcomes`
   for `CategoricalIndex`, `None` for an unresolved `ConditionalCategoricalIndex`).
 - `parameter_axes=` kwarg on `Evaluation.evaluate()`, `execute_plan()`,
-  `evaluate_incremental()`, and `submit_evaluate()` — declares named PARAMETER
+  `EvaluationHandle.from_evaluation()`, and `AsyncEvaluationHandle.from_evaluation()` — declares named PARAMETER
   axes for correlated parameter sweeps (closing #154).  Maps axis name to a 1-D
   numpy array.  Callable values in `parameters=` are now supported: each
   callable receives axis arrays by name from its signature and computes the

--- a/civic_digital_twins/dt_model/simulation/__init__.py
+++ b/civic_digital_twins/dt_model/simulation/__init__.py
@@ -3,10 +3,12 @@
 
 from .ensemble import (
     AxisEnsemble,
+    BatchDrawable,
     CrossProductEnsemble,
     DistributionEnsemble,
     Ensemble,
     EnsembleAxisSpec,
+    FrozenEnsemble,
     PartitionedEnsemble,
     WeightedScenario,
     sample_across,
@@ -20,6 +22,7 @@ from .scenario import Scenario
 __all__ = [
     "AsyncEvaluationHandle",
     "AxisEnsemble",
+    "BatchDrawable",
     "CrossProductEnsemble",
     "DistributionEnsemble",
     "Ensemble",
@@ -29,6 +32,7 @@ __all__ = [
     "EvaluationHandle",
     "EvaluationPlan",
     "EvaluationResult",
+    "FrozenEnsemble",
     "IncompatibleResultError",
     "ModelEvaluator",
     "ModelOutput",

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -576,8 +576,8 @@ class DistributionEnsemble:
         ``parameters=`` at :meth:`~evaluation.Evaluation.evaluate` time) and
         must not be sampled by this ensemble.  These indexes are silently
         skipped in both the constructor validation and :meth:`assignments`.
-        Callers of :meth:`EvaluationHandle.from_evaluation` and
-        :meth:`AsyncEvaluationHandle.from_evaluation` should not set this
+        Callers of :meth:`EvaluationHandle.evaluate` and
+        :meth:`AsyncEvaluationHandle.evaluate` should not set this
         directly; it is managed automatically from the ``parameters=`` dict.
 
     Raises

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -134,48 +134,186 @@ class AxisEnsemble(Protocol):
 class FrozenEnsemble:
     """An :class:`AxisEnsemble` backed by pre-computed sample arrays — no RNG draws.
 
-    A frozen ensemble holds the samples already drawn for a single ENSEMBLE
-    axis so the plan can be re-executed over the *same* scenarios (e.g. when
+    A frozen ensemble holds the samples already drawn for one or more ENSEMBLE
+    axes so the plan can be re-executed over the *same* scenarios (e.g. when
     extending the PARAMETER grid) without advancing any random generator.
-    Produced by :meth:`DistributionEnsemble.draw_batch`; held by
+    Produced by :meth:`DistributionEnsemble.draw_batch` and similar methods on
+    other ensemble types; held by
     :class:`~simulation.handle.EvaluationHandle` as the accumulated sample set.
+
+    Parameters
+    ----------
+    axes:
+        Ordered ENSEMBLE axes (one per partition for multi-axis ensembles).
+    weights:
+        Factorized weight vectors aligned with *axes*.
+    cached_assignments:
+        Pre-drawn samples for every abstract index.  Shape contract follows
+        :class:`AxisEnsemble`: size ``Sj`` at dimension ``j`` when the index
+        is assigned to ``axes[j]``, size 1 otherwise.
     """
 
     def __init__(
         self,
-        axis: Axis,
-        weights: np.ndarray,
+        axes: tuple[Axis, ...],
+        weights: tuple[np.ndarray, ...],
         cached_assignments: dict[GenericIndex, np.ndarray],
     ) -> None:
-        self._axis = axis
+        self._axes = axes
         self._weights = weights
         self._cached_assignments = cached_assignments
 
     @property
     def ensemble_axes(self) -> tuple[Axis, ...]:
-        """Single ENSEMBLE axis carrying the frozen samples."""
-        return (self._axis,)
+        """ENSEMBLE axes carrying the frozen samples."""
+        return self._axes
 
     @property
     def ensemble_weights(self) -> tuple[np.ndarray, ...]:
-        """Factorized weight vector for the frozen samples, shape ``(size,)``."""
-        return (self._weights,)
+        """Factorized weight vectors for the frozen samples."""
+        return self._weights
 
     def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
         """Return the cached batched samples for every abstract index."""
         return self._cached_assignments
 
+    def draw_batch(self, size: int, rng: np.random.Generator, *, axis: str | None = None) -> "FrozenEnsemble":
+        """Not supported — :class:`FrozenEnsemble` is immutable.
+
+        Use the live ensemble recipe (:class:`DistributionEnsemble`,
+        :class:`CrossProductEnsemble`, etc.) stored in
+        :attr:`~simulation.handle.EvaluationHandle._ensemble_recipe` to draw
+        more samples.
+        """
+        raise TypeError(
+            "FrozenEnsemble cannot draw new samples — it holds a fixed snapshot. "
+            "Use the live ensemble recipe to draw more samples."
+        )
+
     def concat(self, other: "FrozenEnsemble") -> "FrozenEnsemble":
-        """Return a new frozen ensemble with concatenated samples and proportional weights."""
-        S1 = self._weights.size
-        S2 = other._weights.size
+        """Return a new single-axis frozen ensemble concatenating *other*'s samples.
+
+        Both *self* and *other* must be single-axis.  Use :meth:`concat_along`
+        for multi-axis ensembles.
+        """
+        assert len(self._axes) == 1 and len(other._axes) == 1, (
+            "FrozenEnsemble.concat is for single-axis ensembles; use concat_along for multi-axis."
+        )
+        S1 = self._weights[0].size
+        S2 = other._weights[0].size
         alpha = S1 / (S1 + S2)
-        merged_weights = np.concatenate([self._weights * alpha, other._weights * (1.0 - alpha)])
+        merged_weights = np.concatenate([self._weights[0] * alpha, other._weights[0] * (1.0 - alpha)])
         merged_assignments = {
             idx: np.concatenate([self._cached_assignments[idx], other._cached_assignments[idx]])
             for idx in self._cached_assignments
         }
-        return FrozenEnsemble(Axis("_ensemble", ENSEMBLE), merged_weights, merged_assignments)
+        new_ax = Axis(self._axes[0].name, ENSEMBLE)
+        return FrozenEnsemble(
+            (new_ax,),
+            (merged_weights,),
+            merged_assignments,
+        )
+
+    def concat_along(self, axis_name: str, other: "FrozenEnsemble") -> "FrozenEnsemble":
+        """Extend the named axis by appending *other* (single-axis) into this ensemble.
+
+        Indexes assigned to *axis_name* (shape > 1 at that dimension) are
+        concatenated; all other indexes are carried forward unchanged.  Weights
+        are combined with the size-proportional mixture rule.
+
+        Parameters
+        ----------
+        axis_name:
+            Name of the ENSEMBLE axis to grow.
+        other:
+            Single-axis :class:`FrozenEnsemble` produced by the recipe's
+            :meth:`draw_batch`.
+        """
+        ax_idx = next(i for i, ax in enumerate(self._axes) if ax.name == axis_name)
+        S1 = self._weights[ax_idx].size
+        S2 = other._weights[0].size
+        alpha = S1 / (S1 + S2)
+        merged_weights = np.concatenate([self._weights[ax_idx] * alpha, other._weights[0] * (1.0 - alpha)])
+        new_ax = Axis(axis_name, ENSEMBLE)
+        new_axes = tuple(new_ax if i == ax_idx else ax for i, ax in enumerate(self._axes))
+        new_weights = tuple(merged_weights if i == ax_idx else w for i, w in enumerate(self._weights))
+        M = len(self._axes)
+        merged_assignments: dict[GenericIndex, np.ndarray] = {}
+        for gidx, arr in self._cached_assignments.items():
+            if arr.shape[ax_idx] > 1:
+                other_arr = other._cached_assignments[gidx]  # shape (S2,)
+                target_shape = [1] * M
+                target_shape[ax_idx] = S2
+                merged_assignments[gidx] = np.concatenate([arr, other_arr.reshape(target_shape)], axis=ax_idx)
+            else:
+                merged_assignments[gidx] = arr
+        return FrozenEnsemble(new_axes, new_weights, merged_assignments)
+
+    def with_replaced_axis(self, axis_name: str, other: "FrozenEnsemble") -> "FrozenEnsemble":
+        """Return a copy with the named axis replaced by *other*'s samples.
+
+        Used when extending one axis of a multi-axis ensemble: *other*
+        (single-axis) provides fresh samples for the target axis; all other
+        axes keep their existing samples.  The result is a full multi-axis
+        ensemble suitable for :meth:`~simulation.evaluation.Evaluation.execute_plan`.
+
+        Parameters
+        ----------
+        axis_name:
+            Name of the ENSEMBLE axis to replace.
+        other:
+            Single-axis :class:`FrozenEnsemble` produced by the recipe's
+            :meth:`draw_batch`.
+        """
+        ax_idx = next(i for i, ax in enumerate(self._axes) if ax.name == axis_name)
+        S2 = other._weights[0].size
+        new_ax = Axis(axis_name, ENSEMBLE)
+        new_axes = tuple(new_ax if i == ax_idx else ax for i, ax in enumerate(self._axes))
+        new_weights = tuple(other._weights[0] if i == ax_idx else w for i, w in enumerate(self._weights))
+        M = len(self._axes)
+        merged_assignments: dict[GenericIndex, np.ndarray] = {}
+        for gidx, arr in self._cached_assignments.items():
+            if arr.shape[ax_idx] > 1:
+                other_arr = other._cached_assignments[gidx]  # shape (S2,)
+                target_shape = [1] * M
+                target_shape[ax_idx] = S2
+                merged_assignments[gidx] = other_arr.reshape(target_shape)
+            else:
+                merged_assignments[gidx] = arr
+        return FrozenEnsemble(new_axes, new_weights, merged_assignments)
+
+
+@runtime_checkable
+class BatchDrawable(Protocol):
+    """Protocol for ensemble types that can draw additional Monte Carlo batches.
+
+    Implemented by :class:`DistributionEnsemble`, :class:`CrossProductEnsemble`,
+    and :class:`PartitionedEnsemble`.  Types where incremental extension is
+    meaningless (e.g. :class:`FrozenEnsemble`) raise :class:`TypeError`.
+
+    The caller (e.g. :class:`~simulation.handle.EvaluationHandle`) owns the
+    RNG and passes it in.  Implementations must **not** store *rng* after the
+    call returns and must not accumulate internal state across calls.
+    """
+
+    def draw_batch(
+        self, size: int, rng: np.random.Generator, *, axis: str | None = None
+    ) -> FrozenEnsemble:
+        """Draw *size* new samples and return them as a :class:`FrozenEnsemble`.
+
+        Parameters
+        ----------
+        size:
+            New Monte Carlo budget: total samples for :class:`DistributionEnsemble`,
+            additional samples per combo for :class:`CrossProductEnsemble`,
+            new samples on the named axis for :class:`PartitionedEnsemble`.
+        rng:
+            Caller-owned :class:`numpy.random.Generator`.  Advanced in-place.
+        axis:
+            For :class:`PartitionedEnsemble`: name of the ENSEMBLE axis to
+            extend.  Must be ``None`` for single-axis ensemble types.
+        """
+        ...  # pragma: no cover
 
 
 class PartitionedEnsemble:
@@ -343,6 +481,63 @@ class PartitionedEnsemble:
 
         return result
 
+    def draw_batch(
+        self, size: int, rng: np.random.Generator, *, axis: str | None = None
+    ) -> FrozenEnsemble:
+        """Draw *size* new samples for the named ENSEMBLE axis.
+
+        Returns a **single-axis** :class:`FrozenEnsemble` carrying fresh samples
+        only for the indexes assigned to *axis*.  The caller
+        (:class:`~simulation.handle.EvaluationHandle`) is responsible for
+        combining this batch with the existing frozen state for all other axes
+        via :meth:`FrozenEnsemble.with_replaced_axis` before passing it to
+        :meth:`~simulation.evaluation.Evaluation.execute_plan`.
+
+        Parameters
+        ----------
+        size:
+            Number of new samples to draw for the target axis.
+        rng:
+            Caller-owned :class:`numpy.random.Generator`.  Advanced in-place.
+        axis:
+            Name of the ENSEMBLE axis to extend.  Required when this ensemble
+            has more than one axis; inferred automatically when there is only
+            one axis.
+
+        Raises
+        ------
+        ValueError
+            If *axis* is ``None`` and the ensemble has more than one axis, or
+            if *axis* does not name a known axis.
+        """
+        if axis is None:
+            if len(self._specs) == 1:
+                axis = self._specs[0].name
+            else:
+                names = [s.name for s in self._specs]
+                raise ValueError(
+                    f"PartitionedEnsemble has {len(self._specs)} axes {names!r}; "
+                    "specify axis= to indicate which axis to extend."
+                )
+        spec = next((s for s in self._specs if s.name == axis), None)
+        if spec is None:
+            raise ValueError(f"PartitionedEnsemble has no axis named {axis!r}.")
+        new_assignments: dict[GenericIndex, np.ndarray] = {}
+        for idx in spec.indexes:
+            if isinstance(idx, CategoricalIndex):
+                new_assignments[idx] = idx.sample(rng, size=size)  # shape (size,)
+            else:
+                dist = self._scenario.effective_distribution(idx)
+                if dist is None:  # pragma: no cover — guarded by __init__ validation
+                    raise ValueError(f"Index {getattr(idx, 'name', repr(idx))!r} is not samplable.")
+                raw = dist.rvs(size=size, random_state=rng) if rng is not None else dist.rvs(size=size)
+                new_assignments[idx] = np.asarray(raw)  # shape (size,)
+        return FrozenEnsemble(
+            (Axis(axis, ENSEMBLE),),
+            (np.full(size, 1.0 / size),),
+            new_assignments,
+        )
+
 
 class DistributionEnsemble:
     """Ensemble that independently samples each samplable abstract index.
@@ -498,7 +693,9 @@ class DistributionEnsemble:
                 result[idx] = np.asarray(raw)  # shape (S,)
         return result
 
-    def draw_batch(self, size: int, rng: np.random.Generator) -> FrozenEnsemble:
+    def draw_batch(
+        self, size: int, rng: np.random.Generator, *, axis: str | None = None
+    ) -> FrozenEnsemble:
         """Draw *size* fresh samples and return them as a :class:`FrozenEnsemble`.
 
         The caller (e.g. :class:`~simulation.handle.EvaluationHandle`) owns *rng*
@@ -512,6 +709,9 @@ class DistributionEnsemble:
             Number of new Monte Carlo samples to draw.
         rng:
             Caller-owned :class:`numpy.random.Generator`.  Advanced in-place.
+        axis:
+            Must be ``None``; :class:`DistributionEnsemble` has a single ENSEMBLE
+            axis and does not support named-axis extension.
 
         Returns
         -------
@@ -519,11 +719,20 @@ class DistributionEnsemble:
             Frozen batch whose samples are identical to what
             ``DistributionEnsemble(self._scenario, size, rng=rng,
             exclude=self._exclude)`` would produce.
+
+        Raises
+        ------
+        ValueError
+            If *axis* is not ``None``.
         """
+        if axis is not None:
+            raise ValueError(
+                f"DistributionEnsemble has a single ENSEMBLE axis; axis= must be None, got {axis!r}."
+            )
         new_dist = DistributionEnsemble(self._scenario, size, rng=rng, exclude=self._exclude)
         return FrozenEnsemble(
-            new_dist.ensemble_axes[0],
-            new_dist.ensemble_weights[0],
+            (new_dist.ensemble_axes[0],),
+            (new_dist.ensemble_weights[0],),
             dict(new_dist.assignments()),
         )
 
@@ -860,6 +1069,10 @@ class CrossProductEnsemble:
         self._weights_arr = weights
         self.size = S_total
         self._scenario = scenario
+        # Store init params so draw_batch can reconstruct with a different n_samples_per_combo.
+        self._init_restrictions: Mapping[Any, Sequence[str]] | None = restrictions if restrictions else None
+        self._init_max_categorical_size = max_categorical_size
+        self._init_exclude = list(exclude) if exclude is not None else None
 
     @property
     def ensemble_axes(self) -> tuple[Axis, ...]:
@@ -878,6 +1091,48 @@ class CrossProductEnsemble:
     def __len__(self) -> int:
         """Return the total number of scenarios."""
         return self.size
+
+    def draw_batch(
+        self, size: int, rng: np.random.Generator, *, axis: str | None = None
+    ) -> FrozenEnsemble:
+        """Draw *size* additional samples per categorical combination.
+
+        Reconstructs the cross-product with the same scenario, restrictions,
+        and categorical structure but with ``n_samples_per_combo=size`` and
+        *rng* as the source of randomness.
+
+        Parameters
+        ----------
+        size:
+            Number of new Monte Carlo samples to draw **per categorical combo**.
+        rng:
+            Caller-owned :class:`numpy.random.Generator`.  Advanced in-place.
+        axis:
+            Must be ``None``; :class:`CrossProductEnsemble` has a single
+            ENSEMBLE axis.
+
+        Raises
+        ------
+        ValueError
+            If *axis* is not ``None``.
+        """
+        if axis is not None:
+            raise ValueError(
+                f"CrossProductEnsemble has a single ENSEMBLE axis; axis= must be None, got {axis!r}."
+            )
+        new_cpe = CrossProductEnsemble(
+            self._scenario,
+            restrictions=self._init_restrictions,
+            max_categorical_size=self._init_max_categorical_size,
+            n_samples_per_combo=size,
+            exclude=self._init_exclude,
+            rng=rng,
+        )
+        return FrozenEnsemble(
+            (new_cpe.ensemble_axes[0],),
+            (new_cpe.ensemble_weights[0],),
+            dict(new_cpe.assignments()),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
@@ -177,7 +179,7 @@ class FrozenEnsemble:
         """Return the cached batched samples for every abstract index."""
         return self._cached_assignments
 
-    def draw_batch(self, size: int, rng: np.random.Generator, *, axis: str | None = None) -> "FrozenEnsemble":
+    def draw_batch(self, size: int, rng: np.random.Generator, *, axis: str | None = None) -> FrozenEnsemble:
         """Not supported — :class:`FrozenEnsemble` is immutable.
 
         Use the live ensemble recipe (:class:`DistributionEnsemble`,
@@ -190,7 +192,7 @@ class FrozenEnsemble:
             "Use the live ensemble recipe to draw more samples."
         )
 
-    def concat(self, other: "FrozenEnsemble") -> "FrozenEnsemble":
+    def concat(self, other: FrozenEnsemble) -> FrozenEnsemble:
         """Return a new single-axis frozen ensemble concatenating *other*'s samples.
 
         Both *self* and *other* must be single-axis.  Use :meth:`concat_along`
@@ -214,7 +216,7 @@ class FrozenEnsemble:
             merged_assignments,
         )
 
-    def concat_along(self, axis_name: str, other: "FrozenEnsemble") -> "FrozenEnsemble":
+    def concat_along(self, axis_name: str, other: FrozenEnsemble) -> FrozenEnsemble:
         """Extend the named axis by appending *other* (single-axis) into this ensemble.
 
         Indexes assigned to *axis_name* (shape > 1 at that dimension) are
@@ -249,7 +251,7 @@ class FrozenEnsemble:
                 merged_assignments[gidx] = arr
         return FrozenEnsemble(new_axes, new_weights, merged_assignments)
 
-    def with_replaced_axis(self, axis_name: str, other: "FrozenEnsemble") -> "FrozenEnsemble":
+    def with_replaced_axis(self, axis_name: str, other: FrozenEnsemble) -> FrozenEnsemble:
         """Return a copy with the named axis replaced by *other*'s samples.
 
         Used when extending one axis of a multi-axis ensemble: *other*
@@ -296,9 +298,7 @@ class BatchDrawable(Protocol):
     call returns and must not accumulate internal state across calls.
     """
 
-    def draw_batch(
-        self, size: int, rng: np.random.Generator, *, axis: str | None = None
-    ) -> FrozenEnsemble:
+    def draw_batch(self, size: int, rng: np.random.Generator, *, axis: str | None = None) -> FrozenEnsemble:
         """Draw *size* new samples and return them as a :class:`FrozenEnsemble`.
 
         Parameters
@@ -481,9 +481,7 @@ class PartitionedEnsemble:
 
         return result
 
-    def draw_batch(
-        self, size: int, rng: np.random.Generator, *, axis: str | None = None
-    ) -> FrozenEnsemble:
+    def draw_batch(self, size: int, rng: np.random.Generator, *, axis: str | None = None) -> FrozenEnsemble:
         """Draw *size* new samples for the named ENSEMBLE axis.
 
         Returns a **single-axis** :class:`FrozenEnsemble` carrying fresh samples
@@ -693,9 +691,7 @@ class DistributionEnsemble:
                 result[idx] = np.asarray(raw)  # shape (S,)
         return result
 
-    def draw_batch(
-        self, size: int, rng: np.random.Generator, *, axis: str | None = None
-    ) -> FrozenEnsemble:
+    def draw_batch(self, size: int, rng: np.random.Generator, *, axis: str | None = None) -> FrozenEnsemble:
         """Draw *size* fresh samples and return them as a :class:`FrozenEnsemble`.
 
         The caller (e.g. :class:`~simulation.handle.EvaluationHandle`) owns *rng*
@@ -726,9 +722,7 @@ class DistributionEnsemble:
             If *axis* is not ``None``.
         """
         if axis is not None:
-            raise ValueError(
-                f"DistributionEnsemble has a single ENSEMBLE axis; axis= must be None, got {axis!r}."
-            )
+            raise ValueError(f"DistributionEnsemble has a single ENSEMBLE axis; axis= must be None, got {axis!r}.")
         new_dist = DistributionEnsemble(self._scenario, size, rng=rng, exclude=self._exclude)
         return FrozenEnsemble(
             (new_dist.ensemble_axes[0],),
@@ -1092,9 +1086,7 @@ class CrossProductEnsemble:
         """Return the total number of scenarios."""
         return self.size
 
-    def draw_batch(
-        self, size: int, rng: np.random.Generator, *, axis: str | None = None
-    ) -> FrozenEnsemble:
+    def draw_batch(self, size: int, rng: np.random.Generator, *, axis: str | None = None) -> FrozenEnsemble:
         """Draw *size* additional samples per categorical combination.
 
         Reconstructs the cross-product with the same scenario, restrictions,
@@ -1117,9 +1109,7 @@ class CrossProductEnsemble:
             If *axis* is not ``None``.
         """
         if axis is not None:
-            raise ValueError(
-                f"CrossProductEnsemble has a single ENSEMBLE axis; axis= must be None, got {axis!r}."
-            )
+            raise ValueError(f"CrossProductEnsemble has a single ENSEMBLE axis; axis= must be None, got {axis!r}.")
         new_cpe = CrossProductEnsemble(
             self._scenario,
             restrictions=self._init_restrictions,

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -578,8 +578,8 @@ class DistributionEnsemble:
         ``parameters=`` at :meth:`~evaluation.Evaluation.evaluate` time) and
         must not be sampled by this ensemble.  These indexes are silently
         skipped in both the constructor validation and :meth:`assignments`.
-        Callers of :meth:`~evaluation.Evaluation.evaluate_incremental` and
-        :meth:`~evaluation.Evaluation.submit_evaluate` should not set this
+        Callers of :meth:`EvaluationHandle.from_evaluation` and
+        :meth:`AsyncEvaluationHandle.from_evaluation` should not set this
         directly; it is managed automatically from the ``parameters=`` dict.
 
     Raises

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -131,6 +131,53 @@ class AxisEnsemble(Protocol):
         ...  # pragma: no cover
 
 
+class FrozenEnsemble:
+    """An :class:`AxisEnsemble` backed by pre-computed sample arrays — no RNG draws.
+
+    A frozen ensemble holds the samples already drawn for a single ENSEMBLE
+    axis so the plan can be re-executed over the *same* scenarios (e.g. when
+    extending the PARAMETER grid) without advancing any random generator.
+    Produced by :meth:`DistributionEnsemble.draw_batch`; held by
+    :class:`~simulation.handle.EvaluationHandle` as the accumulated sample set.
+    """
+
+    def __init__(
+        self,
+        axis: Axis,
+        weights: np.ndarray,
+        cached_assignments: dict[GenericIndex, np.ndarray],
+    ) -> None:
+        self._axis = axis
+        self._weights = weights
+        self._cached_assignments = cached_assignments
+
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]:
+        """Single ENSEMBLE axis carrying the frozen samples."""
+        return (self._axis,)
+
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        """Factorized weight vector for the frozen samples, shape ``(size,)``."""
+        return (self._weights,)
+
+    def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
+        """Return the cached batched samples for every abstract index."""
+        return self._cached_assignments
+
+    def concat(self, other: "FrozenEnsemble") -> "FrozenEnsemble":
+        """Return a new frozen ensemble with concatenated samples and proportional weights."""
+        S1 = self._weights.size
+        S2 = other._weights.size
+        alpha = S1 / (S1 + S2)
+        merged_weights = np.concatenate([self._weights * alpha, other._weights * (1.0 - alpha)])
+        merged_assignments = {
+            idx: np.concatenate([self._cached_assignments[idx], other._cached_assignments[idx]])
+            for idx in self._cached_assignments
+        }
+        return FrozenEnsemble(Axis("_ensemble", ENSEMBLE), merged_weights, merged_assignments)
+
+
 class PartitionedEnsemble:
     """Ensemble that distributes abstract indexes across multiple named ENSEMBLE axes.
 
@@ -450,6 +497,35 @@ class DistributionEnsemble:
                     raw = dist.rvs(size=self._size)
                 result[idx] = np.asarray(raw)  # shape (S,)
         return result
+
+    def draw_batch(self, size: int, rng: np.random.Generator) -> FrozenEnsemble:
+        """Draw *size* fresh samples and return them as a :class:`FrozenEnsemble`.
+
+        The caller (e.g. :class:`~simulation.handle.EvaluationHandle`) owns *rng*
+        and passes it in so the ensemble remains stateless — it never stores *rng*
+        and calling this method multiple times with the same *rng* will advance it
+        reproducibly.
+
+        Parameters
+        ----------
+        size:
+            Number of new Monte Carlo samples to draw.
+        rng:
+            Caller-owned :class:`numpy.random.Generator`.  Advanced in-place.
+
+        Returns
+        -------
+        FrozenEnsemble
+            Frozen batch whose samples are identical to what
+            ``DistributionEnsemble(self._scenario, size, rng=rng,
+            exclude=self._exclude)`` would produce.
+        """
+        new_dist = DistributionEnsemble(self._scenario, size, rng=rng, exclude=self._exclude)
+        return FrozenEnsemble(
+            new_dist.ensemble_axes[0],
+            new_dist.ensemble_weights[0],
+            dict(new_dist.assignments()),
+        )
 
     # ------------------------------------------------------------------
     # Legacy iterable interface (backward compatible)

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -1,16 +1,12 @@
 """Generic model evaluation."""
 # SPDX-License-Identifier: Apache-2.0
 
-import concurrent.futures
 import inspect
 import warnings
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
-
-if TYPE_CHECKING:  # pragma: no cover
-    from .handle import AsyncEvaluationHandle, EvaluationHandle
 
 from ..engine.frontend import graph, linearize
 from ..engine.numpybackend import executor
@@ -18,27 +14,11 @@ from ..model.axis import DOMAIN, ENSEMBLE, PARAMETER, Axis
 from ..model.index import GenericIndex
 from ..model.model import Model
 from ..model.model_variant import ModelVariant
-from .ensemble import AxisEnsemble, DistributionEnsemble, Ensemble, WeightedScenario
+from .ensemble import AxisEnsemble, Ensemble, WeightedScenario
 from .plan import EvaluationPlan, Region, RegionGuard
 from .scenario import Scenario
 
 __all__ = ["EvaluationResult", "Evaluation"]
-
-# Lazy-initialised default executor for submit_evaluate().
-# Allocated on first use so that importing this module does not spawn threads
-# for callers who never use async evaluation.
-# Uses a ThreadPoolExecutor: the GIL is released during NumPy computation, so
-# the main thread remains responsive while evaluation runs in the background.
-# Process pools are deferred to v0.11 (out of scope for this milestone).
-_default_executor: concurrent.futures.ThreadPoolExecutor | None = None
-
-
-def _get_default_executor() -> concurrent.futures.ThreadPoolExecutor:
-    """Return (and lazily create) the module-level default ThreadPoolExecutor."""
-    global _default_executor
-    if _default_executor is None:
-        _default_executor = concurrent.futures.ThreadPoolExecutor()
-    return _default_executor
 
 
 def _validate_scenarios(
@@ -1000,169 +980,6 @@ class Evaluation:
             axis_sizes=axis_sizes,
             factorized_weights=factorized_weights,
             named_axis_values=parameter_axes if parameter_axes else None,
-        )
-
-    def evaluate_incremental(
-        self,
-        initial_ensemble_size: int,
-        nodes_of_interest: list[GenericIndex] | None = None,
-        *,
-        parameters: dict[GenericIndex, Any] | None = None,
-        parameter_axes: dict[str, np.ndarray] | None = None,
-        strategy: str = "monolithic",
-        rng: np.random.Generator | None = None,
-        functions: dict[str, executor.Functor] | None = None,
-        backend: type[executor.NumpyBackend] = executor.NumpyBackend,
-    ) -> "EvaluationHandle":
-        """Build a plan, run an initial ensemble, and return an incremental handle.
-
-        The returned :class:`~simulation.handle.EvaluationHandle` holds the first
-        result and can be extended with additional Monte Carlo samples via
-        :meth:`~simulation.handle.EvaluationHandle.extend` without discarding
-        prior results.
-
-        All sample draws (initial and extended) share the same
-        :class:`numpy.random.Generator`, making the full sequence reproducible
-        from a single seed.
-
-        Parameters
-        ----------
-        initial_ensemble_size:
-            Number of scenarios in the first evaluation batch.
-        nodes_of_interest:
-            Indexes to evaluate.  Defaults to all indexes in the model.
-        parameters:
-            PARAMETER axes for multi-dimensional evaluation.  Passed through
-            to every :meth:`execute_plan` call on the handle.
-        strategy:
-            Plan build strategy (``"monolithic"`` or ``"regional"``).
-        rng:
-            Random number generator for reproducibility.  When ``None``, a
-            fresh :func:`numpy.random.default_rng` is created automatically.
-        functions:
-            Optional user-defined functions passed to the executor.
-        backend:
-            The computation backend (currently only ``NumpyBackend``).
-
-        Returns
-        -------
-        EvaluationHandle
-            Incremental handle wrapping the first result.
-        """
-        from .handle import EvaluationHandle  # local import avoids circular dependency
-
-        parameters = parameters or {}
-        if rng is None:
-            rng = np.random.default_rng()
-
-        plan = self.build_plan(nodes_of_interest, strategy=strategy)
-        dist_ensemble = DistributionEnsemble(self._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters))
-        # Draw samples once and freeze them so parameter-extension can reuse the
-        # same scenarios without advancing the RNG a second time.
-        ensemble = dist_ensemble.draw_batch(initial_ensemble_size, rng)
-        result = self.execute_plan(
-            plan, ensemble, parameters=parameters, parameter_axes=parameter_axes, functions=functions, backend=backend
-        )
-        return EvaluationHandle(
-            evaluation=self,
-            plan=plan,
-            result=result,
-            rng=rng,
-            parameters=parameters,
-            parameter_axes=parameter_axes,
-            ensemble=ensemble,
-            ensemble_recipe=dist_ensemble,
-            functions=functions,
-            backend=backend,
-        )
-
-    def submit_evaluate(
-        self,
-        initial_ensemble_size: int,
-        nodes_of_interest: list[GenericIndex] | None = None,
-        *,
-        parameters: dict[GenericIndex, Any] | None = None,
-        parameter_axes: dict[str, np.ndarray] | None = None,
-        strategy: str = "monolithic",
-        rng: np.random.Generator | None = None,
-        functions: dict[str, executor.Functor] | None = None,
-        backend: type[executor.NumpyBackend] = executor.NumpyBackend,
-        pool: concurrent.futures.Executor | None = None,
-    ) -> "AsyncEvaluationHandle":
-        """Submit an evaluation to a background thread and return immediately.
-
-        Mirrors :meth:`evaluate_incremental` but runs the initial
-        :meth:`execute_plan` call on a thread from *exec* (or the module-level
-        :data:`_DEFAULT_EXECUTOR`) so that the caller is not blocked.  The
-        returned :class:`~simulation.handle.AsyncEvaluationHandle` can be
-        polled for status or awaited for its result.
-
-        Once the future resolves, :meth:`~simulation.handle.AsyncEvaluationHandle.extend`
-        works identically to :class:`~simulation.handle.EvaluationHandle`.
-
-        Parameters
-        ----------
-        initial_ensemble_size:
-            Number of scenarios in the first evaluation batch.
-        nodes_of_interest:
-            Indexes to evaluate.  Defaults to all indexes in the model.
-        parameters:
-            PARAMETER axes for multi-dimensional evaluation.
-        strategy:
-            Plan build strategy (``"monolithic"`` or ``"regional"``).
-        rng:
-            Random number generator for reproducibility.  When ``None``, a
-            fresh :func:`numpy.random.default_rng` is created automatically.
-        functions:
-            Optional user-defined functions passed to the executor.
-        backend:
-            The computation backend (currently only ``NumpyBackend``).
-        pool:
-            :class:`concurrent.futures.Executor` to submit the work to.
-            Defaults to a module-level :class:`~concurrent.futures.ThreadPoolExecutor`
-            shared across calls (created lazily on first use).
-
-        Returns
-        -------
-        AsyncEvaluationHandle
-            Handle wrapping the in-flight future.  Call
-            :meth:`~simulation.handle.AsyncEvaluationHandle.get` to block for
-            the result or
-            :meth:`~simulation.handle.AsyncEvaluationHandle.poll` to check
-            without blocking.
-        """
-        from .handle import AsyncEvaluationHandle  # local import avoids circular dependency
-
-        parameters = parameters or {}
-        if rng is None:
-            rng = np.random.default_rng()
-
-        plan = self.build_plan(nodes_of_interest, strategy=strategy)
-        dist_ensemble = DistributionEnsemble(self._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters))
-        # Draw samples in the main thread before submitting so the frozen batch
-        # can be shared safely with the background thread.
-        ensemble = dist_ensemble.draw_batch(initial_ensemble_size, rng)
-        _exec = pool or _get_default_executor()
-        future: concurrent.futures.Future[EvaluationResult] = _exec.submit(
-            self.execute_plan,
-            plan,
-            ensemble,
-            parameters=parameters,
-            parameter_axes=parameter_axes,
-            functions=functions,
-            backend=backend,
-        )
-        return AsyncEvaluationHandle(
-            future=future,
-            evaluation=self,
-            plan=plan,
-            rng=rng,
-            parameters=parameters,
-            parameter_axes=parameter_axes,
-            ensemble=ensemble,
-            ensemble_recipe=dist_ensemble,
-            functions=functions,
-            backend=backend,
         )
 
     def evaluate(

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -1049,7 +1049,7 @@ class Evaluation:
         EvaluationHandle
             Incremental handle wrapping the first result.
         """
-        from .handle import EvaluationHandle, _replay_from_dist  # local import avoids circular dependency
+        from .handle import EvaluationHandle  # local import avoids circular dependency
 
         parameters = parameters or {}
         if rng is None:
@@ -1059,7 +1059,7 @@ class Evaluation:
         dist_ensemble = DistributionEnsemble(self._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters))
         # Draw samples once and freeze them so parameter-extension can reuse the
         # same scenarios without advancing the RNG a second time.
-        ensemble = _replay_from_dist(dist_ensemble)
+        ensemble = dist_ensemble.draw_batch(initial_ensemble_size, rng)
         result = self.execute_plan(
             plan, ensemble, parameters=parameters, parameter_axes=parameter_axes, functions=functions, backend=backend
         )
@@ -1071,6 +1071,7 @@ class Evaluation:
             parameters=parameters,
             parameter_axes=parameter_axes,
             ensemble=ensemble,
+            ensemble_recipe=dist_ensemble,
             functions=functions,
             backend=backend,
         )
@@ -1130,7 +1131,7 @@ class Evaluation:
             :meth:`~simulation.handle.AsyncEvaluationHandle.poll` to check
             without blocking.
         """
-        from .handle import AsyncEvaluationHandle, _replay_from_dist  # local import avoids circular dependency
+        from .handle import AsyncEvaluationHandle  # local import avoids circular dependency
 
         parameters = parameters or {}
         if rng is None:
@@ -1138,9 +1139,9 @@ class Evaluation:
 
         plan = self.build_plan(nodes_of_interest, strategy=strategy)
         dist_ensemble = DistributionEnsemble(self._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters))
-        # Draw samples in the main thread before submitting so the frozen replay
+        # Draw samples in the main thread before submitting so the frozen batch
         # can be shared safely with the background thread.
-        ensemble = _replay_from_dist(dist_ensemble)
+        ensemble = dist_ensemble.draw_batch(initial_ensemble_size, rng)
         _exec = pool or _get_default_executor()
         future: concurrent.futures.Future[EvaluationResult] = _exec.submit(
             self.execute_plan,
@@ -1159,6 +1160,7 @@ class Evaluation:
             parameters=parameters,
             parameter_axes=parameter_axes,
             ensemble=ensemble,
+            ensemble_recipe=dist_ensemble,
             functions=functions,
             backend=backend,
         )

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -1049,14 +1049,17 @@ class Evaluation:
         EvaluationHandle
             Incremental handle wrapping the first result.
         """
-        from .handle import EvaluationHandle  # local import avoids circular dependency
+        from .handle import EvaluationHandle, _replay_from_dist  # local import avoids circular dependency
 
         parameters = parameters or {}
         if rng is None:
             rng = np.random.default_rng()
 
         plan = self.build_plan(nodes_of_interest, strategy=strategy)
-        ensemble = DistributionEnsemble(self._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters))
+        dist_ensemble = DistributionEnsemble(self._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters))
+        # Draw samples once and freeze them so parameter-extension can reuse the
+        # same scenarios without advancing the RNG a second time.
+        ensemble = _replay_from_dist(dist_ensemble)
         result = self.execute_plan(
             plan, ensemble, parameters=parameters, parameter_axes=parameter_axes, functions=functions, backend=backend
         )
@@ -1067,6 +1070,7 @@ class Evaluation:
             rng=rng,
             parameters=parameters,
             parameter_axes=parameter_axes,
+            ensemble=ensemble,
             functions=functions,
             backend=backend,
         )
@@ -1126,14 +1130,17 @@ class Evaluation:
             :meth:`~simulation.handle.AsyncEvaluationHandle.poll` to check
             without blocking.
         """
-        from .handle import AsyncEvaluationHandle  # local import avoids circular dependency
+        from .handle import AsyncEvaluationHandle, _replay_from_dist  # local import avoids circular dependency
 
         parameters = parameters or {}
         if rng is None:
             rng = np.random.default_rng()
 
         plan = self.build_plan(nodes_of_interest, strategy=strategy)
-        ensemble = DistributionEnsemble(self._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters))
+        dist_ensemble = DistributionEnsemble(self._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters))
+        # Draw samples in the main thread before submitting so the frozen replay
+        # can be shared safely with the background thread.
+        ensemble = _replay_from_dist(dist_ensemble)
         _exec = pool or _get_default_executor()
         future: concurrent.futures.Future[EvaluationResult] = _exec.submit(
             self.execute_plan,
@@ -1151,6 +1158,7 @@ class Evaluation:
             rng=rng,
             parameters=parameters,
             parameter_axes=parameter_axes,
+            ensemble=ensemble,
             functions=functions,
             backend=backend,
         )

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -398,8 +398,8 @@ def _frozen_ensemble_from_result(
     excluded_ids = frozenset(id(idx) for idx in parameters)
     assignments: dict[GenericIndex, np.ndarray] = {}
     for idx in scenario.abstract_indexes():
-        if id(idx) in excluded_ids or idx.node not in result._state.values:
-            continue
+        if id(idx) in excluded_ids or idx.node not in result._state.values:  # pragma: no cover
+            continue  # pragma: no cover
         val = np.asarray(result._state.values[idx.node])
         # Drop leading PARAMETER dimensions (all size 1 for ensemble-only nodes)
         # until only the ENSEMBLE dimension(s) remain.  In practice the numpy

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -21,7 +21,6 @@ constructing these classes directly.
 from __future__ import annotations
 
 import concurrent.futures
-from collections.abc import Mapping
 
 import numpy as np
 
@@ -35,61 +34,11 @@ from ..model.index import GenericIndex
 #   handle.py → evaluation.py  (module-level imports below are fine because
 #                                evaluation.py does not import handle.py at
 #                                module level)
+from .ensemble import DistributionEnsemble, FrozenEnsemble
 from .evaluation import Evaluation, EvaluationResult
 from .plan import EvaluationPlan
 
 __all__ = ["AsyncEvaluationHandle", "EvaluationHandle"]
-
-
-class _ReplayEnsemble:
-    """AxisEnsemble backed by pre-computed (frozen) sample arrays — no RNG draws.
-
-    Returned by :func:`_replay_from` and stored on :class:`EvaluationHandle` so
-    that parameter-grid extension can re-run the plan over the *same* scenarios
-    without advancing the RNG a second time.
-    """
-
-    def __init__(
-        self,
-        axis: Axis,
-        weights: np.ndarray,
-        cached_assignments: dict[GenericIndex, np.ndarray],
-    ) -> None:
-        self._axis = axis
-        self._weights = weights
-        self._cached_assignments = cached_assignments
-
-    @property
-    def ensemble_axes(self) -> tuple[Axis, ...]:
-        return (self._axis,)
-
-    @property
-    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
-        return (self._weights,)
-
-    def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
-        return self._cached_assignments
-
-    def concat(self, other: _ReplayEnsemble) -> _ReplayEnsemble:
-        """Return a new replay ensemble with concatenated samples and proportional weights."""
-        S1 = self._weights.size
-        S2 = other._weights.size
-        alpha = S1 / (S1 + S2)
-        merged_weights = np.concatenate([self._weights * alpha, other._weights * (1.0 - alpha)])
-        merged_assignments = {
-            idx: np.concatenate([self._cached_assignments[idx], other._cached_assignments[idx]])
-            for idx in self._cached_assignments
-        }
-        return _ReplayEnsemble(Axis("_ensemble", ENSEMBLE), merged_weights, merged_assignments)
-
-
-def _replay_from_dist(dist_ensemble: object) -> _ReplayEnsemble:
-    """Draw samples from *dist_ensemble* once and wrap them in a :class:`_ReplayEnsemble`."""
-    return _ReplayEnsemble(
-        dist_ensemble.ensemble_axes[0],  # type: ignore[union-attr]
-        dist_ensemble.ensemble_weights[0],  # type: ignore[union-attr]
-        dict(dist_ensemble.assignments()),  # type: ignore[union-attr]
-    )
 
 
 def _merge_results(
@@ -468,6 +417,12 @@ class EvaluationHandle:
         Frozen replay of the initial ensemble's sample draws, used by
         :meth:`extend` when *extra_parameters* is supplied.  ``None`` when
         the handle was constructed without an ensemble (e.g. in tests).
+    ensemble_recipe:
+        The live :class:`~simulation.ensemble.DistributionEnsemble` that was
+        used to draw the initial samples.  Stored so that
+        :meth:`_extend_ensemble_axis` can ask it to draw more samples without
+        re-importing the type or reaching into private evaluation state.
+        ``None`` when the handle was constructed without an ensemble.
     functions:
         Optional user-defined functions passed through to the executor.
     backend:
@@ -483,7 +438,8 @@ class EvaluationHandle:
         rng: np.random.Generator,
         parameters: dict[GenericIndex, np.ndarray],
         parameter_axes: dict[str, np.ndarray] | None = None,
-        ensemble: _ReplayEnsemble | None = None,
+        ensemble: FrozenEnsemble | None = None,
+        ensemble_recipe: DistributionEnsemble | None = None,
         functions: dict[str, executor.Functor] | None = None,
         backend: type[executor.NumpyBackend] = executor.NumpyBackend,
     ) -> None:
@@ -494,6 +450,7 @@ class EvaluationHandle:
         self._parameters = parameters
         self._parameter_axes = parameter_axes
         self._ensemble = ensemble
+        self._ensemble_recipe = ensemble_recipe
         self._functions = functions
         self._backend = backend
 
@@ -520,12 +477,11 @@ class EvaluationHandle:
 
     def _extend_ensemble_axis(self, ensemble_size: int) -> None:
         """Draw *ensemble_size* new scenarios and merge along the ENSEMBLE axis."""
-        from .ensemble import DistributionEnsemble
-
-        new_dist = DistributionEnsemble(
-            self._evaluation._scenario, ensemble_size, rng=self._rng, exclude=frozenset(self._parameters)
+        assert self._ensemble_recipe is not None, (
+            "EvaluationHandle._extend_ensemble_axis() requires an ensemble_recipe. "
+            "Obtain the handle via evaluate_incremental() to enable ensemble extension."
         )
-        new_replay = _replay_from_dist(new_dist)
+        new_replay = self._ensemble_recipe.draw_batch(ensemble_size, self._rng)
         new_result = self._evaluation.execute_plan(
             self._plan, new_replay,
             parameters=self._parameters, parameter_axes=self._parameter_axes,
@@ -662,6 +618,9 @@ class AsyncEvaluationHandle(EvaluationHandle):
     ensemble:
         Frozen replay of the initial ensemble's sample draws (see
         :class:`EvaluationHandle`).
+    ensemble_recipe:
+        The live ensemble used to draw the initial samples (see
+        :class:`EvaluationHandle`).
     functions:
         Optional user-defined functions passed through to the executor.
     backend:
@@ -677,7 +636,8 @@ class AsyncEvaluationHandle(EvaluationHandle):
         rng: np.random.Generator,
         parameters: dict[GenericIndex, np.ndarray],
         parameter_axes: dict[str, np.ndarray] | None,
-        ensemble: _ReplayEnsemble | None,
+        ensemble: FrozenEnsemble | None,
+        ensemble_recipe: DistributionEnsemble | None,
         functions: dict[str, executor.Functor] | None,
         backend: type[executor.NumpyBackend],
     ) -> None:
@@ -689,6 +649,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
             parameters=parameters,
             parameter_axes=parameter_axes,
             ensemble=ensemble,
+            ensemble_recipe=ensemble_recipe,
             functions=functions,
             backend=backend,
         )

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -12,15 +12,15 @@ background thread and the handle exposes :meth:`~AsyncEvaluationHandle.poll` and
 Once the future resolves, :meth:`~AsyncEvaluationHandle.extend` works identically
 to the synchronous base class.
 
-Obtain instances via
-:meth:`~simulation.evaluation.Evaluation.evaluate_incremental` (synchronous) or
-:meth:`~simulation.evaluation.Evaluation.submit_evaluate` (asynchronous) rather than
-constructing these classes directly.
+Obtain instances via :meth:`EvaluationHandle.from_evaluation` (synchronous) or
+:meth:`AsyncEvaluationHandle.from_evaluation` (asynchronous) rather than constructing
+these classes directly.
 """
 
 from __future__ import annotations
 
 import concurrent.futures
+from typing import Any
 
 import numpy as np
 
@@ -28,15 +28,28 @@ from ..engine.frontend import graph
 from ..engine.numpybackend import executor
 from ..model.axis import ENSEMBLE, PARAMETER, Axis
 from ..model.index import GenericIndex
-
-# Imported at runtime to avoid circular imports:
-#   evaluation.py → handle.py  (local import inside evaluate_incremental)
-#   handle.py → evaluation.py  (module-level imports below are fine because
-#                                evaluation.py does not import handle.py at
-#                                module level)
-from .ensemble import BatchDrawable, FrozenEnsemble
+from .ensemble import BatchDrawable, DistributionEnsemble, FrozenEnsemble
 from .evaluation import Evaluation, EvaluationResult
 from .plan import EvaluationPlan
+
+# ---------------------------------------------------------------------------
+# Module-level thread-pool executor (shared across all async evaluations)
+# ---------------------------------------------------------------------------
+
+# Allocated lazily on first use so that importing this module does not spawn
+# threads for callers who never use async evaluation.
+# Uses a ThreadPoolExecutor: the GIL is released during NumPy computation, so
+# the main thread remains responsive while evaluation runs in the background.
+_default_executor: concurrent.futures.ThreadPoolExecutor | None = None
+
+
+def _get_default_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Return (and lazily create) the module-level default ThreadPoolExecutor."""
+    global _default_executor
+    if _default_executor is None:
+        _default_executor = concurrent.futures.ThreadPoolExecutor()
+    return _default_executor
+
 
 __all__ = ["AsyncEvaluationHandle", "EvaluationHandle"]
 
@@ -123,21 +136,15 @@ def _merge_results(
         grow_ax_2, ens_pos2 = grow_entry_2
         if ens_pos != ens_pos2:
             raise ValueError(
-                f"Growing ENSEMBLE axis {merge_axis_name!r} is at dim {ens_pos} in r1 "
-                f"but dim {ens_pos2} in r2."
-            )
-        # Validate the fixed ENSEMBLE axes match by name, position, and size.
-        def _fixed_ens_sig(
-            axes: list[tuple[Axis, int]], sizes: dict[Axis, int]
-        ) -> frozenset[tuple[str, int, int]]:
-            return frozenset(
-                (ax.name, pos, sizes[ax]) for ax, pos in axes if ax.name != merge_axis_name
+                f"Growing ENSEMBLE axis {merge_axis_name!r} is at dim {ens_pos} in r1 but dim {ens_pos2} in r2."
             )
 
+        # Validate the fixed ENSEMBLE axes match by name, position, and size.
+        def _fixed_ens_sig(axes: list[tuple[Axis, int]], sizes: dict[Axis, int]) -> frozenset[tuple[str, int, int]]:
+            return frozenset((ax.name, pos, sizes[ax]) for ax, pos in axes if ax.name != merge_axis_name)
+
         if _fixed_ens_sig(ens_1, r1._axis_sizes) != _fixed_ens_sig(ens_2, r2._axis_sizes):
-            raise ValueError(
-                "_merge_results: fixed ENSEMBLE axis layouts differ between r1 and r2."
-            )
+            raise ValueError("_merge_results: fixed ENSEMBLE axis layouts differ between r1 and r2.")
 
     S1: int = r1._axis_sizes[grow_ax_1]
     S2: int = r2._axis_sizes[grow_ax_2]
@@ -265,9 +272,7 @@ def _merge_results_param_extend(
     ax_ens, ens_pos = ens_1[0]
     _, ens_pos2 = ens_2[0]
     if ens_pos != ens_pos2:
-        raise ValueError(
-            f"ENSEMBLE axis position mismatch: r1 at dim {ens_pos}, r2 at dim {ens_pos2}."
-        )
+        raise ValueError(f"ENSEMBLE axis position mismatch: r1 at dim {ens_pos}, r2 at dim {ens_pos2}.")
     S = r1._axis_sizes[ax_ens]
     S2_check = r2._axis_sizes[ens_2[0][0]]
     if S != S2_check:
@@ -294,23 +299,17 @@ def _merge_results_param_extend(
         None,
     )
     if grow_ax_2 is None:
-        raise ValueError(
-            f"_merge_results_param_extend: no PARAMETER axis named {param_name!r} in r2."
-        )
+        raise ValueError(f"_merge_results_param_extend: no PARAMETER axis named {param_name!r} in r2.")
     P2 = r2._axis_sizes[grow_ax_2]
 
     # --- Validate fixed PARAMETER axes ---
     def _fixed_sig(layout: dict[Axis, int], sizes: dict[Axis, int]) -> frozenset[tuple[str, int, int]]:
         return frozenset(
-            (ax.name, pos, sizes[ax])
-            for ax, pos in layout.items()
-            if ax.role == PARAMETER and ax.name != param_name
+            (ax.name, pos, sizes[ax]) for ax, pos in layout.items() if ax.role == PARAMETER and ax.name != param_name
         )
 
     if _fixed_sig(r1._axis_layout, r1._axis_sizes) != _fixed_sig(r2._axis_layout, r2._axis_sizes):
-        raise ValueError(
-            "_merge_results_param_extend: fixed PARAMETER axis layouts differ between r1 and r2."
-        )
+        raise ValueError("_merge_results_param_extend: fixed PARAMETER axis layouts differ between r1 and r2.")
 
     # --- Concatenate node arrays along the growing PARAMETER axis ---
     merged_values: dict[graph.Node, np.ndarray] = {}
@@ -387,8 +386,7 @@ class EvaluationHandle:
         :class:`~simulation.ensemble.CrossProductEnsemble`, and
         :class:`~simulation.ensemble.PartitionedEnsemble` all do.
 
-    Obtain an instance via
-    :meth:`~simulation.evaluation.Evaluation.evaluate_incremental` rather than
+    Obtain an instance via :meth:`EvaluationHandle.from_evaluation` rather than
     constructing this class directly.
 
     Parameters
@@ -467,6 +465,88 @@ class EvaluationHandle:
         return self._result
 
     # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_evaluation(
+        cls,
+        evaluation: Evaluation,
+        initial_ensemble_size: int,
+        nodes_of_interest: list[GenericIndex] | None = None,
+        *,
+        parameters: dict[GenericIndex, Any] | None = None,
+        parameter_axes: dict[str, np.ndarray] | None = None,
+        strategy: str = "monolithic",
+        rng: np.random.Generator | None = None,
+        functions: dict[str, executor.Functor] | None = None,
+        backend: type[executor.NumpyBackend] = executor.NumpyBackend,
+    ) -> "EvaluationHandle":
+        """Build a plan, run an initial ensemble, and return an incremental handle.
+
+        The returned :class:`EvaluationHandle` holds the first result and can be
+        extended with additional Monte Carlo samples via :meth:`extend` without
+        discarding prior results.
+
+        All sample draws (initial and extended) share the same
+        :class:`numpy.random.Generator`, making the full sequence reproducible
+        from a single seed.
+
+        Parameters
+        ----------
+        evaluation:
+            The :class:`~simulation.evaluation.Evaluation` to run.
+        initial_ensemble_size:
+            Number of scenarios in the first evaluation batch.
+        nodes_of_interest:
+            Indexes to evaluate.  Defaults to all indexes in the model.
+        parameters:
+            PARAMETER axes for multi-dimensional evaluation.
+        parameter_axes:
+            Named PARAMETER axes for correlated sweeps.
+        strategy:
+            Plan build strategy (``"monolithic"`` or ``"regional"``).
+        rng:
+            Random number generator for reproducibility.  When ``None``, a
+            fresh :func:`numpy.random.default_rng` is created automatically.
+        functions:
+            Optional user-defined functions passed to the executor.
+        backend:
+            The computation backend (currently only ``NumpyBackend``).
+
+        Returns
+        -------
+        EvaluationHandle
+            Incremental handle wrapping the first result.
+        """
+        parameters = parameters or {}
+        if rng is None:
+            rng = np.random.default_rng()
+
+        plan = evaluation.build_plan(nodes_of_interest, strategy=strategy)
+        dist_ensemble = DistributionEnsemble(
+            evaluation._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters)
+        )
+        # Draw samples once and freeze them so parameter-extension can reuse the
+        # same scenarios without advancing the RNG a second time.
+        ensemble = dist_ensemble.draw_batch(initial_ensemble_size, rng)
+        result = evaluation.execute_plan(
+            plan, ensemble, parameters=parameters, parameter_axes=parameter_axes, functions=functions, backend=backend
+        )
+        return cls(
+            evaluation=evaluation,
+            plan=plan,
+            result=result,
+            rng=rng,
+            parameters=parameters,
+            parameter_axes=parameter_axes,
+            ensemble=ensemble,
+            ensemble_recipe=dist_ensemble,
+            functions=functions,
+            backend=backend,
+        )
+
+    # ------------------------------------------------------------------
     # Private helpers — one primitive operation each
     # ------------------------------------------------------------------
 
@@ -485,7 +565,7 @@ class EvaluationHandle:
         """
         assert self._ensemble_recipe is not None, (
             "EvaluationHandle._extend_ensemble_axis() requires an ensemble_recipe. "
-            "Obtain the handle via evaluate_incremental() to enable ensemble extension."
+            "Obtain the handle via EvaluationHandle.from_evaluation() to enable ensemble extension."
         )
         new_batch = self._ensemble_recipe.draw_batch(ensemble_size, self._rng, axis=axis)
         if axis is not None and self._ensemble is not None and len(self._ensemble.ensemble_axes) > 1:
@@ -495,9 +575,12 @@ class EvaluationHandle:
         else:
             execution_ensemble = new_batch
         new_result = self._evaluation.execute_plan(
-            self._plan, execution_ensemble,
-            parameters=self._parameters, parameter_axes=self._parameter_axes,
-            functions=self._functions, backend=self._backend,
+            self._plan,
+            execution_ensemble,
+            parameters=self._parameters,
+            parameter_axes=self._parameter_axes,
+            functions=self._functions,
+            backend=self._backend,
         )
         assert self._result is not None
         self._result = _merge_results(self._result, new_result, self._plan, merge_axis_name=axis)
@@ -512,10 +595,12 @@ class EvaluationHandle:
         assert self._result is not None
         assert self._ensemble is not None
         r_extra = self._evaluation.execute_plan(
-            self._plan, self._ensemble,
+            self._plan,
+            self._ensemble,
             parameters={**self._parameters, param_idx: extra_vals},
             parameter_axes=self._parameter_axes,
-            functions=self._functions, backend=self._backend,
+            functions=self._functions,
+            backend=self._backend,
         )
         self._result = _merge_results_param_extend(self._result, r_extra, self._plan, param_idx)
         self._parameters = {
@@ -591,7 +676,10 @@ class EvaluationHandle:
             Explicit multi-axis ENSEMBLE extension dict ``{axis_name: N}``.
             Mutually exclusive with *ensemble_size* > 0.
         extra_parameters:
-            PARAMETER extension dict ``{idx: extra_array}``.
+            Dict ``{idx: extra_array, ...}`` extending the PARAMETER sweep for
+            each *idx*.  Every key must already be present in the
+            ``parameters=`` dict passed to
+            :meth:`EvaluationHandle.from_evaluation`.
 
         Returns
         -------
@@ -663,8 +751,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
     :class:`~simulation.ensemble.BatchDrawable` contract that the
     *ensemble_recipe* must satisfy.
 
-    Obtain an instance via
-    :meth:`~simulation.evaluation.Evaluation.submit_evaluate` rather than
+    Obtain an instance via :meth:`AsyncEvaluationHandle.from_evaluation` rather than
     constructing this class directly.
 
     Parameters
@@ -721,6 +808,103 @@ class AsyncEvaluationHandle(EvaluationHandle):
             backend=backend,
         )
         self._future = future
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_evaluation(
+        cls,
+        evaluation: Evaluation,
+        initial_ensemble_size: int,
+        nodes_of_interest: list[GenericIndex] | None = None,
+        *,
+        parameters: dict[GenericIndex, Any] | None = None,
+        parameter_axes: dict[str, np.ndarray] | None = None,
+        strategy: str = "monolithic",
+        rng: np.random.Generator | None = None,
+        functions: dict[str, executor.Functor] | None = None,
+        backend: type[executor.NumpyBackend] = executor.NumpyBackend,
+        pool: concurrent.futures.Executor | None = None,
+    ) -> "AsyncEvaluationHandle":
+        """Submit an evaluation to a background thread and return immediately.
+
+        Mirrors :meth:`EvaluationHandle.from_evaluation` but runs the initial
+        :meth:`~simulation.evaluation.Evaluation.execute_plan` call on a thread
+        from *pool* (or the module-level default
+        :class:`~concurrent.futures.ThreadPoolExecutor`) so that the caller is
+        not blocked.  The returned handle can be polled for status or awaited
+        for its result.
+
+        Once the future resolves, :meth:`extend` works identically to
+        :class:`EvaluationHandle`.
+
+        Parameters
+        ----------
+        evaluation:
+            The :class:`~simulation.evaluation.Evaluation` to run.
+        initial_ensemble_size:
+            Number of scenarios in the first evaluation batch.
+        nodes_of_interest:
+            Indexes to evaluate.  Defaults to all indexes in the model.
+        parameters:
+            PARAMETER axes for multi-dimensional evaluation.
+        parameter_axes:
+            Named PARAMETER axes for correlated sweeps.
+        strategy:
+            Plan build strategy (``"monolithic"`` or ``"regional"``).
+        rng:
+            Random number generator for reproducibility.  When ``None``, a
+            fresh :func:`numpy.random.default_rng` is created automatically.
+        functions:
+            Optional user-defined functions passed to the executor.
+        backend:
+            The computation backend (currently only ``NumpyBackend``).
+        pool:
+            :class:`concurrent.futures.Executor` to submit the work to.
+            Defaults to a module-level :class:`~concurrent.futures.ThreadPoolExecutor`
+            shared across calls (created lazily on first use).
+
+        Returns
+        -------
+        AsyncEvaluationHandle
+            Handle wrapping the in-flight future.  Call :meth:`get` to block
+            for the result or :meth:`poll` to check without blocking.
+        """
+        parameters = parameters or {}
+        if rng is None:
+            rng = np.random.default_rng()
+
+        plan = evaluation.build_plan(nodes_of_interest, strategy=strategy)
+        dist_ensemble = DistributionEnsemble(
+            evaluation._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters)
+        )
+        # Draw samples in the main thread before submitting so the frozen batch
+        # can be shared safely with the background thread.
+        ensemble = dist_ensemble.draw_batch(initial_ensemble_size, rng)
+        _exec = pool or _get_default_executor()
+        future: concurrent.futures.Future[EvaluationResult] = _exec.submit(
+            evaluation.execute_plan,
+            plan,
+            ensemble,
+            parameters=parameters,
+            parameter_axes=parameter_axes,
+            functions=functions,
+            backend=backend,
+        )
+        return cls(
+            future=future,
+            evaluation=evaluation,
+            plan=plan,
+            rng=rng,
+            parameters=parameters,
+            parameter_axes=parameter_axes,
+            ensemble=ensemble,
+            ensemble_recipe=dist_ensemble,
+            functions=functions,
+            backend=backend,
+        )
 
     # ------------------------------------------------------------------
     # Internal

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -12,8 +12,8 @@ background thread and the handle exposes :meth:`~AsyncEvaluationHandle.poll` and
 Once the future resolves, :meth:`~AsyncEvaluationHandle.extend` works identically
 to the synchronous base class.
 
-Obtain instances via :meth:`EvaluationHandle.from_evaluation` (synchronous) or
-:meth:`AsyncEvaluationHandle.from_evaluation` (asynchronous) rather than constructing
+Obtain instances via :meth:`EvaluationHandle.evaluate` (synchronous) or
+:meth:`AsyncEvaluationHandle.evaluate` (asynchronous) rather than constructing
 these classes directly.
 """
 
@@ -31,6 +31,7 @@ from ..model.index import GenericIndex
 from .ensemble import BatchDrawable, DistributionEnsemble, FrozenEnsemble
 from .evaluation import Evaluation, EvaluationResult
 from .plan import EvaluationPlan
+from .scenario import Scenario
 
 # ---------------------------------------------------------------------------
 # Module-level thread-pool executor (shared across all async evaluations)
@@ -349,10 +350,15 @@ def _merge_results_param_extend(
 
     # Concatenate the growing parameter's value array.
     merged_parameter_arrays: dict[GenericIndex, np.ndarray] = dict(r1._parameter_arrays)
-    if param_idx in r1._parameter_arrays and param_idx in r2._parameter_arrays:
-        merged_parameter_arrays[param_idx] = np.concatenate(
-            [r1._parameter_arrays[param_idx], r2._parameter_arrays[param_idx]]
+    if param_idx not in r1._parameter_arrays or param_idx not in r2._parameter_arrays:  # pragma: no cover
+        raise ValueError(  # pragma: no cover
+            f"_merge_results_param_extend: parameter index {param_name!r} is not tracked in "
+            "parameter_arrays.  PARAMETER axis extension requires indexes supplied via "
+            "parameters=, not parameter_axes=."
         )
+    merged_parameter_arrays[param_idx] = np.concatenate(
+        [r1._parameter_arrays[param_idx], r2._parameter_arrays[param_idx]]
+    )
 
     merged_state = executor.State(merged_values)
     return EvaluationResult(
@@ -363,6 +369,47 @@ def _merge_results_param_extend(
         factorized_weights=merged_factorized_weights,
         named_axis_values=r1._named_axis_values or None,
     )
+
+
+def _frozen_ensemble_from_result(
+    result: EvaluationResult,
+    scenario: Scenario,
+    parameters: dict[GenericIndex, np.ndarray],
+) -> FrozenEnsemble:
+    """Reconstruct a :class:`FrozenEnsemble` from a materialised :class:`EvaluationResult`.
+
+    Extracts the abstract (ensemble-assigned) index values from the result's
+    state dict.  These nodes are singleton on all PARAMETER dimensions and
+    full-sized on the ENSEMBLE dimension(s), so they faithfully replay the
+    original random draws when fed back into :meth:`~evaluation.Evaluation.execute_plan`.
+
+    Used by :meth:`EvaluationHandle._extend_param_axis` when no frozen sample
+    snapshot is available (e.g. on handles produced by
+    :meth:`~simulation.runner.ModelEvaluator.resume`).
+    """
+    ens_entries = sorted(
+        ((ax, pos) for ax, pos in result._axis_layout.items() if ax.role == ENSEMBLE),
+        key=lambda t: t[1],
+    )
+    axes = tuple(ax for ax, _ in ens_entries)
+    weights = tuple(result._factorized_weights[ax] for ax in axes)
+    n_ens_dims = len(axes)
+
+    excluded_ids = frozenset(id(idx) for idx in parameters)
+    assignments: dict[GenericIndex, np.ndarray] = {}
+    for idx in scenario.abstract_indexes():
+        if id(idx) in excluded_ids or idx.node not in result._state.values:
+            continue
+        val = np.asarray(result._state.values[idx.node])
+        # Drop leading PARAMETER dimensions (all size 1 for ensemble-only nodes)
+        # until only the ENSEMBLE dimension(s) remain.  In practice the numpy
+        # executor stores abstract-index nodes at their original assignment shape
+        # so this loop is never entered; it is a safety net for alternative
+        # executor implementations.
+        while val.ndim > n_ens_dims:
+            val = val[0]  # pragma: no cover
+        assignments[idx] = val
+    return FrozenEnsemble(axes, weights, assignments)
 
 
 class EvaluationHandle:
@@ -386,7 +433,7 @@ class EvaluationHandle:
         :class:`~simulation.ensemble.CrossProductEnsemble`, and
         :class:`~simulation.ensemble.PartitionedEnsemble` all do.
 
-    Obtain an instance via :meth:`EvaluationHandle.from_evaluation` rather than
+    Obtain an instance via :meth:`EvaluationHandle.evaluate` rather than
     constructing this class directly.
 
     Parameters
@@ -469,12 +516,13 @@ class EvaluationHandle:
     # ------------------------------------------------------------------
 
     @classmethod
-    def from_evaluation(
+    def evaluate(
         cls,
         evaluation: Evaluation,
         initial_ensemble_size: int,
         nodes_of_interest: list[GenericIndex] | None = None,
         *,
+        ensemble_recipe: BatchDrawable | None = None,
         parameters: dict[GenericIndex, Any] | None = None,
         parameter_axes: dict[str, np.ndarray] | None = None,
         strategy: str = "monolithic",
@@ -497,9 +545,23 @@ class EvaluationHandle:
         evaluation:
             The :class:`~simulation.evaluation.Evaluation` to run.
         initial_ensemble_size:
-            Number of scenarios in the first evaluation batch.
+            Number of scenarios in the first evaluation batch.  Passed to
+            :meth:`~simulation.ensemble.BatchDrawable.draw_batch` as *size*.
+            For :class:`~simulation.ensemble.DistributionEnsemble` this is the
+            total number of Monte Carlo samples; for
+            :class:`~simulation.ensemble.CrossProductEnsemble` it is the number
+            of samples per categorical combination.
         nodes_of_interest:
             Indexes to evaluate.  Defaults to all indexes in the model.
+        ensemble_recipe:
+            The :class:`~simulation.ensemble.BatchDrawable` ensemble to use for
+            sampling.  When ``None`` (default) a fresh
+            :class:`~simulation.ensemble.DistributionEnsemble` is built
+            automatically from *evaluation*'s scenario.  Supply a
+            :class:`~simulation.ensemble.CrossProductEnsemble` or single-axis
+            :class:`~simulation.ensemble.PartitionedEnsemble` here to use those
+            sampling strategies for both the initial batch and all future
+            :meth:`extend` calls.
         parameters:
             PARAMETER axes for multi-dimensional evaluation.
         parameter_axes:
@@ -524,12 +586,13 @@ class EvaluationHandle:
             rng = np.random.default_rng()
 
         plan = evaluation.build_plan(nodes_of_interest, strategy=strategy)
-        dist_ensemble = DistributionEnsemble(
-            evaluation._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters)
-        )
+        if ensemble_recipe is None:
+            ensemble_recipe = DistributionEnsemble(
+                evaluation._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters)
+            )
         # Draw samples once and freeze them so parameter-extension can reuse the
         # same scenarios without advancing the RNG a second time.
-        ensemble = dist_ensemble.draw_batch(initial_ensemble_size, rng)
+        ensemble = ensemble_recipe.draw_batch(initial_ensemble_size, rng)
         result = evaluation.execute_plan(
             plan, ensemble, parameters=parameters, parameter_axes=parameter_axes, functions=functions, backend=backend
         )
@@ -541,7 +604,7 @@ class EvaluationHandle:
             parameters=parameters,
             parameter_axes=parameter_axes,
             ensemble=ensemble,
-            ensemble_recipe=dist_ensemble,
+            ensemble_recipe=ensemble_recipe,
             functions=functions,
             backend=backend,
         )
@@ -563,10 +626,11 @@ class EvaluationHandle:
             :class:`~simulation.ensemble.PartitionedEnsemble`): name of the
             ENSEMBLE axis to grow.  ``None`` for single-axis ensembles.
         """
-        assert self._ensemble_recipe is not None, (
-            "EvaluationHandle._extend_ensemble_axis() requires an ensemble_recipe. "
-            "Obtain the handle via EvaluationHandle.from_evaluation() to enable ensemble extension."
-        )
+        if self._ensemble_recipe is None:
+            raise RuntimeError(
+                "EvaluationHandle._extend_ensemble_axis() requires an ensemble_recipe. "
+                "Obtain the handle via EvaluationHandle.evaluate() to enable ensemble extension."
+            )
         new_batch = self._ensemble_recipe.draw_batch(ensemble_size, self._rng, axis=axis)
         if axis is not None and self._ensemble is not None and len(self._ensemble.ensemble_axes) > 1:
             # Multi-axis: pair fresh samples for the target axis with the existing
@@ -593,10 +657,18 @@ class EvaluationHandle:
     def _extend_param_axis(self, param_idx: GenericIndex, extra_vals: np.ndarray) -> None:
         """Re-run the stored ensemble at *extra_vals* and merge along the PARAMETER axis."""
         assert self._result is not None
-        assert self._ensemble is not None
+        # Use the stored frozen snapshot when available; otherwise reconstruct one
+        # from the materialised result state (e.g. on resumed handles).  Both
+        # paths produce the same abstract-index values because ensemble-only nodes
+        # are singleton on all PARAMETER dimensions and full-sized on ENSEMBLE.
+        ensemble = (
+            self._ensemble
+            if self._ensemble is not None
+            else _frozen_ensemble_from_result(self._result, self._evaluation._scenario, self._parameters)
+        )
         r_extra = self._evaluation.execute_plan(
             self._plan,
-            self._ensemble,
+            ensemble,
             parameters={**self._parameters, param_idx: extra_vals},
             parameter_axes=self._parameter_axes,
             functions=self._functions,
@@ -648,11 +720,22 @@ class EvaluationHandle:
         ``extra_parameters={idx: extra_array, ...}`` re-runs the plan over
         new parameter values using the **same** frozen sample draws and merges
         along each PARAMETER axis.  Every key must already be present in the
-        ``parameters=`` dict passed to
-        :meth:`~simulation.evaluation.Evaluation.evaluate_incremental`.
+        ``parameters=`` dict passed to :meth:`EvaluationHandle.evaluate`.
         Multiple entries are processed one axis at a time::
 
             handle.extend(extra_parameters={x1: np.array([0.9, 1.0])})
+
+        .. note::
+
+            PARAMETER extension requires a single ENSEMBLE axis.  Handles
+            backed by multi-axis :class:`~simulation.ensemble.PartitionedEnsemble`
+            recipes will raise :class:`ValueError` from
+            :func:`_merge_results_param_extend`.
+
+            When no frozen sample snapshot is stored (e.g. on handles produced
+            by :meth:`~simulation.runner.ModelEvaluator.resume`), the abstract
+            index values are reconstructed from the materialised result state
+            so the common-random-numbers guarantee is preserved.
 
         Combined
         --------
@@ -679,7 +762,7 @@ class EvaluationHandle:
             Dict ``{idx: extra_array, ...}`` extending the PARAMETER sweep for
             each *idx*.  Every key must already be present in the
             ``parameters=`` dict passed to
-            :meth:`EvaluationHandle.from_evaluation`.
+            :meth:`EvaluationHandle.evaluate`.
 
         Returns
         -------
@@ -721,11 +804,6 @@ class EvaluationHandle:
                     f"extend(extra_parameters=): {names} not in the original parameters= dict. "
                     "Only existing parameter axes can be extended."
                 )
-            if self._ensemble is None:
-                raise RuntimeError(
-                    "EvaluationHandle has no stored ensemble; extra_parameters extension is unavailable. "
-                    "Obtain the handle via evaluate_incremental() to enable this feature."
-                )
 
         if ensemble_size > 0:
             self._extend_ensemble_axis(ensemble_size, axis=None)
@@ -751,7 +829,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
     :class:`~simulation.ensemble.BatchDrawable` contract that the
     *ensemble_recipe* must satisfy.
 
-    Obtain an instance via :meth:`AsyncEvaluationHandle.from_evaluation` rather than
+    Obtain an instance via :meth:`AsyncEvaluationHandle.evaluate` rather than
     constructing this class directly.
 
     Parameters
@@ -814,12 +892,13 @@ class AsyncEvaluationHandle(EvaluationHandle):
     # ------------------------------------------------------------------
 
     @classmethod
-    def from_evaluation(
+    def evaluate(
         cls,
         evaluation: Evaluation,
         initial_ensemble_size: int,
         nodes_of_interest: list[GenericIndex] | None = None,
         *,
+        ensemble_recipe: BatchDrawable | None = None,
         parameters: dict[GenericIndex, Any] | None = None,
         parameter_axes: dict[str, np.ndarray] | None = None,
         strategy: str = "monolithic",
@@ -830,7 +909,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
     ) -> AsyncEvaluationHandle:
         """Submit an evaluation to a background thread and return immediately.
 
-        Mirrors :meth:`EvaluationHandle.from_evaluation` but runs the initial
+        Mirrors :meth:`EvaluationHandle.evaluate` but runs the initial
         :meth:`~simulation.evaluation.Evaluation.execute_plan` call on a thread
         from *pool* (or the module-level default
         :class:`~concurrent.futures.ThreadPoolExecutor`) so that the caller is
@@ -848,6 +927,9 @@ class AsyncEvaluationHandle(EvaluationHandle):
             Number of scenarios in the first evaluation batch.
         nodes_of_interest:
             Indexes to evaluate.  Defaults to all indexes in the model.
+        ensemble_recipe:
+            Optional :class:`~simulation.ensemble.BatchDrawable` recipe; see
+            :meth:`EvaluationHandle.evaluate` for details.
         parameters:
             PARAMETER axes for multi-dimensional evaluation.
         parameter_axes:
@@ -877,12 +959,13 @@ class AsyncEvaluationHandle(EvaluationHandle):
             rng = np.random.default_rng()
 
         plan = evaluation.build_plan(nodes_of_interest, strategy=strategy)
-        dist_ensemble = DistributionEnsemble(
-            evaluation._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters)
-        )
+        if ensemble_recipe is None:
+            ensemble_recipe = DistributionEnsemble(
+                evaluation._scenario, initial_ensemble_size, rng=rng, exclude=frozenset(parameters)
+            )
         # Draw samples in the main thread before submitting so the frozen batch
         # can be shared safely with the background thread.
-        ensemble = dist_ensemble.draw_batch(initial_ensemble_size, rng)
+        ensemble = ensemble_recipe.draw_batch(initial_ensemble_size, rng)
         _exec = pool or _get_default_executor()
         future: concurrent.futures.Future[EvaluationResult] = _exec.submit(
             evaluation.execute_plan,
@@ -901,7 +984,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
             parameters=parameters,
             parameter_axes=parameter_axes,
             ensemble=ensemble,
-            ensemble_recipe=dist_ensemble,
+            ensemble_recipe=ensemble_recipe,
             functions=functions,
             backend=backend,
         )

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -481,7 +481,7 @@ class EvaluationHandle:
         rng: np.random.Generator | None = None,
         functions: dict[str, executor.Functor] | None = None,
         backend: type[executor.NumpyBackend] = executor.NumpyBackend,
-    ) -> "EvaluationHandle":
+    ) -> EvaluationHandle:
         """Build a plan, run an initial ensemble, and return an incremental handle.
 
         The returned :class:`EvaluationHandle` holds the first result and can be
@@ -827,7 +827,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
         functions: dict[str, executor.Functor] | None = None,
         backend: type[executor.NumpyBackend] = executor.NumpyBackend,
         pool: concurrent.futures.Executor | None = None,
-    ) -> "AsyncEvaluationHandle":
+    ) -> AsyncEvaluationHandle:
         """Submit an evaluation to a background thread and return immediately.
 
         Mirrors :meth:`EvaluationHandle.from_evaluation` but runs the initial
@@ -1002,6 +1002,4 @@ class AsyncEvaluationHandle(EvaluationHandle):
                 "AsyncEvaluationHandle: cannot extend before the evaluation completes. Call .get() or .poll() first."
             )
         self._resolve()  # populate self._result before super().extend() reads it
-        return super().extend(
-            ensemble_size, extra_ensemble=extra_ensemble, extra_parameters=extra_parameters
-        )
+        return super().extend(ensemble_size, extra_ensemble=extra_ensemble, extra_parameters=extra_parameters)

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -34,7 +34,7 @@ from ..model.index import GenericIndex
 #   handle.py → evaluation.py  (module-level imports below are fine because
 #                                evaluation.py does not import handle.py at
 #                                module level)
-from .ensemble import DistributionEnsemble, FrozenEnsemble
+from .ensemble import BatchDrawable, FrozenEnsemble
 from .evaluation import Evaluation, EvaluationResult
 from .plan import EvaluationPlan
 
@@ -379,18 +379,13 @@ class EvaluationHandle:
 
     .. note::
 
-        Both the initial evaluation (via
-        :meth:`~simulation.evaluation.Evaluation.evaluate_incremental`) and
-        every subsequent :meth:`extend` call use
-        :class:`~simulation.ensemble.DistributionEnsemble` to generate
-        scenarios.  This means the model's abstract indexes must all be either
-        :class:`~model.index.Distribution`-backed or
-        :class:`~model.index.CategoricalIndex`.  Models that require
-        :class:`~simulation.ensemble.CrossProductEnsemble` or
-        :class:`~simulation.ensemble.PartitionedEnsemble` cannot be used with
-        this handle; use
-        :meth:`~simulation.evaluation.Evaluation.execute_plan` directly
-        instead.
+        :meth:`extend` delegates ensemble growth to the stored
+        *ensemble_recipe* via the :class:`~simulation.ensemble.BatchDrawable`
+        protocol.  Any ensemble type that implements :meth:`draw_batch
+        <simulation.ensemble.BatchDrawable.draw_batch>` can serve as the
+        recipe — :class:`~simulation.ensemble.DistributionEnsemble`,
+        :class:`~simulation.ensemble.CrossProductEnsemble`, and
+        :class:`~simulation.ensemble.PartitionedEnsemble` all do.
 
     Obtain an instance via
     :meth:`~simulation.evaluation.Evaluation.evaluate_incremental` rather than
@@ -418,11 +413,11 @@ class EvaluationHandle:
         :meth:`extend` when *extra_parameters* is supplied.  ``None`` when
         the handle was constructed without an ensemble (e.g. in tests).
     ensemble_recipe:
-        The live :class:`~simulation.ensemble.DistributionEnsemble` that was
+        The live :class:`~simulation.ensemble.BatchDrawable` ensemble that was
         used to draw the initial samples.  Stored so that
         :meth:`_extend_ensemble_axis` can ask it to draw more samples without
-        re-importing the type or reaching into private evaluation state.
-        ``None`` when the handle was constructed without an ensemble.
+        naming any concrete ensemble class or reaching into private evaluation
+        state.  ``None`` when the handle was constructed without an ensemble.
     functions:
         Optional user-defined functions passed through to the executor.
     backend:
@@ -439,7 +434,7 @@ class EvaluationHandle:
         parameters: dict[GenericIndex, np.ndarray],
         parameter_axes: dict[str, np.ndarray] | None = None,
         ensemble: FrozenEnsemble | None = None,
-        ensemble_recipe: DistributionEnsemble | None = None,
+        ensemble_recipe: BatchDrawable | None = None,
         functions: dict[str, executor.Functor] | None = None,
         backend: type[executor.NumpyBackend] = executor.NumpyBackend,
     ) -> None:
@@ -475,22 +470,42 @@ class EvaluationHandle:
     # Private helpers — one primitive operation each
     # ------------------------------------------------------------------
 
-    def _extend_ensemble_axis(self, ensemble_size: int) -> None:
-        """Draw *ensemble_size* new scenarios and merge along the ENSEMBLE axis."""
+    def _extend_ensemble_axis(self, ensemble_size: int, axis: str | None = None) -> None:
+        """Draw *ensemble_size* new scenarios and merge along an ENSEMBLE axis.
+
+        Parameters
+        ----------
+        ensemble_size:
+            Number of new Monte Carlo samples (or samples per combo for
+            :class:`~simulation.ensemble.CrossProductEnsemble`).
+        axis:
+            For multi-axis ensembles (e.g.
+            :class:`~simulation.ensemble.PartitionedEnsemble`): name of the
+            ENSEMBLE axis to grow.  ``None`` for single-axis ensembles.
+        """
         assert self._ensemble_recipe is not None, (
             "EvaluationHandle._extend_ensemble_axis() requires an ensemble_recipe. "
             "Obtain the handle via evaluate_incremental() to enable ensemble extension."
         )
-        new_replay = self._ensemble_recipe.draw_batch(ensemble_size, self._rng)
+        new_batch = self._ensemble_recipe.draw_batch(ensemble_size, self._rng, axis=axis)
+        if axis is not None and self._ensemble is not None and len(self._ensemble.ensemble_axes) > 1:
+            # Multi-axis: pair fresh samples for the target axis with the existing
+            # frozen samples for all other axes before executing the plan.
+            execution_ensemble = self._ensemble.with_replaced_axis(axis, new_batch)
+        else:
+            execution_ensemble = new_batch
         new_result = self._evaluation.execute_plan(
-            self._plan, new_replay,
+            self._plan, execution_ensemble,
             parameters=self._parameters, parameter_axes=self._parameter_axes,
             functions=self._functions, backend=self._backend,
         )
         assert self._result is not None
-        self._result = _merge_results(self._result, new_result, self._plan)
+        self._result = _merge_results(self._result, new_result, self._plan, merge_axis_name=axis)
         if self._ensemble is not None:
-            self._ensemble = self._ensemble.concat(new_replay)
+            if axis is not None and len(self._ensemble.ensemble_axes) > 1:
+                self._ensemble = self._ensemble.concat_along(axis, new_batch)
+            else:
+                self._ensemble = self._ensemble.concat(new_batch)
 
     def _extend_param_axis(self, param_idx: GenericIndex, extra_vals: np.ndarray) -> None:
         """Re-run the stored ensemble at *extra_vals* and merge along the PARAMETER axis."""
@@ -516,27 +531,67 @@ class EvaluationHandle:
         self,
         ensemble_size: int = 0,
         *,
+        extra_ensemble: dict[str, int] | None = None,
         extra_parameters: dict[GenericIndex, np.ndarray] | None = None,
     ) -> EvaluationResult:
         """Grow the ensemble and/or the PARAMETER grid and merge.
 
-        *ensemble_size* draws additional Monte Carlo samples via
-        :class:`~simulation.ensemble.DistributionEnsemble` and merges along
-        the ENSEMBLE axis.  *extra_parameters* re-runs the plan over new
-        parameter values using the **same** sample draws and merges along the
-        PARAMETER axis.  Both may be supplied together; multiple entries in
-        *extra_parameters* are processed one axis at a time.
+        ENSEMBLE extension
+        -----------------
+        Two mutually exclusive forms are accepted:
+
+        * **Shorthand** — ``ensemble_size=N`` (positional).  Draws *N* new
+          Monte Carlo samples on the single ENSEMBLE axis of the recipe.
+          Raises :class:`ValueError` when the recipe has more than one axis;
+          use *extra_ensemble* instead::
+
+              handle.extend(50)
+
+        * **Explicit dict** — ``extra_ensemble={"axis_name": N, ...}``.
+          Extends one or more named ENSEMBLE axes, processed sequentially.
+          Each entry calls :meth:`_extend_ensemble_axis` and the results are
+          merged with the appropriate :meth:`_merge_results` call.  Use this
+          form for :class:`~simulation.ensemble.PartitionedEnsemble`::
+
+              handle.extend(extra_ensemble={"unc": 5, "default": 3})
+
+        Supplying both *ensemble_size* > 0 and *extra_ensemble* at the same
+        time raises :class:`ValueError`.
+
+        PARAMETER extension
+        ------------------
+        ``extra_parameters={idx: extra_array, ...}`` re-runs the plan over
+        new parameter values using the **same** frozen sample draws and merges
+        along each PARAMETER axis.  Every key must already be present in the
+        ``parameters=`` dict passed to
+        :meth:`~simulation.evaluation.Evaluation.evaluate_incremental`.
+        Multiple entries are processed one axis at a time::
+
+            handle.extend(extra_parameters={x1: np.array([0.9, 1.0])})
+
+        Combined
+        --------
+        ENSEMBLE and PARAMETER extension may be combined freely::
+
+            # single-axis recipe + parameter extension
+            handle.extend(50, extra_parameters={x1: vals})
+
+            # PartitionedEnsemble: extend one axis + parameter extension
+            handle.extend(
+                extra_ensemble={"unc": 5},
+                extra_parameters={x1: vals},
+            )
 
         Parameters
         ----------
         ensemble_size:
-            Number of new Monte Carlo scenarios to evaluate.  When ``<= 0``
-            and *extra_parameters* is ``None``, this is a no-op.
+            Shorthand for single-axis ENSEMBLE extension.  Mutually exclusive
+            with *extra_ensemble*.
+        extra_ensemble:
+            Explicit multi-axis ENSEMBLE extension dict ``{axis_name: N}``.
+            Mutually exclusive with *ensemble_size* > 0.
         extra_parameters:
-            Dict ``{idx: extra_array, ...}`` extending the PARAMETER sweep for
-            each *idx*.  Every key must already be present in the
-            ``parameters=`` dict passed to
-            :meth:`~simulation.evaluation.Evaluation.evaluate_incremental`.
+            PARAMETER extension dict ``{idx: extra_array}``.
 
         Returns
         -------
@@ -547,12 +602,21 @@ class EvaluationHandle:
         Raises
         ------
         ValueError
-            If any key in *extra_parameters* is not in the original
+            If both *ensemble_size* > 0 and *extra_ensemble* are supplied, if
+            any key in *extra_ensemble* is not a known ENSEMBLE axis name, or
+            if any key in *extra_parameters* is not in the original
             ``parameters=`` dict.
         RuntimeError
-            If the handle has no stored ensemble (constructed without one).
+            If the handle has no stored ensemble and *extra_parameters* is
+            supplied.
         """
-        if extra_parameters is None and ensemble_size <= 0:
+        if ensemble_size > 0 and extra_ensemble is not None:
+            raise ValueError(
+                "extend(): ensemble_size and extra_ensemble are mutually exclusive. "
+                "Use ensemble_size for single-axis recipes; use extra_ensemble for "
+                "named-axis (PartitionedEnsemble) extension."
+            )
+        if extra_parameters is None and extra_ensemble is None and ensemble_size <= 0:
             return self._result  # type: ignore[return-value]
 
         assert self._result is not None, (
@@ -576,7 +640,10 @@ class EvaluationHandle:
                 )
 
         if ensemble_size > 0:
-            self._extend_ensemble_axis(ensemble_size)
+            self._extend_ensemble_axis(ensemble_size, axis=None)
+        if extra_ensemble is not None:
+            for axis_name, size in extra_ensemble.items():
+                self._extend_ensemble_axis(size, axis=axis_name)
         if extra_parameters is not None:
             for idx, vals in extra_parameters.items():
                 self._extend_param_axis(idx, np.asarray(vals))
@@ -593,8 +660,8 @@ class AsyncEvaluationHandle(EvaluationHandle):
     :class:`EvaluationHandle`.
 
     See the :class:`EvaluationHandle` class note for the
-    :class:`~simulation.ensemble.DistributionEnsemble` constraint that applies
-    to both the initial evaluation and every :meth:`extend` call.
+    :class:`~simulation.ensemble.BatchDrawable` contract that the
+    *ensemble_recipe* must satisfy.
 
     Obtain an instance via
     :meth:`~simulation.evaluation.Evaluation.submit_evaluate` rather than
@@ -637,7 +704,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
         parameters: dict[GenericIndex, np.ndarray],
         parameter_axes: dict[str, np.ndarray] | None,
         ensemble: FrozenEnsemble | None,
-        ensemble_recipe: DistributionEnsemble | None,
+        ensemble_recipe: BatchDrawable | None,
         functions: dict[str, executor.Functor] | None,
         backend: type[executor.NumpyBackend],
     ) -> None:
@@ -733,6 +800,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
         self,
         ensemble_size: int = 0,
         *,
+        extra_ensemble: dict[str, int] | None = None,
         extra_parameters: dict[GenericIndex, np.ndarray] | None = None,
     ) -> EvaluationResult:
         """Extend the ensemble after the background evaluation completes.
@@ -750,4 +818,6 @@ class AsyncEvaluationHandle(EvaluationHandle):
                 "AsyncEvaluationHandle: cannot extend before the evaluation completes. Call .get() or .poll() first."
             )
         self._resolve()  # populate self._result before super().extend() reads it
-        return super().extend(ensemble_size, extra_parameters=extra_parameters)
+        return super().extend(
+            ensemble_size, extra_ensemble=extra_ensemble, extra_parameters=extra_parameters
+        )

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -49,8 +49,10 @@ def _merge_results(
 
     Both results must have been produced by the same plan and with the same
     PARAMETER axes.  The merge concatenates node values along the single
-    ENSEMBLE axis and renormalises weights to a uniform distribution over
-    the combined scenario count.
+    ENSEMBLE axis and combines weights as a size-proportional mixture:
+    each scenario's weight is scaled by ``S_i / (S1 + S2)`` so that the
+    merged weights still sum to 1 and non-uniform weight schemes (e.g.
+    :class:`~simulation.ensemble.CrossProductEnsemble`) are preserved.
 
     Parameters
     ----------
@@ -159,8 +161,12 @@ def _merge_results(
         merged_ens_axis: S1 + S2,
     }
 
-    # Uniform weights renormalised over the combined ensemble.
-    merged_weights = np.full(S1 + S2, 1.0 / (S1 + S2))
+    # Size-proportional mixture: each partial result contributes weight
+    # proportional to its scenario count, preserving non-uniform schemes.
+    w1 = r1._factorized_weights[ax1]
+    w2 = r2._factorized_weights[ax2]
+    alpha = S1 / (S1 + S2)
+    merged_weights = np.concatenate([w1 * alpha, w2 * (1.0 - alpha)])
     merged_factorized_weights: dict[Axis, np.ndarray] = {merged_ens_axis: merged_weights}
 
     merged_state = executor.State(merged_values)

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -21,12 +21,13 @@ constructing these classes directly.
 from __future__ import annotations
 
 import concurrent.futures
+from collections.abc import Mapping
 
 import numpy as np
 
 from ..engine.frontend import graph
 from ..engine.numpybackend import executor
-from ..model.axis import ENSEMBLE, Axis
+from ..model.axis import ENSEMBLE, PARAMETER, Axis
 from ..model.index import GenericIndex
 
 # Imported at runtime to avoid circular imports:
@@ -38,6 +39,57 @@ from .evaluation import Evaluation, EvaluationResult
 from .plan import EvaluationPlan
 
 __all__ = ["AsyncEvaluationHandle", "EvaluationHandle"]
+
+
+class _ReplayEnsemble:
+    """AxisEnsemble backed by pre-computed (frozen) sample arrays — no RNG draws.
+
+    Returned by :func:`_replay_from` and stored on :class:`EvaluationHandle` so
+    that parameter-grid extension can re-run the plan over the *same* scenarios
+    without advancing the RNG a second time.
+    """
+
+    def __init__(
+        self,
+        axis: Axis,
+        weights: np.ndarray,
+        cached_assignments: dict[GenericIndex, np.ndarray],
+    ) -> None:
+        self._axis = axis
+        self._weights = weights
+        self._cached_assignments = cached_assignments
+
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]:
+        return (self._axis,)
+
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        return (self._weights,)
+
+    def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
+        return self._cached_assignments
+
+    def concat(self, other: _ReplayEnsemble) -> _ReplayEnsemble:
+        """Return a new replay ensemble with concatenated samples and proportional weights."""
+        S1 = self._weights.size
+        S2 = other._weights.size
+        alpha = S1 / (S1 + S2)
+        merged_weights = np.concatenate([self._weights * alpha, other._weights * (1.0 - alpha)])
+        merged_assignments = {
+            idx: np.concatenate([self._cached_assignments[idx], other._cached_assignments[idx]])
+            for idx in self._cached_assignments
+        }
+        return _ReplayEnsemble(Axis("_ensemble", ENSEMBLE), merged_weights, merged_assignments)
+
+
+def _replay_from_dist(dist_ensemble: object) -> _ReplayEnsemble:
+    """Draw samples from *dist_ensemble* once and wrap them in a :class:`_ReplayEnsemble`."""
+    return _ReplayEnsemble(
+        dist_ensemble.ensemble_axes[0],  # type: ignore[union-attr]
+        dist_ensemble.ensemble_weights[0],  # type: ignore[union-attr]
+        dict(dist_ensemble.assignments()),  # type: ignore[union-attr]
+    )
 
 
 def _merge_results(
@@ -180,6 +232,157 @@ def _merge_results(
     )
 
 
+def _merge_results_param_extend(
+    r1: EvaluationResult,
+    r2: EvaluationResult,
+    plan: EvaluationPlan,
+    param_idx: GenericIndex,
+) -> EvaluationResult:
+    """Merge two results by extending the PARAMETER axis for *param_idx*.
+
+    Both results must have been produced by the **same ensemble** (identical
+    ENSEMBLE axis size and position) and the same fixed PARAMETER axes.
+    *r1*'s PARAMETER axis for *param_idx* has size ``P1``; *r2*'s has size
+    ``P2``.  The merged result has size ``P1 + P2``.
+
+    Parameters
+    ----------
+    r1:
+        The accumulated result with the original parameter values.
+    r2:
+        The result evaluated at the extra parameter values using the same
+        ensemble as *r1*.
+    plan:
+        The shared evaluation plan.
+    param_idx:
+        The index whose PARAMETER axis is being extended.
+
+    Returns
+    -------
+    EvaluationResult
+        A new result with node arrays concatenated along *param_idx*'s axis.
+
+    Raises
+    ------
+    ValueError
+        If either result lacks an ENSEMBLE axis, if the ENSEMBLE sizes differ,
+        if *param_idx* has no PARAMETER axis in *r1*, or if the fixed
+        PARAMETER axes do not match.
+    """
+    param_name: str = getattr(param_idx, "name", repr(param_idx))
+
+    # --- Validate ENSEMBLE axes ---
+    ens_1 = [(ax, pos) for ax, pos in r1._axis_layout.items() if ax.role == ENSEMBLE]
+    ens_2 = [(ax, pos) for ax, pos in r2._axis_layout.items() if ax.role == ENSEMBLE]
+    if len(ens_1) != 1 or len(ens_2) != 1:
+        raise ValueError(
+            "_merge_results_param_extend requires exactly one ENSEMBLE axis in each result; "
+            f"got {len(ens_1)} in r1 and {len(ens_2)} in r2."
+        )
+    ax_ens, ens_pos = ens_1[0]
+    _, ens_pos2 = ens_2[0]
+    if ens_pos != ens_pos2:
+        raise ValueError(
+            f"ENSEMBLE axis position mismatch: r1 at dim {ens_pos}, r2 at dim {ens_pos2}."
+        )
+    S = r1._axis_sizes[ax_ens]
+    S2_check = r2._axis_sizes[ens_2[0][0]]
+    if S != S2_check:
+        raise ValueError(
+            f"_merge_results_param_extend requires identical ENSEMBLE sizes; got {S} vs {S2_check}. "
+            "Both results must be produced by the same ensemble."
+        )
+
+    # --- Locate the growing PARAMETER axis in r1 ---
+    grow_ax_1: Axis | None = next(
+        (ax for ax, _ in r1._axis_layout.items() if ax.role == PARAMETER and ax.name == param_name),
+        None,
+    )
+    if grow_ax_1 is None:
+        raise ValueError(
+            f"_merge_results_param_extend: no PARAMETER axis named {param_name!r} in r1. "
+            "extra_parameters must contain indexes already present in the initial parameters= dict."
+        )
+    param_pos = r1._axis_layout[grow_ax_1]
+    P1 = r1._axis_sizes[grow_ax_1]
+
+    grow_ax_2: Axis | None = next(
+        (ax for ax, _ in r2._axis_layout.items() if ax.role == PARAMETER and ax.name == param_name),
+        None,
+    )
+    if grow_ax_2 is None:
+        raise ValueError(
+            f"_merge_results_param_extend: no PARAMETER axis named {param_name!r} in r2."
+        )
+    P2 = r2._axis_sizes[grow_ax_2]
+
+    # --- Validate fixed PARAMETER axes ---
+    def _fixed_sig(layout: dict[Axis, int], sizes: dict[Axis, int]) -> frozenset[tuple[str, int, int]]:
+        return frozenset(
+            (ax.name, pos, sizes[ax])
+            for ax, pos in layout.items()
+            if ax.role == PARAMETER and ax.name != param_name
+        )
+
+    if _fixed_sig(r1._axis_layout, r1._axis_sizes) != _fixed_sig(r2._axis_layout, r2._axis_sizes):
+        raise ValueError(
+            "_merge_results_param_extend: fixed PARAMETER axis layouts differ between r1 and r2."
+        )
+
+    # --- Concatenate node arrays along the growing PARAMETER axis ---
+    merged_values: dict[graph.Node, np.ndarray] = {}
+    for noi in plan.nodes_of_interest:
+        node = noi.node
+        v1 = np.asarray(r1._state.values[node])
+        v2 = np.asarray(r2._state.values[node])
+
+        # Ensure both arrays are at least (param_pos + 1)-dimensional.
+        while v1.ndim <= param_pos:
+            v1 = v1[np.newaxis]  # pragma: no cover
+        while v2.ndim <= param_pos:
+            v2 = v2[np.newaxis]  # pragma: no cover
+
+        if v1.shape[param_pos] == 1 and v2.shape[param_pos] == 1:
+            # Node is constant across the PARAMETER axis (e.g. ensemble-only
+            # inputs that don't vary with the swept parameter).  Keep singleton.
+            merged_values[node] = v1
+        else:
+            merged_values[node] = np.concatenate([v1, v2], axis=param_pos)
+
+    # --- Build merged axis metadata ---
+    # Fresh Axis identity for the grown dimension (old object would carry stale size).
+    merged_grow_ax = Axis(param_name, PARAMETER)
+    merged_axis_layout: dict[Axis, int] = {}
+    merged_axis_sizes: dict[Axis, int] = {}
+    for ax, pos in r1._axis_layout.items():
+        if ax is grow_ax_1:
+            merged_axis_layout[merged_grow_ax] = pos
+            merged_axis_sizes[merged_grow_ax] = P1 + P2
+        else:
+            merged_axis_layout[ax] = pos
+            merged_axis_sizes[ax] = r1._axis_sizes[ax]
+
+    # Factorised weights: ENSEMBLE axis unchanged.
+    merged_factorized_weights: dict[Axis, np.ndarray] = dict(r1._factorized_weights)
+
+    # Concatenate the growing parameter's value array.
+    merged_parameter_arrays: dict[GenericIndex, np.ndarray] = dict(r1._parameter_arrays)
+    if param_idx in r1._parameter_arrays and param_idx in r2._parameter_arrays:
+        merged_parameter_arrays[param_idx] = np.concatenate(
+            [r1._parameter_arrays[param_idx], r2._parameter_arrays[param_idx]]
+        )
+
+    merged_state = executor.State(merged_values)
+    return EvaluationResult(
+        merged_state,
+        merged_axis_layout,
+        merged_parameter_arrays,
+        axis_sizes=merged_axis_sizes,
+        factorized_weights=merged_factorized_weights,
+        named_axis_values=r1._named_axis_values or None,
+    )
+
+
 class EvaluationHandle:
     """Incremental evaluation handle for growing an ensemble in steps.
 
@@ -227,6 +430,10 @@ class EvaluationHandle:
     parameter_axes:
         Named PARAMETER axes dict passed to the initial execution (from
         ``parameter_axes=``).  ``None`` when correlated axes were not used.
+    ensemble:
+        Frozen replay of the initial ensemble's sample draws, used by
+        :meth:`extend` when *extra_parameters* is supplied.  ``None`` when
+        the handle was constructed without an ensemble (e.g. in tests).
     functions:
         Optional user-defined functions passed through to the executor.
     backend:
@@ -242,6 +449,7 @@ class EvaluationHandle:
         rng: np.random.Generator,
         parameters: dict[GenericIndex, np.ndarray],
         parameter_axes: dict[str, np.ndarray] | None = None,
+        ensemble: _ReplayEnsemble | None = None,
         functions: dict[str, executor.Functor] | None = None,
         backend: type[executor.NumpyBackend] = executor.NumpyBackend,
     ) -> None:
@@ -251,6 +459,7 @@ class EvaluationHandle:
         self._rng = rng
         self._parameters = parameters
         self._parameter_axes = parameter_axes
+        self._ensemble = ensemble
         self._functions = functions
         self._backend = backend
 
@@ -271,19 +480,62 @@ class EvaluationHandle:
             raise RuntimeError("result is not yet available.")
         return self._result
 
+    # ------------------------------------------------------------------
+    # Private helpers — one primitive operation each
+    # ------------------------------------------------------------------
+
+    def _extend_ensemble_axis(self, ensemble_size: int) -> None:
+        """Draw *ensemble_size* new scenarios and merge along the ENSEMBLE axis."""
+        from .ensemble import DistributionEnsemble
+
+        new_dist = DistributionEnsemble(
+            self._evaluation._scenario, ensemble_size, rng=self._rng, exclude=frozenset(self._parameters)
+        )
+        new_replay = _replay_from_dist(new_dist)
+        new_result = self._evaluation.execute_plan(
+            self._plan, new_replay,
+            parameters=self._parameters, parameter_axes=self._parameter_axes,
+            functions=self._functions, backend=self._backend,
+        )
+        assert self._result is not None
+        self._result = _merge_results(self._result, new_result, self._plan)
+        if self._ensemble is not None:
+            self._ensemble = self._ensemble.concat(new_replay)
+
+    def _extend_param_axis(self, param_idx: GenericIndex, extra_vals: np.ndarray) -> None:
+        """Re-run the stored ensemble at *extra_vals* and merge along the PARAMETER axis."""
+        assert self._result is not None
+        assert self._ensemble is not None
+        r_extra = self._evaluation.execute_plan(
+            self._plan, self._ensemble,
+            parameters={**self._parameters, param_idx: extra_vals},
+            parameter_axes=self._parameter_axes,
+            functions=self._functions, backend=self._backend,
+        )
+        self._result = _merge_results_param_extend(self._result, r_extra, self._plan, param_idx)
+        self._parameters = {
+            **self._parameters,
+            param_idx: np.concatenate([self._parameters[param_idx], extra_vals]),
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
     def extend(
         self,
         ensemble_size: int = 0,
         *,
         extra_parameters: dict[GenericIndex, np.ndarray] | None = None,
     ) -> EvaluationResult:
-        """Grow the ensemble by *ensemble_size* additional samples and merge.
+        """Grow the ensemble and/or the PARAMETER grid and merge.
 
-        Draws ``ensemble_size`` new scenarios from
-        :class:`~simulation.ensemble.DistributionEnsemble` using the shared RNG
-        (see class-level note for the ensemble-type constraint), executes the
-        plan, and merges the result via :func:`_merge_results`.  The merged
-        result replaces :attr:`result`.
+        *ensemble_size* draws additional Monte Carlo samples via
+        :class:`~simulation.ensemble.DistributionEnsemble` and merges along
+        the ENSEMBLE axis.  *extra_parameters* re-runs the plan over new
+        parameter values using the **same** sample draws and merges along the
+        PARAMETER axis.  Both may be supplied together; multiple entries in
+        *extra_parameters* are processed one axis at a time.
 
         Parameters
         ----------
@@ -291,10 +543,10 @@ class EvaluationHandle:
             Number of new Monte Carlo scenarios to evaluate.  When ``<= 0``
             and *extra_parameters* is ``None``, this is a no-op.
         extra_parameters:
-            Not yet implemented in v0.10.0; raises :exc:`NotImplementedError`
-            when provided.  PARAMETER-grid extension (evaluating at additional
-            parameter values) requires a different merging strategy and is
-            deferred to a future release.
+            Dict ``{idx: extra_array, ...}`` extending the PARAMETER sweep for
+            each *idx*.  Every key must already be present in the
+            ``parameters=`` dict passed to
+            :meth:`~simulation.evaluation.Evaluation.evaluate_incremental`.
 
         Returns
         -------
@@ -304,17 +556,14 @@ class EvaluationHandle:
 
         Raises
         ------
-        NotImplementedError
-            When *extra_parameters* is not ``None`` (deferred in v0.10.0).
+        ValueError
+            If any key in *extra_parameters* is not in the original
+            ``parameters=`` dict.
+        RuntimeError
+            If the handle has no stored ensemble (constructed without one).
         """
-        if extra_parameters is not None:
-            raise NotImplementedError(
-                "Parameter-grid extension (extra_parameters) is not yet implemented "
-                "in v0.10.0. PARAMETER-grid extension requires a different merging "
-                "strategy and is deferred to a future release."
-            )
-        if ensemble_size <= 0:
-            return self._result  # type: ignore[return-value]  # None only on async path before resolve
+        if extra_parameters is None and ensemble_size <= 0:
+            return self._result  # type: ignore[return-value]
 
         assert self._result is not None, (
             "EvaluationHandle.extend() called with _result=None — "
@@ -322,20 +571,26 @@ class EvaluationHandle:
             "AsyncEvaluationHandle.extend() failed to call _resolve() first."
         )
 
-        from .ensemble import DistributionEnsemble
+        if extra_parameters is not None:
+            bad = [k for k in extra_parameters if k not in self._parameters]
+            if bad:
+                names = ", ".join(repr(getattr(k, "name", repr(k))) for k in bad)
+                raise ValueError(
+                    f"extend(extra_parameters=): {names} not in the original parameters= dict. "
+                    "Only existing parameter axes can be extended."
+                )
+            if self._ensemble is None:
+                raise RuntimeError(
+                    "EvaluationHandle has no stored ensemble; extra_parameters extension is unavailable. "
+                    "Obtain the handle via evaluate_incremental() to enable this feature."
+                )
 
-        new_ensemble = DistributionEnsemble(
-            self._evaluation._scenario, ensemble_size, rng=self._rng, exclude=frozenset(self._parameters)
-        )
-        new_result = self._evaluation.execute_plan(
-            self._plan,
-            new_ensemble,
-            parameters=self._parameters,
-            parameter_axes=self._parameter_axes,
-            functions=self._functions,
-            backend=self._backend,
-        )
-        self._result = _merge_results(self._result, new_result, self._plan)
+        if ensemble_size > 0:
+            self._extend_ensemble_axis(ensemble_size)
+        if extra_parameters is not None:
+            for idx, vals in extra_parameters.items():
+                self._extend_param_axis(idx, np.asarray(vals))
+
         return self._result
 
 
@@ -370,6 +625,9 @@ class AsyncEvaluationHandle(EvaluationHandle):
         The PARAMETER axis dict passed to the initial execution.
     parameter_axes:
         Named PARAMETER axes dict passed to the initial execution.
+    ensemble:
+        Frozen replay of the initial ensemble's sample draws (see
+        :class:`EvaluationHandle`).
     functions:
         Optional user-defined functions passed through to the executor.
     backend:
@@ -385,6 +643,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
         rng: np.random.Generator,
         parameters: dict[GenericIndex, np.ndarray],
         parameter_axes: dict[str, np.ndarray] | None,
+        ensemble: _ReplayEnsemble | None,
         functions: dict[str, executor.Functor] | None,
         backend: type[executor.NumpyBackend],
     ) -> None:
@@ -395,6 +654,7 @@ class AsyncEvaluationHandle(EvaluationHandle):
             rng=rng,
             parameters=parameters,
             parameter_axes=parameter_axes,
+            ensemble=ensemble,
             functions=functions,
             backend=backend,
         )
@@ -489,8 +749,6 @@ class AsyncEvaluationHandle(EvaluationHandle):
         ------
         RuntimeError
             If the background evaluation has not yet completed.
-        NotImplementedError
-            When *extra_parameters* is not ``None`` (deferred in v0.10.0).
         """
         if not self._future.done():
             raise RuntimeError(

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -96,15 +96,18 @@ def _merge_results(
     r1: EvaluationResult,
     r2: EvaluationResult,
     plan: EvaluationPlan,
+    *,
+    merge_axis_name: str | None = None,
 ) -> EvaluationResult:
     """Merge two :class:`~simulation.evaluation.EvaluationResult` instances.
 
     Both results must have been produced by the same plan and with the same
-    PARAMETER axes.  The merge concatenates node values along the single
-    ENSEMBLE axis and combines weights as a size-proportional mixture:
-    each scenario's weight is scaled by ``S_i / (S1 + S2)`` so that the
-    merged weights still sum to 1 and non-uniform weight schemes (e.g.
+    PARAMETER axes.  The merge concatenates node values along one ENSEMBLE
+    axis and combines that axis's weights as a size-proportional mixture so
+    that non-uniform weight schemes (e.g.
     :class:`~simulation.ensemble.CrossProductEnsemble`) are preserved.
+    All other ENSEMBLE axes and their factorised weights pass through
+    unchanged from *r1*.
 
     Parameters
     ----------
@@ -116,49 +119,81 @@ def _merge_results(
     plan:
         The shared evaluation plan.  Used to enumerate the nodes of interest
         that must appear in the merged state.
+    merge_axis_name:
+        Name of the ENSEMBLE axis to grow.  Required when either result has
+        more than one ENSEMBLE axis; ignored (but validated) for single-axis
+        results.
 
     Returns
     -------
     EvaluationResult
-        A new result whose node arrays are concatenated along the ENSEMBLE axis.
+        A new result whose node arrays are concatenated along the chosen
+        ENSEMBLE axis (or kept as singletons when both inputs are singleton
+        on that axis).
 
     Raises
     ------
     ValueError
-        If either result has no ENSEMBLE axis, if their ENSEMBLE axes are at
-        different positions, or if the PARAMETER axis layouts are incompatible.
-    NotImplementedError
-        If either result has more than one ENSEMBLE axis (multi-axis merging is
-        not supported in v0.10.0).
+        If either result has no ENSEMBLE axis, if *merge_axis_name* is absent
+        when multiple ENSEMBLE axes are present, if the named axis is missing
+        or at different positions in the two results, if the fixed ENSEMBLE
+        axes differ, or if the PARAMETER axis layouts are incompatible.
     """
-    # --- Locate the single ENSEMBLE axis in each result ---
+    # --- Collect ENSEMBLE axes ---
     ens_1 = [(ax, pos) for ax, pos in r1._axis_layout.items() if ax.role == ENSEMBLE]
     ens_2 = [(ax, pos) for ax, pos in r2._axis_layout.items() if ax.role == ENSEMBLE]
 
     if not ens_1 or not ens_2:
         raise ValueError(
-            "_merge_results requires both results to have exactly one ENSEMBLE axis; "
+            "_merge_results requires both results to have at least one ENSEMBLE axis; "
             f"got {len(ens_1)} in r1 and {len(ens_2)} in r2."
         )
-    if len(ens_1) != 1 or len(ens_2) != 1:
-        raise NotImplementedError(
-            "Merging results with multiple ENSEMBLE axes is not supported in v0.10.0. "
-            "Use a single-axis DistributionEnsemble."
-        )
 
-    ax1, ens_pos = ens_1[0]
-    ax2, ens_pos2 = ens_2[0]
-    if ens_pos != ens_pos2:
-        raise ValueError(  # pragma: no cover
-            f"ENSEMBLE axis position mismatch: r1 has ensemble at dim {ens_pos}, r2 has it at dim {ens_pos2}."
-        )
+    # --- Identify the growing axis ---
+    if len(ens_1) == 1 and len(ens_2) == 1:
+        grow_ax_1, ens_pos = ens_1[0]
+        grow_ax_2, ens_pos2 = ens_2[0]
+        if ens_pos != ens_pos2:
+            raise ValueError(  # pragma: no cover
+                f"ENSEMBLE axis position mismatch: r1 at dim {ens_pos}, r2 at dim {ens_pos2}."
+            )
+    else:
+        if merge_axis_name is None:
+            names = sorted(ax.name for ax, _ in ens_1)
+            raise ValueError(
+                f"_merge_results: both results have multiple ENSEMBLE axes {names}; "
+                "specify merge_axis_name= to indicate which axis to grow."
+            )
+        grow_entry_1 = next(((ax, pos) for ax, pos in ens_1 if ax.name == merge_axis_name), None)
+        grow_entry_2 = next(((ax, pos) for ax, pos in ens_2 if ax.name == merge_axis_name), None)
+        if grow_entry_1 is None:
+            raise ValueError(f"_merge_results: no ENSEMBLE axis named {merge_axis_name!r} in r1.")
+        if grow_entry_2 is None:
+            raise ValueError(f"_merge_results: no ENSEMBLE axis named {merge_axis_name!r} in r2.")
+        grow_ax_1, ens_pos = grow_entry_1
+        grow_ax_2, ens_pos2 = grow_entry_2
+        if ens_pos != ens_pos2:
+            raise ValueError(
+                f"Growing ENSEMBLE axis {merge_axis_name!r} is at dim {ens_pos} in r1 "
+                f"but dim {ens_pos2} in r2."
+            )
+        # Validate the fixed ENSEMBLE axes match by name, position, and size.
+        def _fixed_ens_sig(
+            axes: list[tuple[Axis, int]], sizes: dict[Axis, int]
+        ) -> frozenset[tuple[str, int, int]]:
+            return frozenset(
+                (ax.name, pos, sizes[ax]) for ax, pos in axes if ax.name != merge_axis_name
+            )
 
-    S1: int = r1._axis_sizes[ax1]
-    S2: int = r2._axis_sizes[ax2]
+        if _fixed_ens_sig(ens_1, r1._axis_sizes) != _fixed_ens_sig(ens_2, r2._axis_sizes):
+            raise ValueError(
+                "_merge_results: fixed ENSEMBLE axis layouts differ between r1 and r2."
+            )
+
+    S1: int = r1._axis_sizes[grow_ax_1]
+    S2: int = r2._axis_sizes[grow_ax_2]
 
     # --- Validate that PARAMETER axes are compatible ---
-    # Both results must come from the same plan executed with identical parameters.
-    # Axis equality is identity-based, so we compare by (name, role, position, size).
     def _param_sig(layout: dict[Axis, int], sizes: dict[Axis, int]) -> frozenset[tuple[str, object, int, int]]:
         return frozenset((ax.name, ax.role, pos, sizes[ax]) for ax, pos in layout.items() if ax.role != ENSEMBLE)
 
@@ -168,7 +203,7 @@ def _merge_results(
             "Ensure both were built from the same plan with the same 'parameters=' dict."
         )
 
-    # --- Merge node values along the ENSEMBLE axis ---
+    # --- Merge node values along the growing ENSEMBLE axis ---
     merged_values: dict[graph.Node, np.ndarray] = {}
     for idx in plan.nodes_of_interest:
         node = idx.node
@@ -181,7 +216,6 @@ def _merge_results(
         v1 = np.asarray(r1._state.values[node])
         v2 = np.asarray(r2._state.values[node])
 
-        # Ensure both arrays are at least (ens_pos + 1)-dimensional.
         while v1.ndim <= ens_pos:
             v1 = v1[np.newaxis]  # pragma: no cover
         while v2.ndim <= ens_pos:
@@ -190,7 +224,6 @@ def _merge_results(
         if v1.shape[ens_pos] == 1 and v2.shape[ens_pos] == 1 and np.array_equal(v1, v2):
             merged_values[node] = v1
         else:
-            # Expand singleton dims before concatenation so shapes match.
             if v1.shape[ens_pos] == 1:
                 bcast = v1.shape[:ens_pos] + (S1,) + v1.shape[ens_pos + 1 :]
                 v1 = np.broadcast_to(v1, bcast).copy()
@@ -200,26 +233,27 @@ def _merge_results(
             merged_values[node] = np.concatenate([v1, v2], axis=ens_pos)
 
     # --- Build merged axis metadata ---
-    # Create a fresh Axis object for the combined ensemble dimension
-    # (Axis equality is identity-based; we must not reuse ax1 or ax2 as dict keys
-    # since their sizes differ from the merged size).
-    merged_ens_axis = Axis("_ensemble", ENSEMBLE)
+    # Fresh Axis object for the grown dimension (identity-based keys; old object
+    # would carry a stale size and must not be reused).
+    merged_grow_ax = Axis(grow_ax_1.name, ENSEMBLE)
     merged_axis_layout: dict[Axis, int] = {
-        **{ax: pos for ax, pos in r1._axis_layout.items() if ax.role != ENSEMBLE},
-        merged_ens_axis: ens_pos,
+        **{ax: pos for ax, pos in r1._axis_layout.items() if ax is not grow_ax_1},
+        merged_grow_ax: ens_pos,
     }
     merged_axis_sizes: dict[Axis, int] = {
-        **{ax: sz for ax, sz in r1._axis_sizes.items() if ax.role != ENSEMBLE},
-        merged_ens_axis: S1 + S2,
+        **{ax: sz for ax, sz in r1._axis_sizes.items() if ax is not grow_ax_1},
+        merged_grow_ax: S1 + S2,
     }
 
-    # Size-proportional mixture: each partial result contributes weight
-    # proportional to its scenario count, preserving non-uniform schemes.
-    w1 = r1._factorized_weights[ax1]
-    w2 = r2._factorized_weights[ax2]
+    # Size-proportional mixture for the growing axis; fixed ENSEMBLE axes
+    # keep their factorised weights from r1 unchanged.
+    w1 = r1._factorized_weights[grow_ax_1]
+    w2 = r2._factorized_weights[grow_ax_2]
     alpha = S1 / (S1 + S2)
-    merged_weights = np.concatenate([w1 * alpha, w2 * (1.0 - alpha)])
-    merged_factorized_weights: dict[Axis, np.ndarray] = {merged_ens_axis: merged_weights}
+    merged_factorized_weights: dict[Axis, np.ndarray] = {
+        **{ax: w for ax, w in r1._factorized_weights.items() if ax is not grow_ax_1},
+        merged_grow_ax: np.concatenate([w1 * alpha, w2 * (1.0 - alpha)]),
+    }
 
     merged_state = executor.State(merged_values)
     return EvaluationResult(

--- a/civic_digital_twins/dt_model/simulation/runner.py
+++ b/civic_digital_twins/dt_model/simulation/runner.py
@@ -98,7 +98,7 @@ class EvaluationConfig:
     ensemble_size : int
         Total number of Monte Carlo samples drawn in one blocking
         :meth:`ModelEvaluator.evaluate` call.  Equivalent to
-        :meth:`~simulation.handle.EvaluationHandle.from_evaluation`'s
+        :meth:`~simulation.handle.EvaluationHandle.evaluate`'s
         ``initial_ensemble_size`` parameter.  Also used as the increment
         size when :meth:`ModelEvaluator.resume` extends a saved evaluation.
     """
@@ -621,7 +621,7 @@ class ModelRunHandle(Generic[OutputT]):
 
     The future is obtained from either
     :attr:`~simulation.handle.AsyncEvaluationHandle.future` (Bologna, tier 3
-    via :meth:`AsyncEvaluationHandle.from_evaluation`) or
+    via :meth:`AsyncEvaluationHandle.evaluate`) or
     :func:`~dt_model.simulation.handle._get_default_executor` with
     :meth:`~simulation.evaluation.Evaluation.evaluate` as the submitted
     callable (Molveno, thread-pool submit of the engine call).
@@ -952,7 +952,7 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
         """Submit an engine-level async evaluation and return a handle immediately.
 
         Concrete tier-3 default.  Calls
-        :meth:`AsyncEvaluationHandle.from_evaluation` with
+        :meth:`AsyncEvaluationHandle.evaluate` with
         :attr:`eval_functions` and :attr:`eval_backend`, then wraps the
         result in a :class:`ModelRunHandle` whose post-processor is
         :meth:`post_process`.
@@ -972,7 +972,7 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
         ModelRunHandle[OutputT]
             Handle whose :meth:`~ModelRunHandle.get` returns the output.
         """
-        async_handle = AsyncEvaluationHandle.from_evaluation(
+        async_handle = AsyncEvaluationHandle.evaluate(
             Evaluation(scenario),
             config.ensemble_size,
             functions=self.eval_functions,
@@ -1124,6 +1124,16 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
             :meth:`~simulation.handle.EvaluationHandle.extend` to draw
             additional Monte Carlo samples.
 
+        .. note::
+
+            The resumed handle rebuilds its ensemble recipe from
+            :class:`~simulation.ensemble.DistributionEnsemble` using the
+            public *scenario* argument, but does **not** restore the frozen
+            sample snapshot (``_ensemble``).  When
+            ``extend(extra_parameters=…)`` is called, the abstract index
+            values are reconstructed from the saved result state so that the
+            common-random-numbers guarantee is preserved.
+
         Raises
         ------
         IncompatibleResultError
@@ -1142,7 +1152,7 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
         # Rebuild the sampler recipe from the (public) scenario so the resumed
         # handle can draw further samples.  draw_batch() takes the per-call size,
         # so the recipe's nominal size is immaterial; exclude the parameter
-        # indexes exactly as EvaluationHandle.from_evaluation() does.
+        # indexes exactly as EvaluationHandle.evaluate() does.
         ensemble_recipe = DistributionEnsemble(scenario, config.ensemble_size, exclude=frozenset(state.parameters))
         return EvaluationHandle(
             evaluation=evaluation,

--- a/civic_digital_twins/dt_model/simulation/runner.py
+++ b/civic_digital_twins/dt_model/simulation/runner.py
@@ -1138,6 +1138,13 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
         state = self.extract_resume_state(output)
         evaluation = Evaluation(scenario)
         plan = evaluation.build_plan()
+        # Rebuild the sampler recipe from the (public) scenario so the resumed
+        # handle can draw further samples.  draw_batch() takes the per-call size,
+        # so the recipe's nominal size is immaterial; exclude the parameter
+        # indexes exactly as evaluate_incremental() does.
+        ensemble_recipe = DistributionEnsemble(
+            scenario, config.ensemble_size, exclude=frozenset(state.parameters)
+        )
         return EvaluationHandle(
             evaluation=evaluation,
             plan=plan,
@@ -1145,6 +1152,7 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
             rng=rng if rng is not None else np.random.default_rng(),
             parameters=state.parameters,
             parameter_axes=state.parameter_axes,
+            ensemble_recipe=ensemble_recipe,
             functions=state.functions,
             backend=state.backend,
         )

--- a/civic_digital_twins/dt_model/simulation/runner.py
+++ b/civic_digital_twins/dt_model/simulation/runner.py
@@ -39,7 +39,7 @@ from ..model.model import Model
 from ..model.model_variant import ModelVariant
 from .ensemble import DistributionEnsemble
 from .evaluation import Evaluation, EvaluationResult
-from .handle import EvaluationHandle
+from .handle import AsyncEvaluationHandle, EvaluationHandle
 from .scenario import Scenario
 
 __all__ = [
@@ -98,7 +98,7 @@ class EvaluationConfig:
     ensemble_size : int
         Total number of Monte Carlo samples drawn in one blocking
         :meth:`ModelEvaluator.evaluate` call.  Equivalent to
-        :meth:`~simulation.evaluation.Evaluation.evaluate_incremental`'s
+        :meth:`~simulation.handle.EvaluationHandle.from_evaluation`'s
         ``initial_ensemble_size`` parameter.  Also used as the increment
         size when :meth:`ModelEvaluator.resume` extends a saved evaluation.
     """
@@ -621,8 +621,8 @@ class ModelRunHandle(Generic[OutputT]):
 
     The future is obtained from either
     :attr:`~simulation.handle.AsyncEvaluationHandle.future` (Bologna, tier 3
-    via :meth:`~simulation.evaluation.Evaluation.submit_evaluate`) or
-    :func:`~dt_model.simulation.evaluation._get_default_executor` with
+    via :meth:`AsyncEvaluationHandle.from_evaluation`) or
+    :func:`~dt_model.simulation.handle._get_default_executor` with
     :meth:`~simulation.evaluation.Evaluation.evaluate` as the submitted
     callable (Molveno, thread-pool submit of the engine call).
 
@@ -952,7 +952,7 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
         """Submit an engine-level async evaluation and return a handle immediately.
 
         Concrete tier-3 default.  Calls
-        :meth:`~simulation.evaluation.Evaluation.submit_evaluate` with
+        :meth:`AsyncEvaluationHandle.from_evaluation` with
         :attr:`eval_functions` and :attr:`eval_backend`, then wraps the
         result in a :class:`ModelRunHandle` whose post-processor is
         :meth:`post_process`.
@@ -972,7 +972,8 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
         ModelRunHandle[OutputT]
             Handle whose :meth:`~ModelRunHandle.get` returns the output.
         """
-        async_handle = Evaluation(scenario).submit_evaluate(
+        async_handle = AsyncEvaluationHandle.from_evaluation(
+            Evaluation(scenario),
             config.ensemble_size,
             functions=self.eval_functions,
             backend=self.eval_backend,
@@ -1141,10 +1142,8 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
         # Rebuild the sampler recipe from the (public) scenario so the resumed
         # handle can draw further samples.  draw_batch() takes the per-call size,
         # so the recipe's nominal size is immaterial; exclude the parameter
-        # indexes exactly as evaluate_incremental() does.
-        ensemble_recipe = DistributionEnsemble(
-            scenario, config.ensemble_size, exclude=frozenset(state.parameters)
-        )
+        # indexes exactly as EvaluationHandle.from_evaluation() does.
+        ensemble_recipe = DistributionEnsemble(scenario, config.ensemble_size, exclude=frozenset(state.parameters))
         return EvaluationHandle(
             evaluation=evaluation,
             plan=plan,

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -93,7 +93,7 @@ from civic_digital_twins.dt_model import (
     sample_across,
 )
 from civic_digital_twins.dt_model.model.index import Distribution
-from civic_digital_twins.dt_model.simulation.evaluation import _get_default_executor
+from civic_digital_twins.dt_model.simulation.handle import _get_default_executor
 from civic_digital_twins.dt_model.simulation.runner import (
     EvaluationConfig,
     ModelEvaluator,
@@ -1070,7 +1070,7 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         (parameter grids, ensembles, presence samples) synchronously on the
         calling thread, then submits only the
         :meth:`~dt_model.Evaluation.evaluate` call to the shared
-        :func:`~dt_model.simulation.evaluation._get_default_executor` thread
+        :func:`~dt_model.simulation.handle._get_default_executor` thread
         pool.  The :class:`~dt_model.simulation.runner.ModelRunHandle`
         post-processor closure completes the rest of the work once the result
         is available.

--- a/tests/dt_model/simulation/test_cross_product_ensemble.py
+++ b/tests/dt_model/simulation/test_cross_product_ensemble.py
@@ -603,3 +603,72 @@ def test_cross_product_ensemble_accepts_scenario():
     scenario = Scenario(model)
     ens = CrossProductEnsemble(scenario)
     assert len(ens.ensemble_axes) == 1
+
+
+# ---------------------------------------------------------------------------
+# draw_batch
+# ---------------------------------------------------------------------------
+
+
+def test_cpe_draw_batch_returns_frozen_ensemble():
+    """draw_batch returns a FrozenEnsemble with one ENSEMBLE axis and the requested size."""
+    from scipy import stats  # noqa: PLC0415
+
+    from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble  # noqa: PLC0415
+
+    cap = DistributionIndex("cap", stats.uniform, {"loc": 0.0, "scale": 1.0})
+    model = _simple_model(cap)
+    ens = CrossProductEnsemble(Scenario(model), n_samples_per_combo=2, rng=np.random.default_rng(0))
+    batch = ens.draw_batch(3, np.random.default_rng(1))
+    assert isinstance(batch, FrozenEnsemble)
+    assert len(batch.ensemble_axes) == 1
+    # No categorical combos → 1 combo; draw_batch with size=3 → n_samples_per_combo=3 → 3 rows.
+    assert batch.ensemble_weights[0].shape == (3,)
+
+
+def test_cpe_draw_batch_axis_not_none_raises():
+    """draw_batch raises ValueError when axis= is not None."""
+    from scipy import stats  # noqa: PLC0415
+
+    cap = DistributionIndex("cap", stats.uniform, {"loc": 0.0, "scale": 1.0})
+    model = _simple_model(cap)
+    ens = CrossProductEnsemble(Scenario(model), rng=np.random.default_rng(0))
+    with pytest.raises(ValueError, match="single ENSEMBLE axis"):
+        ens.draw_batch(3, np.random.default_rng(1), axis="unc")
+
+
+def test_cpe_no_rng_with_distributions():
+    """CrossProductEnsemble with no rng samples distribution indexes deterministically."""
+    from scipy import stats  # noqa: PLC0415
+
+    cap = DistributionIndex("cap", stats.uniform, {"loc": 0.0, "scale": 1.0})
+    model = _simple_model(cap)
+    ens = CrossProductEnsemble(Scenario(model))  # no rng argument
+    a = ens.assignments()
+    # 1 combo × n_samples_per_combo=1 → shape (1,)
+    assert a[cap].shape == (1,)
+
+
+def test_cpe_exclude_skips_index():
+    """CrossProductEnsemble with exclude= skips the excluded index (covers the continue branch)."""
+    from scipy import stats  # noqa: PLC0415
+
+    cap = DistributionIndex("cap", stats.uniform, {"loc": 0.0, "scale": 1.0})
+    speed = DistributionIndex("speed", stats.norm, {"loc": 1.0, "scale": 0.1})
+    model = _simple_model(cap, speed)
+    # Exclude 'speed' so the CrossProductEnsemble skips it.
+    ens = CrossProductEnsemble(Scenario(model), exclude=[speed], rng=np.random.default_rng(0))
+    a = ens.assignments()
+    # speed is excluded → not in assignments; cap is present.
+    assert cap in a
+    assert speed not in a
+
+
+def test_cat_samples_no_rng_monte_carlo():
+    """_cat_samples with rng=None falls back to np.random.choice for MC sampling."""
+    # max_categorical_size=2 < len(values)=5 triggers the MC branch; rng=None uses np.random.choice.
+    season = CategoricalIndex("season", {"s1": 0.2, "s2": 0.2, "s3": 0.2, "s4": 0.2, "s5": 0.2})
+    model = _simple_model(season)
+    # rng=None means _cat_samples uses np.random.choice
+    ens = CrossProductEnsemble(model, max_categorical_size=2, rng=None)
+    assert ens.assignments()[season].shape == (2,)

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -808,3 +808,37 @@ def test_parameters_index_in_model_does_not_raise():
     # a is in the model — no error expected.
     res = ev.evaluate(parameters={a: np.array([1.0, 2.0])})
     np.testing.assert_array_almost_equal(res[result], [2.0, 4.0])
+
+
+# ---------------------------------------------------------------------------
+# EvaluationResult.full_shape — no-axis path
+# ---------------------------------------------------------------------------
+
+
+def test_evaluation_result_full_shape_no_axes():
+    """EvaluationResult.full_shape returns () when there are no ENSEMBLE or PARAMETER axes."""
+    # A constant-only model with no abstract indexes and evaluated with
+    # ensemble=None produces an EvaluationResult with no axes.
+    I_a = Index("a", 3.0)
+    I_b = Index("b", 4.0)
+    I_result = Index("result", I_a.node + I_b.node)
+    model = _make_model(I_a, I_b, I_result)
+    ev = Evaluation(Scenario(model))
+    result = ev.execute_plan(ev.build_plan(), ensemble=None)
+    assert result.full_shape == ()
+
+
+def test_evaluation_result_full_shape_with_axes():
+    """EvaluationResult.full_shape returns the axis-layout shape when axes are present."""
+    from scipy import stats  # noqa: PLC0415
+
+    from civic_digital_twins.dt_model.model.index import DistributionIndex  # noqa: PLC0415
+    from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble  # noqa: PLC0415
+
+    I_x = DistributionIndex("x", stats.norm, {"loc": 0.0, "scale": 1.0})
+    I_result = Index("result", I_x.node * 2.0)
+    model = _make_model(I_x, I_result)
+    ev = Evaluation(Scenario(model))
+    ens = DistributionEnsemble(Scenario(model), 7)
+    result = ev.evaluate(ensemble=ens)
+    assert result.full_shape == (7,)

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -745,7 +745,7 @@ def test_evaluate_incremental_named_axis_values_preserved_after_extend():
     ev = Evaluation(Scenario(model))
 
     base_arr = np.array([1.0, 2.0, 3.0])
-    handle = EvaluationHandle.from_evaluation(
+    handle = EvaluationHandle.evaluate(
         ev,
         initial_ensemble_size=10,
         parameter_axes={"base": base_arr},

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -17,6 +17,7 @@ from civic_digital_twins.dt_model.model.index import ConstIndex, GenericIndex, I
 from civic_digital_twins.dt_model.model.model import Model
 from civic_digital_twins.dt_model.simulation.ensemble import WeightedScenario
 from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
+from civic_digital_twins.dt_model.simulation.handle import EvaluationHandle
 from civic_digital_twins.dt_model.simulation.scenario import Scenario
 
 # ---------------------------------------------------------------------------
@@ -744,7 +745,8 @@ def test_evaluate_incremental_named_axis_values_preserved_after_extend():
     ev = Evaluation(Scenario(model))
 
     base_arr = np.array([1.0, 2.0, 3.0])
-    handle = ev.evaluate_incremental(
+    handle = EvaluationHandle.from_evaluation(
+        ev,
         initial_ensemble_size=10,
         parameter_axes={"base": base_arr},
         parameters={cost: lambda base: base * 2.0},

--- a/tests/dt_model/simulation/test_evaluation_async.py
+++ b/tests/dt_model/simulation/test_evaluation_async.py
@@ -54,7 +54,7 @@ def _make_simple() -> tuple[Index, _SimpleModel]:
 def test_submit_evaluate_returns_async_handle() -> None:
     """submit_evaluate returns an AsyncEvaluationHandle."""
     _, model = _make_simple()
-    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 50)
+    handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 50)
     assert isinstance(handle, AsyncEvaluationHandle)
 
 
@@ -71,7 +71,7 @@ def test_async_handle_is_subclass_of_evaluation_handle() -> None:
 def test_get_returns_evaluation_result_with_correct_shape() -> None:
     """get() blocks until done and returns a result with the expected shape."""
     _, model = _make_simple()
-    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 40)
+    handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 40)
     result = handle.get()
     assert result[model.outputs.y].shape == (40,)
 
@@ -79,7 +79,7 @@ def test_get_returns_evaluation_result_with_correct_shape() -> None:
 def test_get_idempotent() -> None:
     """Repeated get() calls return the same cached result object."""
     _, model = _make_simple()
-    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30)
+    handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 30)
     r1 = handle.get()
     r2 = handle.get()
     assert r1 is r2
@@ -88,7 +88,7 @@ def test_get_idempotent() -> None:
 def test_result_property_after_get() -> None:
     """handle.result is accessible after get() has been called."""
     _, model = _make_simple()
-    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30)
+    handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 30)
     handle.get()
     arr = handle.result[model.outputs.y]
     assert arr.shape == (30,)
@@ -107,7 +107,7 @@ def test_result_raises_before_done() -> None:
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as slow_exec:
         # Block the sole worker thread.
         blocker = slow_exec.submit(time.sleep, 5)
-        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 20, pool=slow_exec)
+        handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 20, pool=slow_exec)
         try:
             with pytest.raises(RuntimeError, match="still running"):
                 _ = handle.result
@@ -123,7 +123,7 @@ def test_result_raises_before_done() -> None:
 def test_poll_returns_true_after_get() -> None:
     """poll() returns (True, result) after the future resolves."""
     _, model = _make_simple()
-    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30)
+    handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 30)
     handle.get()  # ensure resolved
     done, result = handle.poll()
     assert done is True
@@ -136,7 +136,7 @@ def test_poll_returns_false_while_running() -> None:
     _, model = _make_simple()
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as slow_exec:
         blocker = slow_exec.submit(time.sleep, 5)
-        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 20, pool=slow_exec)
+        handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 20, pool=slow_exec)
         try:
             done, result = handle.poll()
             assert done is False
@@ -153,7 +153,7 @@ def test_poll_returns_false_while_running() -> None:
 def test_extend_after_get_grows_ensemble() -> None:
     """extend() works normally after get() has resolved the future."""
     _, model = _make_simple()
-    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30, rng=np.random.default_rng(1))
+    handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 30, rng=np.random.default_rng(1))
     handle.get()
     handle.extend(20)
     assert handle.result[model.outputs.y].shape == (50,)
@@ -164,7 +164,7 @@ def test_extend_raises_before_done() -> None:
     _, model = _make_simple()
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as slow_exec:
         blocker = slow_exec.submit(time.sleep, 5)
-        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 20, pool=slow_exec)
+        handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 20, pool=slow_exec)
         try:
             with pytest.raises(RuntimeError, match="cannot extend"):
                 handle.extend(10)
@@ -182,8 +182,8 @@ def test_submit_evaluate_matches_evaluate_incremental() -> None:
     _, model = _make_simple()
     ev = Evaluation(model)
 
-    sync_handle = EvaluationHandle.from_evaluation(ev, 50, rng=np.random.default_rng(11))
-    async_handle = AsyncEvaluationHandle.from_evaluation(ev, 50, rng=np.random.default_rng(11))
+    sync_handle = EvaluationHandle.evaluate(ev, 50, rng=np.random.default_rng(11))
+    async_handle = AsyncEvaluationHandle.evaluate(ev, 50, rng=np.random.default_rng(11))
     async_handle.get()
 
     np.testing.assert_array_equal(
@@ -207,6 +207,6 @@ def test_custom_executor_is_used() -> None:
     """A caller-supplied pool is used instead of the default."""
     _, model = _make_simple()
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as custom_exec:
-        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30, pool=custom_exec)
+        handle = AsyncEvaluationHandle.evaluate(Evaluation(model), 30, pool=custom_exec)
         result = handle.get()
     assert result[model.outputs.y].shape == (30,)

--- a/tests/dt_model/simulation/test_evaluation_async.py
+++ b/tests/dt_model/simulation/test_evaluation_async.py
@@ -11,8 +11,12 @@ from scipy import stats
 
 from civic_digital_twins.dt_model.model.index import DistributionIndex, Index
 from civic_digital_twins.dt_model.model.model import Model
-from civic_digital_twins.dt_model.simulation.evaluation import Evaluation, _get_default_executor
-from civic_digital_twins.dt_model.simulation.handle import AsyncEvaluationHandle, EvaluationHandle
+from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
+from civic_digital_twins.dt_model.simulation.handle import (
+    AsyncEvaluationHandle,
+    EvaluationHandle,
+    _get_default_executor,
+)
 
 # ---------------------------------------------------------------------------
 # Shared model fixture (same pattern as test_evaluation_handle.py)
@@ -50,7 +54,7 @@ def _make_simple() -> tuple[Index, _SimpleModel]:
 def test_submit_evaluate_returns_async_handle() -> None:
     """submit_evaluate returns an AsyncEvaluationHandle."""
     _, model = _make_simple()
-    handle = Evaluation(model).submit_evaluate(50)
+    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 50)
     assert isinstance(handle, AsyncEvaluationHandle)
 
 
@@ -67,7 +71,7 @@ def test_async_handle_is_subclass_of_evaluation_handle() -> None:
 def test_get_returns_evaluation_result_with_correct_shape() -> None:
     """get() blocks until done and returns a result with the expected shape."""
     _, model = _make_simple()
-    handle = Evaluation(model).submit_evaluate(40)
+    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 40)
     result = handle.get()
     assert result[model.outputs.y].shape == (40,)
 
@@ -75,7 +79,7 @@ def test_get_returns_evaluation_result_with_correct_shape() -> None:
 def test_get_idempotent() -> None:
     """Repeated get() calls return the same cached result object."""
     _, model = _make_simple()
-    handle = Evaluation(model).submit_evaluate(30)
+    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30)
     r1 = handle.get()
     r2 = handle.get()
     assert r1 is r2
@@ -84,7 +88,7 @@ def test_get_idempotent() -> None:
 def test_result_property_after_get() -> None:
     """handle.result is accessible after get() has been called."""
     _, model = _make_simple()
-    handle = Evaluation(model).submit_evaluate(30)
+    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30)
     handle.get()
     arr = handle.result[model.outputs.y]
     assert arr.shape == (30,)
@@ -103,7 +107,7 @@ def test_result_raises_before_done() -> None:
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as slow_exec:
         # Block the sole worker thread.
         blocker = slow_exec.submit(time.sleep, 5)
-        handle = Evaluation(model).submit_evaluate(20, pool=slow_exec)
+        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 20, pool=slow_exec)
         try:
             with pytest.raises(RuntimeError, match="still running"):
                 _ = handle.result
@@ -119,7 +123,7 @@ def test_result_raises_before_done() -> None:
 def test_poll_returns_true_after_get() -> None:
     """poll() returns (True, result) after the future resolves."""
     _, model = _make_simple()
-    handle = Evaluation(model).submit_evaluate(30)
+    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30)
     handle.get()  # ensure resolved
     done, result = handle.poll()
     assert done is True
@@ -132,7 +136,7 @@ def test_poll_returns_false_while_running() -> None:
     _, model = _make_simple()
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as slow_exec:
         blocker = slow_exec.submit(time.sleep, 5)
-        handle = Evaluation(model).submit_evaluate(20, pool=slow_exec)
+        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 20, pool=slow_exec)
         try:
             done, result = handle.poll()
             assert done is False
@@ -149,7 +153,7 @@ def test_poll_returns_false_while_running() -> None:
 def test_extend_after_get_grows_ensemble() -> None:
     """extend() works normally after get() has resolved the future."""
     _, model = _make_simple()
-    handle = Evaluation(model).submit_evaluate(30, rng=np.random.default_rng(1))
+    handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30, rng=np.random.default_rng(1))
     handle.get()
     handle.extend(20)
     assert handle.result[model.outputs.y].shape == (50,)
@@ -160,7 +164,7 @@ def test_extend_raises_before_done() -> None:
     _, model = _make_simple()
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as slow_exec:
         blocker = slow_exec.submit(time.sleep, 5)
-        handle = Evaluation(model).submit_evaluate(20, pool=slow_exec)
+        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 20, pool=slow_exec)
         try:
             with pytest.raises(RuntimeError, match="cannot extend"):
                 handle.extend(10)
@@ -178,8 +182,8 @@ def test_submit_evaluate_matches_evaluate_incremental() -> None:
     _, model = _make_simple()
     ev = Evaluation(model)
 
-    sync_handle = ev.evaluate_incremental(50, rng=np.random.default_rng(11))
-    async_handle = ev.submit_evaluate(50, rng=np.random.default_rng(11))
+    sync_handle = EvaluationHandle.from_evaluation(ev, 50, rng=np.random.default_rng(11))
+    async_handle = AsyncEvaluationHandle.from_evaluation(ev, 50, rng=np.random.default_rng(11))
     async_handle.get()
 
     np.testing.assert_array_equal(
@@ -203,6 +207,6 @@ def test_custom_executor_is_used() -> None:
     """A caller-supplied pool is used instead of the default."""
     _, model = _make_simple()
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as custom_exec:
-        handle = Evaluation(model).submit_evaluate(30, pool=custom_exec)
+        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(model), 30, pool=custom_exec)
         result = handle.get()
     assert result[model.outputs.y].shape == (30,)

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -517,17 +517,54 @@ def _make_fake_result(
     return EvaluationResult(state, axis_layout, {}, axis_sizes=axis_sizes, factorized_weights=factorized_weights)
 
 
-def test_merge_results_multi_axis_raises() -> None:
-    """_merge_results raises NotImplementedError when either result has multiple ENSEMBLE axes."""
+def test_merge_results_multi_axis_no_name_raises() -> None:
+    """_merge_results raises ValueError for multi-axis results when merge_axis_name is absent."""
     _, model = _make_simple()
     ev = Evaluation(model)
     plan = ev.build_plan()
     ax1 = Axis("ens1", ENSEMBLE)
     ax2 = Axis("ens2", ENSEMBLE)
     r_multi = _make_fake_result(plan, (ax1, ax2), (2, 3))
-    r_single = _make_fake_result(plan, (Axis("ens", ENSEMBLE),), (5,))
-    with pytest.raises(NotImplementedError, match="multiple ENSEMBLE axes"):
-        _merge_results(r_multi, r_single, plan)
+    r_multi2 = _make_fake_result(plan, (Axis("ens1", ENSEMBLE), Axis("ens2", ENSEMBLE)), (4, 3))
+    with pytest.raises(ValueError, match="multiple ENSEMBLE axes"):
+        _merge_results(r_multi, r_multi2, plan)
+
+
+def test_merge_results_multi_axis_concat() -> None:
+    """_merge_results concatenates correctly along the named ENSEMBLE axis."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    plan = ev.build_plan()
+
+    r1 = _make_fake_result(plan, (Axis("ens1", ENSEMBLE), Axis("ens2", ENSEMBLE)), (2, 3))
+    r2 = _make_fake_result(plan, (Axis("ens1", ENSEMBLE), Axis("ens2", ENSEMBLE)), (4, 3))
+    merged = _merge_results(r1, r2, plan, merge_axis_name="ens1")
+
+    merged_ens1 = next(ax for ax in merged._axis_sizes if ax.name == "ens1")
+    merged_ens2 = next(ax for ax in merged._axis_sizes if ax.name == "ens2")
+    assert merged._axis_sizes[merged_ens1] == 6
+    assert merged._axis_sizes[merged_ens2] == 3
+
+    for noi in plan.nodes_of_interest:
+        assert np.asarray(merged._state.values[noi.node]).shape == (6, 3)
+
+    # Growing axis: proportional mixture; fixed axis: unchanged weights from r1.
+    alpha = 2 / 6
+    expected_ens1_w = np.concatenate([np.full(2, 1.0 / 2) * alpha, np.full(4, 1.0 / 4) * (1 - alpha)])
+    np.testing.assert_allclose(merged._factorized_weights[merged_ens1], expected_ens1_w)
+    np.testing.assert_allclose(merged._factorized_weights[merged_ens2], np.full(3, 1.0 / 3))
+
+
+def test_merge_results_multi_axis_fixed_mismatch_raises() -> None:
+    """_merge_results raises ValueError when the fixed ENSEMBLE axis sizes differ."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    plan = ev.build_plan()
+
+    r1 = _make_fake_result(plan, (Axis("ens1", ENSEMBLE), Axis("ens2", ENSEMBLE)), (2, 3))
+    r2 = _make_fake_result(plan, (Axis("ens1", ENSEMBLE), Axis("ens2", ENSEMBLE)), (4, 5))
+    with pytest.raises(ValueError, match="fixed ENSEMBLE axis"):
+        _merge_results(r1, r2, plan, merge_axis_name="ens1")
 
 
 def test_merge_results_parameter_layout_mismatch_raises() -> None:

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -75,7 +75,7 @@ def test_evaluate_incremental_returns_handle() -> None:
     """evaluate_incremental returns an EvaluationHandle."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(50)
+    handle = EvaluationHandle.from_evaluation(ev, 50)
     assert isinstance(handle, EvaluationHandle)
 
 
@@ -83,7 +83,7 @@ def test_handle_result_is_evaluation_result() -> None:
     """handle.result is an EvaluationResult with the correct shape."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(50)
+    handle = EvaluationHandle.from_evaluation(ev, 50)
     result = handle.result
     arr = result[model.outputs.y]
     # shape should be (50,) — one ENSEMBLE axis of size 50
@@ -94,7 +94,7 @@ def test_handle_result_weights_sum_to_one() -> None:
     """Initial result weights are uniform and sum to 1."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(40)
+    handle = EvaluationHandle.from_evaluation(ev, 40)
     w = handle.result.weights
     assert w.shape == (40,)
     np.testing.assert_allclose(w.sum(), 1.0)
@@ -107,8 +107,8 @@ def test_evaluate_incremental_reproducible_with_seed() -> None:
     ev = Evaluation(model)
     rng1 = np.random.default_rng(42)
     rng2 = np.random.default_rng(42)
-    h1 = ev.evaluate_incremental(30, rng=rng1)
-    h2 = ev.evaluate_incremental(30, rng=rng2)
+    h1 = EvaluationHandle.from_evaluation(ev, 30, rng=rng1)
+    h2 = EvaluationHandle.from_evaluation(ev, 30, rng=rng2)
     np.testing.assert_array_equal(h1.result[model.outputs.y], h2.result[model.outputs.y])
 
 
@@ -121,7 +121,7 @@ def test_extend_increases_ensemble_size() -> None:
     """extend(n) grows the ensemble from S to S+n scenarios."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(30)
+    handle = EvaluationHandle.from_evaluation(ev, 30)
     result = handle.extend(20)
     arr = result[model.outputs.y]
     assert arr.shape == (50,)
@@ -131,7 +131,7 @@ def test_extend_updates_handle_result() -> None:
     """handle.result is updated after extend()."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(30)
+    handle = EvaluationHandle.from_evaluation(ev, 30)
     extended = handle.extend(20)
     assert handle.result is extended
 
@@ -140,7 +140,7 @@ def test_extend_weights_renormalized() -> None:
     """After extend(), weights are uniform over the combined ensemble."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(30)
+    handle = EvaluationHandle.from_evaluation(ev, 30)
     handle.extend(20)
     w = handle.result.weights
     assert w.shape == (50,)
@@ -162,7 +162,7 @@ def test_merge_preserves_nonuniform_weights() -> None:
     ax1 = Axis("ens_a", ENSEMBLE)
     ax2 = Axis("ens_b", ENSEMBLE)
     w1 = np.array([0.4, 0.4, 0.1, 0.1])  # non-uniform, sums to 1
-    w2 = np.array([0.7, 0.3])             # non-uniform, sums to 1
+    w2 = np.array([0.7, 0.3])  # non-uniform, sums to 1
 
     def _make(ax, sz, w):
         values = {idx.node: np.zeros(sz) for idx in plan.nodes_of_interest}
@@ -183,7 +183,7 @@ def test_extend_zero_is_noop() -> None:
     """extend(0) is a no-op — result unchanged."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(30)
+    handle = EvaluationHandle.from_evaluation(ev, 30)
     before = handle.result
     returned = handle.extend(0)
     assert returned is before
@@ -194,7 +194,7 @@ def test_extend_negative_is_noop() -> None:
     """extend(-1) is also a no-op."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(30)
+    handle = EvaluationHandle.from_evaluation(ev, 30)
     before = handle.result
     returned = handle.extend(-1)
     assert returned is before
@@ -204,7 +204,7 @@ def test_multiple_extends_accumulate() -> None:
     """Multiple extend() calls accumulate scenarios correctly."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(10)
+    handle = EvaluationHandle.from_evaluation(ev, 10)
     handle.extend(10)
     handle.extend(10)
     arr = handle.result[model.outputs.y]
@@ -223,12 +223,12 @@ def test_incremental_matches_direct_evaluation() -> None:
     ev = Evaluation(model)
 
     # --- Incremental: 30 then 20 ---
-    h = ev.evaluate_incremental(30, rng=np.random.default_rng(99))
+    h = EvaluationHandle.from_evaluation(ev, 30, rng=np.random.default_rng(99))
     h.extend(20)
     incremental_arr = h.result[model.outputs.y]
 
     # --- Direct: 50 at once from the same seed ---
-    direct = ev.evaluate_incremental(50, rng=np.random.default_rng(99))
+    direct = EvaluationHandle.from_evaluation(ev, 50, rng=np.random.default_rng(99))
     direct_arr = direct.result[model.outputs.y]
 
     assert incremental_arr.shape == direct_arr.shape == (50,)
@@ -240,10 +240,10 @@ def test_extend_reproducible_sequence() -> None:
     _, model = _make_simple()
     ev = Evaluation(model)
 
-    h1 = ev.evaluate_incremental(20, rng=np.random.default_rng(7))
+    h1 = EvaluationHandle.from_evaluation(ev, 20, rng=np.random.default_rng(7))
     h1.extend(30)
 
-    h2 = ev.evaluate_incremental(20, rng=np.random.default_rng(7))
+    h2 = EvaluationHandle.from_evaluation(ev, 20, rng=np.random.default_rng(7))
     h2.extend(30)
 
     np.testing.assert_array_equal(h1.result[model.outputs.y], h2.result[model.outputs.y])
@@ -258,7 +258,7 @@ def test_extend_constant_node_stays_singleton() -> None:
     """Constant nodes (no ensemble dependency) remain singletons after merge."""
     model = _ConstModel()
     # ConstModel has no abstract indexes — we must pass it via evaluate(), not
-    # evaluate_incremental (which tries to build a DistributionEnsemble).
+    # EvaluationHandle.from_evaluation (which tries to build a DistributionEnsemble).
     # Instead, test _merge_results directly with a manually built plan + results.
     ev = Evaluation(model)
     plan = ev.build_plan()
@@ -321,6 +321,7 @@ def _make_param_handle(
 ) -> tuple[Index, "_SimpleParamModel", Evaluation, "EvaluationHandle"]:  # type: ignore[name-defined]
     """Helper: model with one distribution index and one sweep parameter."""
     import dataclasses
+
     from scipy import stats
 
     x2 = DistributionIndex("x2", stats.norm, {"loc": 0.0, "scale": 1.0})
@@ -343,7 +344,7 @@ def _make_param_handle(
     model = _SPM(x2, speed)
     ev = Evaluation(model)
     params: dict[GenericIndex, np.ndarray] = {speed: param_vals}
-    handle = ev.evaluate_incremental(ensemble_size, parameters=params, rng=np.random.default_rng(seed))
+    handle = EvaluationHandle.from_evaluation(ev, ensemble_size, parameters=params, rng=np.random.default_rng(seed))
     return speed, model, ev, handle
 
 
@@ -396,12 +397,12 @@ def test_extend_extra_parameters_reproducible() -> None:
     seed = 77
 
     # Incremental path: 3 values + extend with 2 more.
-    h_inc = ev.evaluate_incremental(30, parameters={speed: all_vals[:3]}, rng=np.random.default_rng(seed))
+    h_inc = EvaluationHandle.from_evaluation(ev, 30, parameters={speed: all_vals[:3]}, rng=np.random.default_rng(seed))
     h_inc.extend(extra_parameters={speed: all_vals[3:]})
     inc_arr = h_inc.result[model.outputs.y]
 
     # Direct path: all 5 values at once, same seed.
-    h_dir = ev.evaluate_incremental(30, parameters={speed: all_vals}, rng=np.random.default_rng(seed))
+    h_dir = EvaluationHandle.from_evaluation(ev, 30, parameters={speed: all_vals}, rng=np.random.default_rng(seed))
     dir_arr = h_dir.result[model.outputs.y]
 
     assert inc_arr.shape == dir_arr.shape == (5, 30)
@@ -411,6 +412,7 @@ def test_extend_extra_parameters_reproducible() -> None:
 def test_extend_extra_parameters_multiple_params() -> None:
     """extend(extra_parameters=) with multiple keys extends each axis in turn."""
     import dataclasses
+
     from scipy import stats
 
     x2 = DistributionIndex("x2", stats.norm, {"loc": 0.0, "scale": 1.0})
@@ -435,7 +437,7 @@ def test_extend_extra_parameters_multiple_params() -> None:
     model = _TwoParam(x2, speed, temp)
     ev = Evaluation(model)
     params: dict[GenericIndex, np.ndarray] = {speed: np.array([1.0, 2.0]), temp: np.array([10.0, 20.0])}
-    handle = ev.evaluate_incremental(15, parameters=params, rng=np.random.default_rng(0))
+    handle = EvaluationHandle.from_evaluation(ev, 15, parameters=params, rng=np.random.default_rng(0))
     assert handle.result[model.outputs.y].shape == (2, 2, 15)
 
     handle.extend(extra_parameters={speed: np.array([3.0, 4.0]), temp: np.array([30.0])})
@@ -446,7 +448,7 @@ def test_extend_extra_parameters_unknown_index_raises() -> None:
     """extend(extra_parameters=) raises ValueError for an index not in the original parameters."""
     x, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(20)
+    handle = EvaluationHandle.from_evaluation(ev, 20)
     with pytest.raises(ValueError, match="not in the original parameters"):
         handle.extend(extra_parameters={x: np.array([1.0])})
 
@@ -484,7 +486,7 @@ def test_evaluate_incremental_with_parameters() -> None:
     ev2 = Evaluation(pm)
 
     params: dict[GenericIndex, np.ndarray] = {speed: np.array([1.0, 2.0, 3.0])}
-    handle = ev2.evaluate_incremental(20, parameters=params)
+    handle = EvaluationHandle.from_evaluation(ev2, 20, parameters=params)
     arr = handle.result[pm.outputs.y]
     # shape: (3, 20) — 3 PARAMETER values × 20 ensemble scenarios
     assert arr.shape == (3, 20)

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -148,6 +148,37 @@ def test_extend_weights_renormalized() -> None:
     np.testing.assert_allclose(w, np.full(50, 1.0 / 50))
 
 
+def test_merge_preserves_nonuniform_weights() -> None:
+    """_merge_results uses size-proportional mixture, preserving non-uniform weights.
+
+    merged[i] = w1[i] * S1/(S1+S2)  for i in r1
+    merged[j] = w2[j] * S2/(S1+S2)  for j in r2
+    """
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    plan = ev.build_plan()
+
+    S1, S2 = 4, 2
+    ax1 = Axis("ens_a", ENSEMBLE)
+    ax2 = Axis("ens_b", ENSEMBLE)
+    w1 = np.array([0.4, 0.4, 0.1, 0.1])  # non-uniform, sums to 1
+    w2 = np.array([0.7, 0.3])             # non-uniform, sums to 1
+
+    def _make(ax, sz, w):
+        values = {idx.node: np.zeros(sz) for idx in plan.nodes_of_interest}
+        state = _executor.State(values)
+        return EvaluationResult(state, {ax: 0}, {}, axis_sizes={ax: sz}, factorized_weights={ax: w})
+
+    r1 = _make(ax1, S1, w1)
+    r2 = _make(ax2, S2, w2)
+    merged = _merge_results(r1, r2, plan)
+
+    alpha = S1 / (S1 + S2)
+    expected = np.concatenate([w1 * alpha, w2 * (1.0 - alpha)])
+    np.testing.assert_allclose(merged.weights, expected)
+    np.testing.assert_allclose(merged.weights.sum(), 1.0)
+
+
 def test_extend_zero_is_noop() -> None:
     """extend(0) is a no-op — result unchanged."""
     _, model = _make_simple()

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -288,7 +288,7 @@ def test_extend_with_ensemble_size_1_stochastic() -> None:
     """
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = ev.evaluate_incremental(1, rng=np.random.default_rng(0))
+    handle = EvaluationHandle.evaluate(ev, 1, rng=np.random.default_rng(0))
     # This must not raise AssertionError.
     result = handle.extend(1)
     assert result[model.outputs.y].shape == (2,)
@@ -300,7 +300,7 @@ def test_extend_single_sample_preserves_both_draws() -> None:
     _, model = _make_simple()
     ev = Evaluation(model)
     rng = np.random.default_rng(42)
-    handle = ev.evaluate_incremental(1, rng=rng)
+    handle = EvaluationHandle.evaluate(ev, 1, rng=rng)
     first_draw = handle.result[model.inputs.x].copy()
     handle.extend(1)
     merged_x = handle.result[model.inputs.x]
@@ -310,16 +310,144 @@ def test_extend_single_sample_preserves_both_draws() -> None:
 
 
 # ---------------------------------------------------------------------------
-# extra_parameters raises NotImplementedError
+# extra_parameters — parameter-grid extension
 # ---------------------------------------------------------------------------
 
 
-def test_extend_extra_parameters_raises() -> None:
-    """extend(extra_parameters=...) raises NotImplementedError in v0.10.0."""
+def _make_param_handle(
+    param_vals: np.ndarray,
+    ensemble_size: int,
+    seed: int = 0,
+) -> tuple[Index, "_SimpleParamModel", Evaluation, "EvaluationHandle"]:  # type: ignore[name-defined]
+    """Helper: model with one distribution index and one sweep parameter."""
+    import dataclasses
+    from scipy import stats
+
+    x2 = DistributionIndex("x2", stats.norm, {"loc": 0.0, "scale": 1.0})
+    speed = Index("speed", 1.0)
+
+    class _SPM(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            x: Index
+            speed: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            y: Index
+
+        def __init__(self, x: Index, s: Index) -> None:
+            y = Index("y", x.node + s.node)
+            super().__init__("SPM", inputs=_SPM.Inputs(x=x, speed=s), outputs=_SPM.Outputs(y=y))
+
+    model = _SPM(x2, speed)
+    ev = Evaluation(model)
+    params: dict[GenericIndex, np.ndarray] = {speed: param_vals}
+    handle = ev.evaluate_incremental(ensemble_size, parameters=params, rng=np.random.default_rng(seed))
+    return speed, model, ev, handle
+
+
+def test_extend_extra_parameters_param_only() -> None:
+    """extend(extra_parameters=) extends the PARAMETER axis, keeping the same ensemble."""
+    speed, model, ev, handle = _make_param_handle(np.array([1.0, 2.0, 3.0]), ensemble_size=20)
+    arr = handle.result[model.outputs.y]
+    assert arr.shape == (3, 20)
+
+    handle.extend(extra_parameters={speed: np.array([4.0, 5.0])})
+    arr2 = handle.result[model.outputs.y]
+    assert arr2.shape == (5, 20)
+
+
+def test_extend_extra_parameters_combined() -> None:
+    """extend(N, extra_parameters=) grows both axes simultaneously."""
+    speed, model, ev, handle = _make_param_handle(np.array([1.0, 2.0, 3.0]), ensemble_size=20)
+    handle.extend(10, extra_parameters={speed: np.array([4.0, 5.0])})
+    arr = handle.result[model.outputs.y]
+    assert arr.shape == (5, 30)
+
+
+def test_extend_extra_parameters_reproducible() -> None:
+    """extend(extra_parameters=) matches a single evaluate_incremental with all params."""
+    from scipy import stats
+
+    x2 = DistributionIndex("x2", stats.norm, {"loc": 0.0, "scale": 1.0})
+
+    import dataclasses
+
+    speed = Index("speed", 1.0)
+
+    class _SPM(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            x: Index
+            speed: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            y: Index
+
+        def __init__(self, x: Index, s: Index) -> None:
+            y = Index("y", x.node + s.node)
+            super().__init__("SPM", inputs=_SPM.Inputs(x=x, speed=s), outputs=_SPM.Outputs(y=y))
+
+    model = _SPM(x2, speed)
+    ev = Evaluation(model)
+    all_vals = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    seed = 77
+
+    # Incremental path: 3 values + extend with 2 more.
+    h_inc = ev.evaluate_incremental(30, parameters={speed: all_vals[:3]}, rng=np.random.default_rng(seed))
+    h_inc.extend(extra_parameters={speed: all_vals[3:]})
+    inc_arr = h_inc.result[model.outputs.y]
+
+    # Direct path: all 5 values at once, same seed.
+    h_dir = ev.evaluate_incremental(30, parameters={speed: all_vals}, rng=np.random.default_rng(seed))
+    dir_arr = h_dir.result[model.outputs.y]
+
+    assert inc_arr.shape == dir_arr.shape == (5, 30)
+    np.testing.assert_array_equal(inc_arr, dir_arr)
+
+
+def test_extend_extra_parameters_multiple_params() -> None:
+    """extend(extra_parameters=) with multiple keys extends each axis in turn."""
+    import dataclasses
+    from scipy import stats
+
+    x2 = DistributionIndex("x2", stats.norm, {"loc": 0.0, "scale": 1.0})
+    speed = Index("speed", 1.0)
+    temp = Index("temp", 10.0)
+
+    class _TwoParam(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            x: Index
+            speed: Index
+            temp: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            y: Index
+
+        def __init__(self, x: Index, s: Index, t: Index) -> None:
+            y = Index("y", x.node + s.node + t.node)
+            super().__init__("TP", inputs=_TwoParam.Inputs(x=x, speed=s, temp=t), outputs=_TwoParam.Outputs(y=y))
+
+    model = _TwoParam(x2, speed, temp)
+    ev = Evaluation(model)
+    params: dict[GenericIndex, np.ndarray] = {speed: np.array([1.0, 2.0]), temp: np.array([10.0, 20.0])}
+    handle = ev.evaluate_incremental(15, parameters=params, rng=np.random.default_rng(0))
+    assert handle.result[model.outputs.y].shape == (2, 2, 15)
+
+    handle.extend(extra_parameters={speed: np.array([3.0, 4.0]), temp: np.array([30.0])})
+    assert handle.result[model.outputs.y].shape == (4, 3, 15)
+
+
+def test_extend_extra_parameters_unknown_index_raises() -> None:
+    """extend(extra_parameters=) raises ValueError for an index not in the original parameters."""
     x, model = _make_simple()
     ev = Evaluation(model)
     handle = ev.evaluate_incremental(20)
-    with pytest.raises(NotImplementedError, match="extra_parameters"):
+    with pytest.raises(ValueError, match="not in the original parameters"):
         handle.extend(extra_parameters={x: np.array([1.0])})
 
 

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -77,7 +77,7 @@ def test_evaluate_incremental_returns_handle() -> None:
     """evaluate_incremental returns an EvaluationHandle."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 50)
+    handle = EvaluationHandle.evaluate(ev, 50)
     assert isinstance(handle, EvaluationHandle)
 
 
@@ -85,7 +85,7 @@ def test_handle_result_is_evaluation_result() -> None:
     """handle.result is an EvaluationResult with the correct shape."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 50)
+    handle = EvaluationHandle.evaluate(ev, 50)
     result = handle.result
     arr = result[model.outputs.y]
     # shape should be (50,) — one ENSEMBLE axis of size 50
@@ -96,7 +96,7 @@ def test_handle_result_weights_sum_to_one() -> None:
     """Initial result weights are uniform and sum to 1."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 40)
+    handle = EvaluationHandle.evaluate(ev, 40)
     w = handle.result.weights
     assert w.shape == (40,)
     np.testing.assert_allclose(w.sum(), 1.0)
@@ -109,8 +109,8 @@ def test_evaluate_incremental_reproducible_with_seed() -> None:
     ev = Evaluation(model)
     rng1 = np.random.default_rng(42)
     rng2 = np.random.default_rng(42)
-    h1 = EvaluationHandle.from_evaluation(ev, 30, rng=rng1)
-    h2 = EvaluationHandle.from_evaluation(ev, 30, rng=rng2)
+    h1 = EvaluationHandle.evaluate(ev, 30, rng=rng1)
+    h2 = EvaluationHandle.evaluate(ev, 30, rng=rng2)
     np.testing.assert_array_equal(h1.result[model.outputs.y], h2.result[model.outputs.y])
 
 
@@ -123,7 +123,7 @@ def test_extend_increases_ensemble_size() -> None:
     """extend(n) grows the ensemble from S to S+n scenarios."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 30)
+    handle = EvaluationHandle.evaluate(ev, 30)
     result = handle.extend(20)
     arr = result[model.outputs.y]
     assert arr.shape == (50,)
@@ -133,7 +133,7 @@ def test_extend_updates_handle_result() -> None:
     """handle.result is updated after extend()."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 30)
+    handle = EvaluationHandle.evaluate(ev, 30)
     extended = handle.extend(20)
     assert handle.result is extended
 
@@ -142,7 +142,7 @@ def test_extend_weights_renormalized() -> None:
     """After extend(), weights are uniform over the combined ensemble."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 30)
+    handle = EvaluationHandle.evaluate(ev, 30)
     handle.extend(20)
     w = handle.result.weights
     assert w.shape == (50,)
@@ -185,7 +185,7 @@ def test_extend_zero_is_noop() -> None:
     """extend(0) is a no-op — result unchanged."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 30)
+    handle = EvaluationHandle.evaluate(ev, 30)
     before = handle.result
     returned = handle.extend(0)
     assert returned is before
@@ -196,7 +196,7 @@ def test_extend_negative_is_noop() -> None:
     """extend(-1) is also a no-op."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 30)
+    handle = EvaluationHandle.evaluate(ev, 30)
     before = handle.result
     returned = handle.extend(-1)
     assert returned is before
@@ -206,7 +206,7 @@ def test_multiple_extends_accumulate() -> None:
     """Multiple extend() calls accumulate scenarios correctly."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 10)
+    handle = EvaluationHandle.evaluate(ev, 10)
     handle.extend(10)
     handle.extend(10)
     arr = handle.result[model.outputs.y]
@@ -225,12 +225,12 @@ def test_incremental_matches_direct_evaluation() -> None:
     ev = Evaluation(model)
 
     # --- Incremental: 30 then 20 ---
-    h = EvaluationHandle.from_evaluation(ev, 30, rng=np.random.default_rng(99))
+    h = EvaluationHandle.evaluate(ev, 30, rng=np.random.default_rng(99))
     h.extend(20)
     incremental_arr = h.result[model.outputs.y]
 
     # --- Direct: 50 at once from the same seed ---
-    direct = EvaluationHandle.from_evaluation(ev, 50, rng=np.random.default_rng(99))
+    direct = EvaluationHandle.evaluate(ev, 50, rng=np.random.default_rng(99))
     direct_arr = direct.result[model.outputs.y]
 
     assert incremental_arr.shape == direct_arr.shape == (50,)
@@ -242,10 +242,10 @@ def test_extend_reproducible_sequence() -> None:
     _, model = _make_simple()
     ev = Evaluation(model)
 
-    h1 = EvaluationHandle.from_evaluation(ev, 20, rng=np.random.default_rng(7))
+    h1 = EvaluationHandle.evaluate(ev, 20, rng=np.random.default_rng(7))
     h1.extend(30)
 
-    h2 = EvaluationHandle.from_evaluation(ev, 20, rng=np.random.default_rng(7))
+    h2 = EvaluationHandle.evaluate(ev, 20, rng=np.random.default_rng(7))
     h2.extend(30)
 
     np.testing.assert_array_equal(h1.result[model.outputs.y], h2.result[model.outputs.y])
@@ -260,7 +260,7 @@ def test_extend_constant_node_stays_singleton() -> None:
     """Constant nodes (no ensemble dependency) remain singletons after merge."""
     model = _ConstModel()
     # ConstModel has no abstract indexes — we must pass it via evaluate(), not
-    # EvaluationHandle.from_evaluation (which tries to build a DistributionEnsemble).
+    # EvaluationHandle.evaluate (which tries to build a DistributionEnsemble).
     # Instead, test _merge_results directly with a manually built plan + results.
     ev = Evaluation(model)
     plan = ev.build_plan()
@@ -346,7 +346,7 @@ def _make_param_handle(
     model = _SPM(x2, speed)
     ev = Evaluation(model)
     params: dict[GenericIndex, np.ndarray] = {speed: param_vals}
-    handle = EvaluationHandle.from_evaluation(ev, ensemble_size, parameters=params, rng=np.random.default_rng(seed))
+    handle = EvaluationHandle.evaluate(ev, ensemble_size, parameters=params, rng=np.random.default_rng(seed))
     return speed, model, ev, handle
 
 
@@ -399,12 +399,12 @@ def test_extend_extra_parameters_reproducible() -> None:
     seed = 77
 
     # Incremental path: 3 values + extend with 2 more.
-    h_inc = EvaluationHandle.from_evaluation(ev, 30, parameters={speed: all_vals[:3]}, rng=np.random.default_rng(seed))
+    h_inc = EvaluationHandle.evaluate(ev, 30, parameters={speed: all_vals[:3]}, rng=np.random.default_rng(seed))
     h_inc.extend(extra_parameters={speed: all_vals[3:]})
     inc_arr = h_inc.result[model.outputs.y]
 
     # Direct path: all 5 values at once, same seed.
-    h_dir = EvaluationHandle.from_evaluation(ev, 30, parameters={speed: all_vals}, rng=np.random.default_rng(seed))
+    h_dir = EvaluationHandle.evaluate(ev, 30, parameters={speed: all_vals}, rng=np.random.default_rng(seed))
     dir_arr = h_dir.result[model.outputs.y]
 
     assert inc_arr.shape == dir_arr.shape == (5, 30)
@@ -439,7 +439,7 @@ def test_extend_extra_parameters_multiple_params() -> None:
     model = _TwoParam(x2, speed, temp)
     ev = Evaluation(model)
     params: dict[GenericIndex, np.ndarray] = {speed: np.array([1.0, 2.0]), temp: np.array([10.0, 20.0])}
-    handle = EvaluationHandle.from_evaluation(ev, 15, parameters=params, rng=np.random.default_rng(0))
+    handle = EvaluationHandle.evaluate(ev, 15, parameters=params, rng=np.random.default_rng(0))
     assert handle.result[model.outputs.y].shape == (2, 2, 15)
 
     handle.extend(extra_parameters={speed: np.array([3.0, 4.0]), temp: np.array([30.0])})
@@ -450,7 +450,7 @@ def test_extend_extra_parameters_unknown_index_raises() -> None:
     """extend(extra_parameters=) raises ValueError for an index not in the original parameters."""
     x, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 20)
+    handle = EvaluationHandle.evaluate(ev, 20)
     with pytest.raises(ValueError, match="not in the original parameters"):
         handle.extend(extra_parameters={x: np.array([1.0])})
 
@@ -488,7 +488,7 @@ def test_evaluate_incremental_with_parameters() -> None:
     ev2 = Evaluation(pm)
 
     params: dict[GenericIndex, np.ndarray] = {speed: np.array([1.0, 2.0, 3.0])}
-    handle = EvaluationHandle.from_evaluation(ev2, 20, parameters=params)
+    handle = EvaluationHandle.evaluate(ev2, 20, parameters=params)
     arr = handle.result[pm.outputs.y]
     # shape: (3, 20) — 3 PARAMETER values × 20 ensemble scenarios
     assert arr.shape == (3, 20)
@@ -801,30 +801,29 @@ def test_extend_ensemble_size_and_extra_ensemble_mutually_exclusive() -> None:
     """extend() raises ValueError when both ensemble_size > 0 and extra_ensemble are supplied."""
     _, model = _make_simple()
     ev = Evaluation(model)
-    handle = EvaluationHandle.from_evaluation(ev, 20)
+    handle = EvaluationHandle.evaluate(ev, 20)
     with pytest.raises(ValueError, match="mutually exclusive"):
         handle.extend(10, extra_ensemble={"_ensemble": 5})
 
 
-def test_extend_extra_parameters_no_stored_ensemble_raises() -> None:
-    """extend(extra_parameters=) raises RuntimeError when the handle has no stored ensemble."""
+def test_extend_extra_parameters_without_stored_ensemble() -> None:
+    """extend(extra_parameters=) works without a stored ensemble by reconstructing from result state."""
     speed, model, ev, _ = _make_param_handle(np.array([1.0, 2.0]), ensemble_size=10)
     plan = ev.build_plan()
     ens = DistributionEnsemble(model, 10, rng=np.random.default_rng(0))
     r = ev.execute_plan(plan, ens, parameters={speed: np.array([1.0, 2.0])})
-    # Construct a handle with ensemble=None so the stored-ensemble check triggers.
     handle = EvaluationHandle(
         evaluation=ev,
         plan=plan,
         result=r,
         rng=np.random.default_rng(),
         parameters={speed: np.array([1.0, 2.0])},
-        ensemble=None,  # explicitly no stored ensemble
+        ensemble=None,  # no stored ensemble — reconstructed from result state
         functions=None,
         backend=_executor.NumpyBackend,
     )
-    with pytest.raises(RuntimeError, match="no stored ensemble"):
-        handle.extend(extra_parameters={speed: np.array([3.0])})
+    result = handle.extend(extra_parameters={speed: np.array([3.0])})
+    assert result[model.outputs.y].shape == (3, 10)
 
 
 # ---------------------------------------------------------------------------
@@ -1067,3 +1066,33 @@ def test_extend_extra_ensemble_updates_frozen_ensemble() -> None:
     assert handle._ensemble is not None
     new_size = handle._ensemble.ensemble_weights[0].size
     assert new_size == 5
+
+
+def test_extend_ensemble_axis_no_recipe_raises() -> None:
+    """_extend_ensemble_axis raises RuntimeError when the handle has no ensemble_recipe."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    plan = ev.build_plan()
+    ens = DistributionEnsemble(model, 10, rng=np.random.default_rng(0))
+    result = ev.execute_plan(plan, ens)
+    handle = EvaluationHandle(
+        evaluation=ev,
+        plan=plan,
+        result=result,
+        rng=np.random.default_rng(1),
+        parameters={},
+        ensemble_recipe=None,  # no recipe
+    )
+    with pytest.raises(RuntimeError, match="ensemble_recipe"):
+        handle.extend(5)
+
+
+def test_evaluate_accepts_custom_recipe() -> None:
+    """A caller-supplied BatchDrawable recipe is used for both the initial draw and future extends."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    recipe = DistributionEnsemble(Scenario(model), 20, rng=np.random.default_rng(0))
+    handle = EvaluationHandle.evaluate(ev, 10, ensemble_recipe=recipe)
+    assert handle.result[model.outputs.y].shape == (10,)
+    # The stored recipe is the one we supplied.
+    assert handle._ensemble_recipe is recipe

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -2,6 +2,7 @@
 """Tests for EvaluationHandle (incremental evaluation) — Step 3 of engine-control.md."""
 
 import dataclasses
+from typing import Any
 
 import numpy as np
 import pytest
@@ -14,6 +15,7 @@ from civic_digital_twins.dt_model.model.model import Model
 from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
 from civic_digital_twins.dt_model.simulation.evaluation import Evaluation, EvaluationResult
 from civic_digital_twins.dt_model.simulation.handle import EvaluationHandle, _merge_results
+from civic_digital_twins.dt_model.simulation.scenario import Scenario
 
 # ---------------------------------------------------------------------------
 # Minimal model fixtures
@@ -318,8 +320,8 @@ def _make_param_handle(
     param_vals: np.ndarray,
     ensemble_size: int,
     seed: int = 0,
-) -> tuple[Index, "_SimpleParamModel", Evaluation, "EvaluationHandle"]:  # type: ignore[name-defined]
-    """Helper: model with one distribution index and one sweep parameter."""
+) -> tuple[Index, Any, Evaluation, EvaluationHandle]:
+    """Build a test model with one distribution index and one PARAMETER sweep."""
     import dataclasses
 
     from scipy import stats
@@ -618,3 +620,450 @@ def test_evaluation_handle_result_raises_when_none() -> None:
     )
     with pytest.raises(RuntimeError, match="not yet available"):
         _ = handle.result
+
+
+# ---------------------------------------------------------------------------
+# FrozenEnsemble / BatchDrawable behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_frozen_ensemble_draw_batch_raises() -> None:
+    """FrozenEnsemble.draw_batch raises TypeError with a descriptive message."""
+    from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble  # noqa: PLC0415
+
+    ax = Axis("_ensemble", ENSEMBLE)
+    fe = FrozenEnsemble((ax,), (np.array([0.5, 0.5]),), {})
+    with pytest.raises(TypeError, match="cannot draw new samples"):
+        fe.draw_batch(5, np.random.default_rng())
+
+
+def test_distribution_ensemble_draw_batch_axis_raises() -> None:
+    """DistributionEnsemble.draw_batch raises ValueError when axis= is not None."""
+    x, model = _make_simple()
+    de = DistributionEnsemble(model, 10, rng=np.random.default_rng(0))
+    with pytest.raises(ValueError, match="single ENSEMBLE axis"):
+        de.draw_batch(5, np.random.default_rng(), axis="unc")
+
+
+def test_frozen_ensemble_concat_along() -> None:
+    """FrozenEnsemble.concat_along appends samples along the named axis correctly."""
+    from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble  # noqa: PLC0415
+
+    ax1 = Axis("unc", ENSEMBLE)
+    ax2 = Axis("default", ENSEMBLE)
+    idx_unc = Index("x_unc", 1.0)
+    idx_def = Index("x_def", 2.0)
+    # idx_unc has shape (2, 1): assigned to ax1 (axis 0, size 2), singleton on ax2.
+    # idx_def has shape (1, 3): singleton on ax1, assigned to ax2 (axis 1, size 3).
+    fe = FrozenEnsemble(
+        (ax1, ax2),
+        (np.array([0.5, 0.5]), np.array([1 / 3, 1 / 3, 1 / 3])),
+        {idx_unc: np.ones((2, 1)), idx_def: np.ones((1, 3))},
+    )
+    # other provides fresh ax1 samples (size 1); idx_unc shape (1,).
+    other = FrozenEnsemble(
+        (Axis("unc", ENSEMBLE),),
+        (np.array([1.0]),),
+        {idx_unc: np.array([99.0])},
+    )
+    merged = fe.concat_along("unc", other)
+    # unc axis grows from 2 → 3; default axis stays at 3.
+    assert merged.ensemble_weights[0].size == 3
+    # idx_unc was (2,1) → concat along ax0 with (1,1) → (3,1)
+    assert list(merged._cached_assignments[idx_unc].shape) == [3, 1]
+    # idx_def is singleton at ax0 (shape[0]==1) → carried forward unchanged.
+    assert list(merged._cached_assignments[idx_def].shape) == [1, 3]
+
+
+def test_frozen_ensemble_with_replaced_axis() -> None:
+    """FrozenEnsemble.with_replaced_axis replaces one axis with fresh samples."""
+    from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble  # noqa: PLC0415
+
+    ax1 = Axis("unc", ENSEMBLE)
+    ax2 = Axis("default", ENSEMBLE)
+    idx_unc = Index("x_unc", 1.0)
+    idx_def = Index("x_def", 2.0)
+    # idx_unc has shape (2, 1): assigned to ax1 (axis 0, size 2), singleton on ax2.
+    # idx_def has shape (1, 3): singleton on ax1, assigned to ax2 (axis 1, size 3).
+    fe = FrozenEnsemble(
+        (ax1, ax2),
+        (np.array([0.5, 0.5]), np.array([1 / 3, 1 / 3, 1 / 3])),
+        {idx_unc: np.ones((2, 1)), idx_def: np.ones((1, 3))},
+    )
+    other = FrozenEnsemble(
+        (Axis("unc", ENSEMBLE),),
+        (np.array([1.0]),),
+        {idx_unc: np.array([42.0])},
+    )
+    replaced = fe.with_replaced_axis("unc", other)
+    # unc axis replaced by new size=1; default axis stays at 3.
+    assert replaced.ensemble_weights[0].shape == (1,)
+    # idx_unc: other has shape (1,) → reshaped to (1, 1) for the 2-axis result.
+    assert replaced._cached_assignments[idx_unc].shape == (1, 1)
+    # idx_def: singleton at ax0, carried forward unchanged.
+    assert replaced._cached_assignments[idx_def].shape == (1, 3)
+
+
+# ---------------------------------------------------------------------------
+# _merge_results error paths for missing named axis
+# ---------------------------------------------------------------------------
+
+
+def test_merge_results_missing_named_axis_in_r1() -> None:
+    """_merge_results raises ValueError when merge_axis_name is not in r1."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    plan = ev.build_plan()
+
+    r1 = _make_fake_result(plan, (Axis("ens_a", ENSEMBLE), Axis("ens_b", ENSEMBLE)), (2, 3))
+    r2 = _make_fake_result(plan, (Axis("ens_a", ENSEMBLE), Axis("ens_b", ENSEMBLE)), (4, 3))
+    with pytest.raises(ValueError, match="no ENSEMBLE axis named 'nonexistent' in r1"):
+        _merge_results(r1, r2, plan, merge_axis_name="nonexistent")
+
+
+def test_merge_results_missing_named_axis_in_r2() -> None:
+    """_merge_results raises ValueError when merge_axis_name is not in r2."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    plan = ev.build_plan()
+
+    r1 = _make_fake_result(plan, (Axis("ens_a", ENSEMBLE), Axis("ens_b", ENSEMBLE)), (2, 3))
+    # r2 only has "ens_a", so "ens_b" is absent in r2.
+    r2 = _make_fake_result(plan, (Axis("ens_a", ENSEMBLE),), (4,))
+    with pytest.raises(ValueError, match="no ENSEMBLE axis named 'ens_b' in r2"):
+        _merge_results(r1, r2, plan, merge_axis_name="ens_b")
+
+
+# ---------------------------------------------------------------------------
+# _merge_results_param_extend error paths
+# ---------------------------------------------------------------------------
+
+
+def test_merge_results_param_extend_multi_ensemble_raises() -> None:
+    """_merge_results_param_extend raises ValueError when a result has multiple ENSEMBLE axes."""
+    from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
+
+    speed, model, ev, handle = _make_param_handle(np.array([1.0, 2.0]), ensemble_size=10)
+    plan = ev.build_plan()
+    r1 = handle.result
+
+    # Build a result with two ENSEMBLE axes.
+    ax_a = Axis("ens_a", ENSEMBLE)
+    ax_b = Axis("ens_b", ENSEMBLE)
+    r2_multi = _make_fake_result(plan, (ax_a, ax_b), (2, 3))
+    with pytest.raises(ValueError, match="exactly one ENSEMBLE axis"):
+        _merge_results_param_extend(r2_multi, r1, plan, speed)
+
+
+def test_merge_results_param_extend_ensemble_size_mismatch_raises() -> None:
+    """_merge_results_param_extend raises ValueError when ENSEMBLE sizes differ."""
+    from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
+
+    speed, model, ev, handle = _make_param_handle(np.array([1.0, 2.0]), ensemble_size=10)
+    plan = ev.build_plan()
+    r1 = handle.result
+
+    # Build r2 with a different ensemble size (10+1=11 vs 10).
+    r2 = ev.execute_plan(
+        plan,
+        DistributionEnsemble(model, 11, rng=np.random.default_rng(99)),
+        parameters={speed: np.array([1.0, 2.0])},
+    )
+    with pytest.raises(ValueError, match="identical ENSEMBLE sizes"):
+        _merge_results_param_extend(r1, r2, plan, speed)
+
+
+def test_merge_results_param_extend_missing_param_axis_raises() -> None:
+    """_merge_results_param_extend raises ValueError when r1 has no PARAMETER axis for param_idx."""
+    from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
+
+    x, model = _make_simple()
+    ev = Evaluation(model)
+    plan = ev.build_plan()
+
+    # Both results have only one ENSEMBLE axis and no PARAMETER axis for speed.
+    ens = DistributionEnsemble(model, 5, rng=np.random.default_rng(0))
+    r1 = ev.execute_plan(plan, ens)
+    r2 = ev.execute_plan(plan, ens)
+
+    # speed is not a PARAMETER axis in r1 → raises.
+    speed = Index("speed", 1.0)
+    with pytest.raises(ValueError, match="no PARAMETER axis named"):
+        _merge_results_param_extend(r1, r2, plan, speed)
+
+
+# ---------------------------------------------------------------------------
+# EvaluationHandle.extend() validation paths
+# ---------------------------------------------------------------------------
+
+
+def test_extend_ensemble_size_and_extra_ensemble_mutually_exclusive() -> None:
+    """extend() raises ValueError when both ensemble_size > 0 and extra_ensemble are supplied."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    handle = EvaluationHandle.from_evaluation(ev, 20)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        handle.extend(10, extra_ensemble={"_ensemble": 5})
+
+
+def test_extend_extra_parameters_no_stored_ensemble_raises() -> None:
+    """extend(extra_parameters=) raises RuntimeError when the handle has no stored ensemble."""
+    speed, model, ev, _ = _make_param_handle(np.array([1.0, 2.0]), ensemble_size=10)
+    plan = ev.build_plan()
+    ens = DistributionEnsemble(model, 10, rng=np.random.default_rng(0))
+    r = ev.execute_plan(plan, ens, parameters={speed: np.array([1.0, 2.0])})
+    # Construct a handle with ensemble=None so the stored-ensemble check triggers.
+    handle = EvaluationHandle(
+        evaluation=ev,
+        plan=plan,
+        result=r,
+        rng=np.random.default_rng(),
+        parameters={speed: np.array([1.0, 2.0])},
+        ensemble=None,  # explicitly no stored ensemble
+        functions=None,
+        backend=_executor.NumpyBackend,
+    )
+    with pytest.raises(RuntimeError, match="no stored ensemble"):
+        handle.extend(extra_parameters={speed: np.array([3.0])})
+
+
+# ---------------------------------------------------------------------------
+# _merge_results — growing axis at different positions raises
+# ---------------------------------------------------------------------------
+
+
+def test_merge_results_growing_axis_at_different_position_raises() -> None:
+    """_merge_results raises ValueError when the named growing axis is at different positions."""
+    _, model = _make_simple()
+    ev = Evaluation(model)
+    plan = ev.build_plan()
+
+    # r1: (ens1 at dim 0, ens2 at dim 1)  r2: (ens2 at dim 0, ens1 at dim 1)
+    ax_e1_r1 = Axis("ens1", ENSEMBLE)
+    ax_e2_r1 = Axis("ens2", ENSEMBLE)
+    ax_e1_r2 = Axis("ens1", ENSEMBLE)
+    ax_e2_r2 = Axis("ens2", ENSEMBLE)
+
+    values_r1: dict = {}
+    values_r2: dict = {}
+    for idx in plan.nodes_of_interest:
+        values_r1[idx.node] = np.zeros((2, 3))
+        values_r2[idx.node] = np.zeros((3, 2))
+
+    from civic_digital_twins.dt_model.engine.numpybackend import executor as _ex  # noqa: PLC0415
+
+    r1 = EvaluationResult(
+        _ex.State(values_r1),
+        {ax_e1_r1: 0, ax_e2_r1: 1},
+        {},
+        axis_sizes={ax_e1_r1: 2, ax_e2_r1: 3},
+        factorized_weights={ax_e1_r1: np.full(2, 0.5), ax_e2_r1: np.full(3, 1 / 3)},
+    )
+    r2 = EvaluationResult(
+        _ex.State(values_r2),
+        {ax_e2_r2: 0, ax_e1_r2: 1},
+        {},
+        axis_sizes={ax_e2_r2: 3, ax_e1_r2: 2},
+        factorized_weights={ax_e2_r2: np.full(3, 1 / 3), ax_e1_r2: np.full(2, 0.5)},
+    )
+    # ens1 is at dim 0 in r1 but dim 1 in r2.
+    with pytest.raises(ValueError, match="dim 0 in r1 but dim 1 in r2"):
+        _merge_results(r1, r2, plan, merge_axis_name="ens1")
+
+
+# ---------------------------------------------------------------------------
+# _merge_results_param_extend — additional error paths
+# ---------------------------------------------------------------------------
+
+
+def test_merge_results_param_extend_param_axis_missing_in_r2() -> None:
+    """_merge_results_param_extend raises ValueError when r2 lacks the growing PARAMETER axis."""
+    from civic_digital_twins.dt_model.engine.numpybackend import executor as _ex  # noqa: PLC0415
+    from civic_digital_twins.dt_model.model.axis import PARAMETER  # noqa: PLC0415
+    from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
+
+    speed, model, ev, handle = _make_param_handle(np.array([1.0, 2.0]), ensemble_size=5)
+    plan = ev.build_plan()
+    r1 = handle.result
+
+    # Build r2 with the ENSEMBLE axis at the same position as r1 but WITHOUT the speed PARAMETER axis.
+    # r1 has PARAMETER(speed) at dim 0, ENSEMBLE at dim 1 → r2 needs ENSEMBLE at dim 1 too.
+    ax_fake_param = Axis("speed2_fake", PARAMETER)
+    ax_ens = Axis("_ensemble", ENSEMBLE)
+    values: dict = {}
+    for idx in plan.nodes_of_interest:
+        values[idx.node] = np.zeros((2, 5))
+    r2 = EvaluationResult(
+        _ex.State(values),
+        {ax_fake_param: 0, ax_ens: 1},  # ENSEMBLE at dim 1, matching r1
+        {},
+        axis_sizes={ax_fake_param: 2, ax_ens: 5},
+        factorized_weights={ax_fake_param: np.full(2, 0.5), ax_ens: np.full(5, 0.2)},
+    )
+    # r2 has no PARAMETER axis named "speed" → raises
+    with pytest.raises(ValueError, match="no PARAMETER axis named"):
+        _merge_results_param_extend(r1, r2, plan, speed)
+
+
+def test_merge_results_param_extend_ensemble_pos_mismatch_raises() -> None:
+    """_merge_results_param_extend raises ValueError when ENSEMBLE axis positions differ."""
+    from civic_digital_twins.dt_model.engine.numpybackend import executor as _ex  # noqa: PLC0415
+    from civic_digital_twins.dt_model.model.axis import PARAMETER  # noqa: PLC0415
+    from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
+
+    speed, model, ev, handle = _make_param_handle(np.array([1.0, 2.0]), ensemble_size=5)
+    plan = ev.build_plan()
+    r1 = handle.result
+    # r1: PARAMETER(speed) at dim 0, ENSEMBLE at dim 1 → ens_pos=1
+
+    # Build r2 with ENSEMBLE at dim 0 (position mismatch vs r1's dim 1).
+    ax_param = Axis("speed", PARAMETER)
+    ax_ens = Axis("_ensemble", ENSEMBLE)
+    values: dict = {}
+    for idx in plan.nodes_of_interest:
+        values[idx.node] = np.zeros((5, 2))  # shape (5_ens, 2_param)
+    r2 = EvaluationResult(
+        _ex.State(values),
+        {ax_ens: 0, ax_param: 1},  # ENSEMBLE at dim 0, PARAMETER at dim 1
+        {},
+        axis_sizes={ax_ens: 5, ax_param: 2},
+        factorized_weights={ax_ens: np.full(5, 0.2), ax_param: np.full(2, 0.5)},
+    )
+    with pytest.raises(ValueError, match="ENSEMBLE axis position mismatch"):
+        _merge_results_param_extend(r1, r2, plan, speed)
+
+
+def test_merge_results_param_extend_fixed_param_layout_differs_raises() -> None:
+    """_merge_results_param_extend raises ValueError when fixed PARAMETER axis layouts differ."""
+    import dataclasses  # noqa: PLC0415
+
+    from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
+
+    # Build a model with two parameter indexes: speed and temp.
+    x2 = DistributionIndex("x2", stats.norm, {"loc": 0.0, "scale": 1.0})
+    speed2 = Index("speed2", 1.0)
+    temp2 = Index("temp2", 10.0)
+
+    class _TwoP(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            x: Index
+            speed: Index
+            temp: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            y: Index
+
+        def __init__(self, x: Index, s: Index, t: Index) -> None:
+            y = Index("y", x.node + s.node + t.node)
+            super().__init__("TP2", inputs=_TwoP.Inputs(x=x, speed=s, temp=t), outputs=_TwoP.Outputs(y=y))
+
+    model2 = _TwoP(x2, speed2, temp2)
+    ev2 = Evaluation(model2)
+    plan2 = ev2.build_plan()
+    ens = DistributionEnsemble(model2, 5, rng=np.random.default_rng(0))
+
+    # r1 has speed2(2) × temp2(2) × ens(5)
+    r1 = ev2.execute_plan(
+        plan2,
+        ens,
+        parameters={speed2: np.array([1.0, 2.0]), temp2: np.array([10.0, 20.0])},
+    )
+    # r2 has speed2(3) × temp2(3) × ens(5) — fixed axis temp2 has different size.
+    r2 = ev2.execute_plan(
+        plan2,
+        ens,
+        parameters={speed2: np.array([3.0, 4.0, 5.0]), temp2: np.array([30.0, 40.0, 50.0])},
+    )
+    with pytest.raises(ValueError, match="fixed PARAMETER axis layouts differ"):
+        _merge_results_param_extend(r1, r2, plan2, speed2)
+
+
+# ---------------------------------------------------------------------------
+# PartitionedEnsemble-backed EvaluationHandle — extend via extra_ensemble
+# ---------------------------------------------------------------------------
+
+
+def _make_pe_handle() -> tuple[Any, Any, Evaluation, EvaluationHandle]:
+    """Build a 2-index model and a PartitionedEnsemble-backed EvaluationHandle."""
+    from civic_digital_twins.dt_model.simulation.ensemble import (  # noqa: PLC0415
+        EnsembleAxisSpec,
+        FrozenEnsemble,
+        PartitionedEnsemble,
+    )
+
+    a = DistributionIndex("a", stats.norm, {"loc": 0.0, "scale": 1.0})
+    b = DistributionIndex("b", stats.norm, {"loc": 1.0, "scale": 0.5})
+
+    class _ABModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            a: Index
+            b: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            y: Index
+
+        def __init__(self, _a: Index, _b: Index) -> None:
+            y = Index("y", _a.node + _b.node)
+            super().__init__("ABModel", inputs=_ABModel.Inputs(a=_a, b=_b), outputs=_ABModel.Outputs(y=y))
+
+    model = _ABModel(a, b)
+    scenario = Scenario(model)
+    ev = Evaluation(scenario)
+    plan = ev.build_plan()
+
+    pe = PartitionedEnsemble(
+        scenario,
+        axes=[EnsembleAxisSpec("unc_a", indexes=[a], size=3)],
+        default_axis=EnsembleAxisSpec("unc_b", indexes=[], size=4),
+        rng=np.random.default_rng(0),
+    )
+    assignments = dict(pe.assignments())
+    multi_frozen = FrozenEnsemble(
+        pe.ensemble_axes,
+        pe.ensemble_weights,
+        {a: assignments[a], b: assignments[b]},
+    )
+    result = ev.execute_plan(plan, multi_frozen)
+
+    handle = EvaluationHandle(
+        evaluation=ev,
+        plan=plan,
+        result=result,
+        rng=np.random.default_rng(42),
+        parameters={},
+        ensemble=multi_frozen,
+        ensemble_recipe=pe,
+        functions=None,
+        backend=_executor.NumpyBackend,
+    )
+    return a, b, ev, handle
+
+
+def test_extend_extra_ensemble_grows_named_axis() -> None:
+    """extend(extra_ensemble=) grows the named axis and updates the result shape."""
+    a, b, ev, handle = _make_pe_handle()
+    model = ev._scenario.model
+    # Initial shape: (3, 4) for axes unc_a × unc_b
+    assert handle.result[model.outputs.y].shape == (3, 4)
+
+    handle.extend(extra_ensemble={"unc_a": 2})
+    # unc_a grows from 3 → 5; unc_b stays at 4.
+    assert handle.result[model.outputs.y].shape == (5, 4)
+
+
+def test_extend_extra_ensemble_updates_frozen_ensemble() -> None:
+    """extend(extra_ensemble=) updates the stored frozen ensemble for unc_a axis."""
+    a, b, ev, handle = _make_pe_handle()
+    assert handle._ensemble is not None
+    initial_size = handle._ensemble.ensemble_weights[0].size
+    assert initial_size == 3
+
+    handle.extend(extra_ensemble={"unc_a": 2})
+    # unc_a weights should now have size 5.
+    assert handle._ensemble is not None
+    new_size = handle._ensemble.ensemble_weights[0].size
+    assert new_size == 5

--- a/tests/dt_model/simulation/test_partitioned_ensemble.py
+++ b/tests/dt_model/simulation/test_partitioned_ensemble.py
@@ -367,3 +367,97 @@ def test_partitioned_ensemble_rejects_wrong_type():
     """PartitionedEnsemble raises TypeError when passed something other than Scenario/Model."""
     with pytest.raises(TypeError, match="Scenario, Model, or ModelVariant"):
         PartitionedEnsemble("not a model", axes=[])  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# draw_batch
+# ---------------------------------------------------------------------------
+
+
+def test_draw_batch_single_axis_auto_infers_axis():
+    """draw_batch on a single-axis PartitionedEnsemble auto-infers the axis name."""
+    from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble  # noqa: PLC0415
+
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+    ens = PartitionedEnsemble(
+        Scenario(model),
+        axes=[EnsembleAxisSpec("unc", indexes=[i_a, i_b], size=5)],
+        rng=np.random.default_rng(0),
+    )
+    batch = ens.draw_batch(3, np.random.default_rng(1))
+    assert isinstance(batch, FrozenEnsemble)
+    assert batch.ensemble_weights[0].shape == (3,)
+    assignments = batch.assignments()
+    assert i_a in assignments
+    assert i_b in assignments
+
+
+def test_draw_batch_multi_axis_requires_axis():
+    """draw_batch raises ValueError when axis=None and the ensemble has more than one axis."""
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("unc_a", indexes=[i_a], size=4),
+            EnsembleAxisSpec("unc_b", indexes=[i_b], size=6),
+        ],
+        rng=np.random.default_rng(0),
+    )
+    with pytest.raises(ValueError, match="specify axis="):
+        ens.draw_batch(3, np.random.default_rng(1))
+
+
+def test_draw_batch_explicit_axis_on_multi_axis():
+    """draw_batch with an explicit axis name extends only the named axis."""
+    from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble  # noqa: PLC0415
+
+    i_a = _dist_index("a")
+    i_b = _dist_index("b")
+    model = _make_model(i_a, i_b)
+    ens = PartitionedEnsemble(
+        model,
+        axes=[
+            EnsembleAxisSpec("unc_a", indexes=[i_a], size=4),
+            EnsembleAxisSpec("unc_b", indexes=[i_b], size=6),
+        ],
+        rng=np.random.default_rng(0),
+    )
+    batch = ens.draw_batch(3, np.random.default_rng(1), axis="unc_a")
+    assert isinstance(batch, FrozenEnsemble)
+    assert batch.ensemble_weights[0].shape == (3,)
+    assignments = batch.assignments()
+    assert i_a in assignments
+
+
+def test_draw_batch_unknown_axis_raises():
+    """draw_batch raises ValueError when the requested axis name does not exist."""
+    i_a = _dist_index("a")
+    model = _make_model(i_a)
+    ens = PartitionedEnsemble(
+        model,
+        axes=[EnsembleAxisSpec("unc", indexes=[i_a], size=4)],
+        rng=np.random.default_rng(0),
+    )
+    with pytest.raises(ValueError, match="no axis named"):
+        ens.draw_batch(3, np.random.default_rng(1), axis="nonexistent")
+
+
+def test_draw_batch_categorical_index_in_spec():
+    """draw_batch samples CategoricalIndex correctly when it appears in an axis spec."""
+    from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble  # noqa: PLC0415
+
+    i_cat = CategoricalIndex("mode", {"bike": 0.6, "train": 0.4})
+    model = _make_model(i_cat)
+    ens = PartitionedEnsemble(
+        model,
+        axes=[EnsembleAxisSpec("unc", indexes=[i_cat], size=5)],
+        rng=np.random.default_rng(0),
+    )
+    batch = ens.draw_batch(4, np.random.default_rng(1))
+    assert isinstance(batch, FrozenEnsemble)
+    assert batch.ensemble_weights[0].shape == (4,)
+    assert i_cat in batch.assignments()

--- a/tests/dt_model/simulation/test_runner.py
+++ b/tests/dt_model/simulation/test_runner.py
@@ -735,3 +735,198 @@ class TestResume:
         handle = evaluator.resume(scenario, output, EvaluationConfig(ensemble_size=5))
         extended = handle.extend(ensemble_size=5)
         assert extended is handle.result
+
+
+# ---------------------------------------------------------------------------
+# _encode_array / _decode_array — object dtype path
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeDecodeArrayObjectDtype:
+    """Unit tests for _encode_array / _decode_array with object-dtype arrays."""
+
+    def test_encode_array_object_dtype(self) -> None:
+        """_encode_array uses json encoding for object-dtype arrays."""
+        from civic_digital_twins.dt_model.simulation.runner import _encode_array  # noqa: PLC0415
+
+        arr = np.array(["good", "bad", "good"], dtype=object)
+        encoded = _encode_array(arr)
+        assert encoded["encoding"] == "json"
+        assert encoded["dtype"] == "object"
+
+    def test_decode_array_object_dtype(self) -> None:
+        """_decode_array reconstructs an object-dtype array from a json-encoded dict."""
+        from civic_digital_twins.dt_model.simulation.runner import _decode_array, _encode_array  # noqa: PLC0415
+
+        arr = np.array(["good", "bad"], dtype=object)
+        encoded = _encode_array(arr)
+        decoded = _decode_array(encoded)
+        assert decoded.dtype == object
+        np.testing.assert_array_equal(decoded, arr)
+
+
+# ---------------------------------------------------------------------------
+# ModelOutput.to_snapshot — version stamp
+# ---------------------------------------------------------------------------
+
+
+class TestModelOutputSnapshot:
+    """Unit tests for ModelOutput.to_snapshot()."""
+
+    def test_model_output_snapshot_contains_version(self) -> None:
+        """to_snapshot() stamps 'dt_model_version' and includes serialised fields."""
+        out = _StubOutput(42)
+        snap = out.to_snapshot()
+        assert "dt_model_version" in snap
+        assert snap["value"] == 42
+
+
+# ---------------------------------------------------------------------------
+# ModelOutput._serialize — dataclass branch
+# ---------------------------------------------------------------------------
+
+
+class TestModelOutputSerializeDataclass:
+    """Unit tests for the dataclass branch of ModelOutput._serialize and _deserialize."""
+
+    def _make_dataclass_output(self) -> Any:
+        """Return a concrete dataclass ModelOutput subclass with array and dict-of-array fields."""
+
+        @dataclasses.dataclass(eq=False)
+        class _DataclassOutput(ModelOutput):
+            arr: np.ndarray
+            dict_arr: dict
+
+            def __post_init__(self) -> None:
+                super().__init__()
+
+        return _DataclassOutput
+
+    def test_serialize_encodes_ndarray_field(self) -> None:
+        """_serialize encodes ndarray fields using _encode_array."""
+        cls = self._make_dataclass_output()
+        obj = cls.__new__(cls)
+        ModelOutput.__init__(obj)
+        obj.arr = np.array([1.0, 2.0])
+        obj.dict_arr = {"a": np.array([3.0])}
+        serialised = obj._serialize()
+        # ndarray field should be encoded as a dict with "data", "dtype", "shape".
+        assert isinstance(serialised["arr"], dict)
+        assert "dtype" in serialised["arr"]
+        # dict-of-array field should have each value encoded.
+        assert isinstance(serialised["dict_arr"]["a"], dict)
+        assert "dtype" in serialised["dict_arr"]["a"]
+
+    def test_deserialize_decodes_ndarray_field(self) -> None:
+        """_deserialize decodes encoded array fields back to ndarray."""
+        cls = self._make_dataclass_output()
+        obj = cls.__new__(cls)
+        ModelOutput.__init__(obj)
+        obj.arr = np.array([1.0, 2.0])
+        obj.dict_arr = {"a": np.array([3.0])}
+        serialised = obj._serialize()
+
+        # Reconstruct from serialised form.
+        obj2 = cls.__new__(cls)
+        ModelOutput.__init__(obj2)
+        obj2._deserialize(serialised)
+        np.testing.assert_array_equal(obj2.arr, obj.arr)
+        np.testing.assert_array_equal(obj2.dict_arr["a"], obj.dict_arr["a"])
+
+    def test_serialize_plain_value_field(self) -> None:
+        """_serialize stores plain non-array fields as-is (covers the else branch)."""
+
+        @dataclasses.dataclass(eq=False)
+        class _PlainOutput(ModelOutput):
+            name: str
+            count: int
+
+            def __post_init__(self) -> None:
+                super().__init__()
+
+        obj = _PlainOutput.__new__(_PlainOutput)
+        ModelOutput.__init__(obj)
+        obj.name = "test"
+        obj.count = 42
+        serialised = obj._serialize()
+        assert serialised["name"] == "test"
+        assert serialised["count"] == 42
+
+
+# ---------------------------------------------------------------------------
+# _decode_result round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeResultRoundtrip:
+    """Unit tests for _encode_result / _decode_result round-trip."""
+
+    def test_decode_result_roundtrip(self) -> None:
+        """_encode_result → _decode_result preserves the array shape for all indexes."""
+        from civic_digital_twins.dt_model.simulation.runner import _decode_result  # noqa: PLC0415
+
+        x, model = _make_simple_model()
+        result = _make_result_from(model, size=15)
+        encoded = _encode_result(result, model.indexes)
+        decoded = _decode_result(encoded, model.indexes)
+        # Output y should have shape (15,) after decoding.
+        assert decoded[model.outputs.y].shape == result[model.outputs.y].shape
+
+
+# ---------------------------------------------------------------------------
+# ModelEvaluator default evaluate() / run_async() / extract_resume_state() templates
+# ---------------------------------------------------------------------------
+
+
+class _DefaultTemplateEvaluator(ModelEvaluator[_SimpleModel, _StubOutput]):
+    """Evaluator that uses the default evaluate() template (does not override evaluate)."""
+
+    def post_process(self, scenario: Scenario, result: EvaluationResult) -> _StubOutput:
+        """Return a stub output wrapping the ensemble size."""
+        return _StubOutput(42, include_resume=False)
+
+    def input_schema(self) -> dict:
+        """Return a minimal schema."""
+        return {}
+
+
+class TestModelEvaluatorDefaultTemplate:
+    """Verify the default evaluate() / run_async() / attach_resume / extract_resume_state."""
+
+    def test_evaluate_calls_post_process_and_attach_resume(self) -> None:
+        """Default evaluate() calls post_process and attach_resume, returning a resumable output."""
+        _, model = _make_simple_model()
+        evaluator = _DefaultTemplateEvaluator(model)
+        output = evaluator.evaluate(Scenario(model), EvaluationConfig(ensemble_size=5))
+        assert isinstance(output, _StubOutput)
+        # attach_resume stores the result on output even though include_resume=False in post_process.
+        assert output.is_resumable
+
+    def test_run_async_calls_post_process_and_attach_resume(self) -> None:
+        """Default run_async() returns a handle whose get() calls post_process and attach_resume."""
+        _, model = _make_simple_model()
+        evaluator = _DefaultTemplateEvaluator(model)
+        handle = evaluator.run_async(Scenario(model), EvaluationConfig(ensemble_size=5))
+        output = handle.get()
+        assert isinstance(output, _StubOutput)
+        assert output.is_resumable
+
+    def test_attach_resume_stores_serialized_result(self) -> None:
+        """attach_resume encodes the result and marks the output as resumable."""
+        x, model = _make_simple_model()
+        evaluator = _DefaultTemplateEvaluator(model)
+        result = _make_result_from(model, size=10)
+        out = _StubOutput(7, include_resume=False)
+        assert not out.is_resumable
+        evaluator.attach_resume(out, result)
+        assert out.is_resumable
+
+    def test_extract_resume_state_returns_resume_state(self) -> None:
+        """extract_resume_state decodes the stored result and returns a ResumeState."""
+        _, model = _make_simple_model()
+        evaluator = _DefaultTemplateEvaluator(model)
+        output = evaluator.evaluate(Scenario(model), EvaluationConfig(ensemble_size=5))
+        assert output.is_resumable
+        state = evaluator.extract_resume_state(output)
+        assert isinstance(state, ResumeState)
+        assert isinstance(state.result, EvaluationResult)

--- a/tests/dt_model/simulation/test_runner.py
+++ b/tests/dt_model/simulation/test_runner.py
@@ -423,14 +423,14 @@ class TestAsyncEvaluationHandleFutureProperty:
     def test_future_property_returns_future(self) -> None:
         """AsyncEvaluationHandle.future returns a concurrent.futures.Future."""
         _, model = _make_simple_model()
-        handle = Evaluation(Scenario(model)).submit_evaluate(10)
+        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(Scenario(model)), 10)
         assert isinstance(handle, AsyncEvaluationHandle)
         assert isinstance(handle.future, concurrent.futures.Future)
 
     def test_future_property_is_same_object_used_by_get(self) -> None:
         """The future returned by .future resolves to the same EvaluationResult as .get()."""
         _, model = _make_simple_model()
-        handle = Evaluation(Scenario(model)).submit_evaluate(10)
+        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(Scenario(model)), 10)
         result_via_future = handle.future.result()
         result_via_get = handle.get()
         assert result_via_future is result_via_get
@@ -438,7 +438,7 @@ class TestAsyncEvaluationHandleFutureProperty:
     def test_future_property_is_done_after_get(self) -> None:
         """After .get() resolves, handle.future.done() is True."""
         _, model = _make_simple_model()
-        handle = Evaluation(Scenario(model)).submit_evaluate(10)
+        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(Scenario(model)), 10)
         handle.get()
         assert handle.future.done() is True
 

--- a/tests/dt_model/simulation/test_runner.py
+++ b/tests/dt_model/simulation/test_runner.py
@@ -423,14 +423,14 @@ class TestAsyncEvaluationHandleFutureProperty:
     def test_future_property_returns_future(self) -> None:
         """AsyncEvaluationHandle.future returns a concurrent.futures.Future."""
         _, model = _make_simple_model()
-        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(Scenario(model)), 10)
+        handle = AsyncEvaluationHandle.evaluate(Evaluation(Scenario(model)), 10)
         assert isinstance(handle, AsyncEvaluationHandle)
         assert isinstance(handle.future, concurrent.futures.Future)
 
     def test_future_property_is_same_object_used_by_get(self) -> None:
         """The future returned by .future resolves to the same EvaluationResult as .get()."""
         _, model = _make_simple_model()
-        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(Scenario(model)), 10)
+        handle = AsyncEvaluationHandle.evaluate(Evaluation(Scenario(model)), 10)
         result_via_future = handle.future.result()
         result_via_get = handle.get()
         assert result_via_future is result_via_get
@@ -438,7 +438,7 @@ class TestAsyncEvaluationHandleFutureProperty:
     def test_future_property_is_done_after_get(self) -> None:
         """After .get() resolves, handle.future.done() is True."""
         _, model = _make_simple_model()
-        handle = AsyncEvaluationHandle.from_evaluation(Evaluation(Scenario(model)), 10)
+        handle = AsyncEvaluationHandle.evaluate(Evaluation(Scenario(model)), 10)
         handle.get()
         assert handle.future.done() is True
 


### PR DESCRIPTION
## Summary

- `EvaluationHandle.extend(extra_parameters={idx: vals})` grows the PARAMETER
  grid by re-running the plan over new parameter values using the same frozen
  sample draws; handles without a stored snapshot (e.g. resumed handles)
  reconstruct one from the materialised result state, preserving the
  common-random-numbers guarantee (closing #174).
- `EvaluationHandle.extend(extra_ensemble={"axis": N})` extends a named
  ENSEMBLE axis; `_merge_results` now supports multi-axis results via
  `merge_axis_name=` (closing #175).
- `_merge_results` weight mixing fixed: merged weights are now a
  size-proportional mixture that preserves non-uniform schemes such as
  `CrossProductEnsemble` (closing #176).
- `BatchDrawable` protocol and `draw_batch` added to `DistributionEnsemble`,
  `CrossProductEnsemble`, and `PartitionedEnsemble`; `FrozenEnsemble` made
  multi-axis with `concat_along` / `with_replaced_axis`; `EvaluationHandle`
  becomes recipe-agnostic (closing #199).
- `Evaluation.evaluate_incremental` / `submit_evaluate` moved to
  `EvaluationHandle.evaluate` / `AsyncEvaluationHandle.evaluate` (classmethods);
  `evaluate` accepts an optional `ensemble_recipe: BatchDrawable` to bring a
  custom `CrossProductEnsemble` or `PartitionedEnsemble`.

## Closed issues

Closes #174.
Closes #175.
Closes #176.
Closes #199.