### PR TITLE
feat(scenario): parameter_axes and list[str] override for CategoricalIndex (#165, #187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Scenario` accepts `parameter_axes: list[GenericIndex]` (closing #165).  Indexes declared here
+  are excluded from `Scenario.abstract_indexes()` — `CrossProductEnsemble` skips them
+  automatically without any `exclude=` argument.  `Evaluation.evaluate()` raises `ValueError`
+  when a declared parameter axis is missing from `parameters=`, turning the previously silent
+  two-place duplication into a checked invariant.
 - `@define` decorator — declare a leaf `Model` subclass via a `compute()`
   method instead of a hand-written `__init__`.  `@define("Name")` generates
   `__init__(self, inputs: Inputs)` (plus `fns: Functions` when a `@functions`
@@ -234,6 +239,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release (closing #162).
 - `CrossProductEnsemble.restrictions=` — use `Scenario(model, overrides={idx: [...]})` instead.
   Emits `DeprecationWarning` at construction time.
+- `CrossProductEnsemble.exclude=` — declare parameter axes on the `Scenario` instead:
+  `Scenario(model, parameter_axes=[idx, ...])`.  Emits `DeprecationWarning` at construction time.
 - `Evaluation(model)` and all `Ensemble(model, ...)` constructors — pass a
   `Scenario(model)` instead.  These constructors now auto-wrap the model in a
   base `Scenario` and emit `DeprecationWarning`.  The canonical chain is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   iterates `model.indexes` to inject concrete values; absent entries caused a
   cryptic `PlaceholderValueNotProvided` deep inside the executor — now
   surfaced early with a clear error message (closing #195).
+- `Scenario` accepts `list[str]` overrides for `CategoricalIndex` (closes #187).  Passing a
+  list restricts sampling to that subset and renormalises the model's original probabilities
+  over the listed outcomes at construction time (validated: unknown outcomes or an empty list
+  raise `ValueError`).  The renormalised distribution is stored internally as `dict[str, float]`
+  so all existing downstream code works unchanged.  `DomainValue` now includes `list[str]`.
 
 ### Changed
 
@@ -227,6 +232,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LambdaAdapter` — use `NumpyBackend.adapt()` instead.  `LambdaAdapter` now
   emits a `DeprecationWarning` on construction and will be removed in a future
   release (closing #162).
+- `CrossProductEnsemble.restrictions=` — use `Scenario(model, overrides={idx: [...]})` instead.
+  Emits `DeprecationWarning` at construction time.
 - `Evaluation(model)` and all `Ensemble(model, ...)` constructors — pass a
   `Scenario(model)` instead.  These constructors now auto-wrap the model in a
   base `Scenario` and emit `DeprecationWarning`.  The canonical chain is

--- a/civic_digital_twins/dt_model/model/index.py
+++ b/civic_digital_twins/dt_model/model/index.py
@@ -50,7 +50,7 @@ class Distribution(Protocol):
         ...  # pragma: no cover
 
 
-DomainValue = float | np.ndarray | Distribution | str | dict[str, float]
+DomainValue = float | np.ndarray | Distribution | str | dict[str, float] | list[str]
 """A concrete value assignable to an Index at scenario-evaluation time.
 
 Covers all kinds of domain-level assignment:
@@ -61,6 +61,9 @@ Covers all kinds of domain-level assignment:
 - ``str`` — a categorical outcome pin (for :class:`CategoricalIndex` and
   :class:`ConditionalCategoricalIndex`).
 - ``dict[str, float]`` — a probability weight map (for :class:`CategoricalIndex`).
+- ``list[str]`` — a restriction list (for :class:`CategoricalIndex` only);
+  renormalises the original probabilities over the listed subset at
+  :class:`~simulation.scenario.Scenario` construction time.
 """
 
 

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -902,6 +902,10 @@ class CrossProductEnsemble:
     scenario_or_model:
         Model whose abstract indexes are enumerated / sampled.
     restrictions:
+        .. deprecated::
+            Use a ``list[str]`` override in :class:`~simulation.scenario.Scenario` instead:
+            ``Scenario(model, overrides={idx: ["a", "b"]})`` restricts to that subset and
+            renormalises the original probabilities automatically.
         Maps a categorical index to the subset of support values to use
         instead of its full support.  Omitted or absent entries use the full
         support.
@@ -957,6 +961,15 @@ class CrossProductEnsemble:
             )
         if n_samples_per_combo < 1:
             raise ValueError(f"n_samples_per_combo must be >= 1; got {n_samples_per_combo}.")
+        if restrictions is not None:
+            warnings.warn(
+                "CrossProductEnsemble.restrictions= is deprecated and will be removed in a future version. "
+                "Use a list[str] override in Scenario instead: "
+                "Scenario(model, overrides={idx: [...]}) restricts to that subset and renormalises "
+                "the original probabilities automatically.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if restrictions is None:
             restrictions = {}
         excluded_ids = {id(idx) for idx in (exclude or [])}

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -919,6 +919,13 @@ class CrossProductEnsemble:
         ``|categorical cross-product| × n_samples_per_combo``.  Must be >= 1.
         Has no effect when all distribution-backed indexes are in *exclude*.
     exclude:
+        .. deprecated::
+            Declare parameter axes on the
+            :class:`~simulation.scenario.Scenario` instead:
+            ``Scenario(model, parameter_axes=[idx, ...])`` — the ensemble
+            reads :attr:`~simulation.scenario.Scenario.parameter_axes`
+            automatically and skips those indexes without any explicit
+            *exclude* argument.
         Indexes to exclude from ensemble enumeration / sampling.  Use this to
         mark PARAMETER-axis indexes (e.g. presence variables supplied as grid
         axes to :meth:`~simulation.evaluation.Evaluation.evaluate`) that should
@@ -972,7 +979,17 @@ class CrossProductEnsemble:
             )
         if restrictions is None:
             restrictions = {}
+        if exclude is not None:
+            warnings.warn(
+                "CrossProductEnsemble.exclude= is deprecated and will be removed in a future version. "
+                "Declare parameter axes on the Scenario instead: "
+                "Scenario(model, overrides={...}, parameter_axes=[idx, ...]) and pass that Scenario to "
+                "CrossProductEnsemble — it will skip them automatically.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         excluded_ids = {id(idx) for idx in (exclude or [])}
+        excluded_ids |= {id(idx) for idx in scenario.parameter_axes}
 
         abstract = list(scenario.abstract_indexes())
 
@@ -981,7 +998,7 @@ class CrossProductEnsemble:
         dists_unordered: list[Index] = []
         for idx in abstract:
             if id(idx) in excluded_ids:
-                continue  # skip PARAMETER-axis indexes
+                continue  # skip PARAMETER-axis indexes (deprecated exclude= path)
             if isinstance(idx, CategoricalIndex | ConditionalCategoricalIndex):
                 cats_unordered.append(idx)
             elif isinstance(idx, ConditionalDistributionIndex):

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -1072,6 +1072,19 @@ class Evaluation:
 
         parameters = parameters or {}
 
+        # Enforce: scenario.parameter_axes must all be covered by parameters=.
+        if self._scenario.parameter_axes:
+            param_set_check = set(parameters.keys())
+            missing = [idx for idx in self._scenario.parameter_axes if idx not in param_set_check]
+            if missing:
+                names = ", ".join(repr(getattr(idx, "name", repr(idx))) for idx in missing)
+                raise ValueError(
+                    f"Scenario declares {names} as parameter_axes but "
+                    f"{'it was' if len(missing) == 1 else 'they were'} not supplied in "
+                    "parameters=. Pass their values via "
+                    "Evaluation.evaluate(parameters={idx: values, ...})."
+                )
+
         if nodes_of_interest is None:
             nodes_of_interest = list(self.model.indexes)
 

--- a/civic_digital_twins/dt_model/simulation/scenario.py
+++ b/civic_digital_twins/dt_model/simulation/scenario.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 import numpy as np
 
 from ..engine.frontend import graph
@@ -46,6 +48,15 @@ class Scenario:
         Overrides shadow the index's own ``value`` when :meth:`base_substitutions`
         is called.  See the override compatibility table for which value types are
         accepted for each index kind.
+    parameter_axes:
+        Optional list of abstract indexes that will be supplied externally as
+        PARAMETER axes via ``parameters=`` to
+        :meth:`~simulation.evaluation.Evaluation.evaluate`.  These indexes are
+        excluded from the ensemble's sampling — they do not appear in
+        :meth:`abstract_indexes` and :class:`~simulation.ensemble.CrossProductEnsemble`
+        skips them automatically.
+        :meth:`~simulation.evaluation.Evaluation.evaluate` raises ``ValueError``
+        if any declared parameter axis is absent from ``parameters=``.
 
     Override compatibility
     ----------------------
@@ -91,6 +102,10 @@ class Scenario:
         CondCategorical, no override    │ present           —              —                       None
         CondCategorical, str            │ absent            asarray(str)   —                       {str: 1.0}
 
+        Indexes declared in ``parameter_axes`` are always absent from
+        :meth:`abstract_indexes` regardless of override type; they are
+        excluded before this table is consulted.
+
     Examples
     --------
     >>> from civic_digital_twins.dt_model import Index, Model, Scenario
@@ -106,6 +121,7 @@ class Scenario:
         self,
         model: Model | ModelVariant,
         overrides: dict[GenericIndex, DomainValue] | None = None,
+        parameter_axes: Iterable[GenericIndex] | None = None,
     ) -> None:
         self._model = model
         self._overrides: dict[GenericIndex, DomainValue] = dict(overrides or {})
@@ -123,6 +139,19 @@ class Scenario:
                 "Overrides are matched by object identity — check that you are "
                 "passing index objects that were created as part of model "
                 f"{model.name!r}, not indexes from a different model or a copy."
+            )
+
+        # parameter_axes membership check — same identity-based approach as overrides.
+        self._parameter_axes: list[GenericIndex] = list(parameter_axes or [])
+        foreign_params = [idx for idx in self._parameter_axes if id(idx) not in model_index_ids]
+        if foreign_params:
+            names = ", ".join(repr(getattr(idx, "name", repr(idx))) for idx in foreign_params)
+            raise ValueError(
+                f"Scenario for model {model.name!r}: parameter_axes {names} "
+                f"{'is' if len(foreign_params) == 1 else 'are'} not part of this model. "
+                "parameter_axes are matched by object identity — check that you are "
+                "passing index objects that were created as part of model "
+                f"{model.name!r}."
             )
 
         for idx, val in self._overrides.items():
@@ -258,6 +287,26 @@ class Scenario:
         """
         return dict(self._overrides)
 
+    @property
+    def parameter_axes(self) -> list[GenericIndex]:
+        """Indexes declared as PARAMETER axes for this scenario.
+
+        These indexes are excluded from ensemble sampling by
+        :class:`~simulation.ensemble.CrossProductEnsemble` and must be
+        supplied externally via ``parameters=`` to
+        :meth:`~simulation.evaluation.Evaluation.evaluate`.
+
+        :meth:`~simulation.evaluation.Evaluation.evaluate` enforces that
+        every entry here is covered by the ``parameters=`` dict.
+
+        Returns
+        -------
+        list[GenericIndex]
+            A copy of the parameter-axes list, or an empty list when none
+            were declared.
+        """
+        return list(self._parameter_axes)
+
     def effective_distribution(self, idx: GenericIndex) -> Distribution | None:
         """Return the effective :class:`~model.index.Distribution` for *idx*.
 
@@ -338,12 +387,16 @@ class Scenario:
         list[GenericIndex]
             Indexes that need to be sampled by an ensemble.
         """
+        parameter_axis_ids = {id(idx) for idx in self._parameter_axes}
         result: list[GenericIndex] = []
 
         for idx in self._model.abstract_indexes():
             override = self._overrides.get(idx)
             if override is not None and not isinstance(override, (Distribution, dict)):
                 # Concretely overridden (scalar or str) — handled by base_substitutions; skip.
+                continue
+            if id(idx) in parameter_axis_ids:
+                # Declared as a PARAMETER axis — supplied externally, not for the ensemble.
                 continue
             result.append(idx)
 

--- a/civic_digital_twins/dt_model/simulation/scenario.py
+++ b/civic_digital_twins/dt_model/simulation/scenario.py
@@ -54,18 +54,20 @@ class Scenario:
 
     .. code-block:: text
 
-        Index type                   │ float  str  ndarray  Distribution  dict[str,float]
-        ─────────────────────────────┼───────────────────────────────────────────────────
-        Index                        │  ✓     ✗      ✗         ✗              ✗
-        TimeseriesIndex              │  ✗     ✗      ✓(1-D)    ✗              ✗
-        ConstIndex / ConstTimeseries │  ✗     ✗      ✗         ✗              ✗
-        DistributionIndex            │  ✗     ✗      ✗         ✓              ✗
-        ConditionalDistributionIndex │  ✗     ✗      ✗         ✗              ✗
-        CategoricalIndex             │  ✗     ✓*     ✗         ✗              ✓**
-        ConditionalCategoricalIndex  │  ✗     ✓*     ✗         ✗              ✗
+        Index type                   │ float  str  ndarray  Distribution  dict[str,float]  list[str]
+        ─────────────────────────────┼──────────────────────────────────────────────────────────────
+        Index                        │  ✓     ✗      ✗         ✗              ✗               ✗
+        TimeseriesIndex              │  ✗     ✗      ✓(1-D)    ✗              ✗               ✗
+        ConstIndex / ConstTimeseries │  ✗     ✗      ✗         ✗              ✗               ✗
+        DistributionIndex            │  ✗     ✗      ✗         ✓              ✗               ✗
+        ConditionalDistributionIndex │  ✗     ✗      ✗         ✗              ✗               ✗
+        CategoricalIndex             │  ✗     ✓*     ✗         ✗              ✓**             ✓***
+        ConditionalCategoricalIndex  │  ✗     ✓*     ✗         ✗              ✗               ✗
 
         * str must be in idx.support
         ** dict keys must be a non-empty subset of idx.support, positive probs summing to 1.0
+        *** list must be a non-empty subset of idx.support; original model probabilities are
+            renormalised over the listed outcomes and stored as dict[str, float]
 
         Method behaviour for accepted overrides:
 
@@ -85,6 +87,7 @@ class Scenario:
         CategoricalIndex, no override   │ present           —              —                       idx.outcomes
         CategoricalIndex, str           │ absent            asarray(str)   —                       {str: 1.0}
         CategoricalIndex, dict          │ present           —              —                       override dict
+        CategoricalIndex, list          │ present           —              —                       renormalized dict
         CondCategorical, no override    │ present           —              —                       None
         CondCategorical, str            │ absent            asarray(str)   —                       {str: 1.0}
 
@@ -165,6 +168,19 @@ class Scenario:
                         raise ValueError(
                             f"Override {val!r} is not in the support of CategoricalIndex {idx.name!r}: {idx.support!r}."
                         )
+                elif isinstance(val, list):
+                    # list[str]: restrict to subset and renormalise original model probabilities.
+                    if not val:
+                        raise ValueError(f"Override list for CategoricalIndex {idx.name!r} must not be empty.")
+                    unknown = [v for v in val if v not in idx.support]
+                    if unknown:
+                        raise ValueError(
+                            f"Override list for CategoricalIndex {idx.name!r} contains outcomes "
+                            f"outside its support {sorted(idx.support)!r}: {sorted(unknown)!r}."
+                        )
+                    # Renormalise original model probabilities over the restricted subset.
+                    total = sum(idx.outcomes[v] for v in val)
+                    self._overrides[idx] = {v: idx.outcomes[v] / total for v in val}
                 elif isinstance(val, dict):
                     keys, support = set(val.keys()), set(idx.support)
                     if not keys:
@@ -188,8 +204,9 @@ class Scenario:
                         )
                 else:
                     raise TypeError(
-                        f"Override for CategoricalIndex {idx.name!r} must be a str (concrete outcome) or "
-                        f"dict[str, float] (new probabilities); got {type(val).__name__!r}."
+                        f"Override for CategoricalIndex {idx.name!r} must be a str (concrete outcome), "
+                        f"list[str] (restriction subset — renormalises original probabilities), or "
+                        f"dict[str, float] (explicit new probabilities); got {type(val).__name__!r}."
                     )
                 continue
 

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -706,22 +706,26 @@ objects can be used as dictionary keys, matching the convention of
 
 ### Step 2 — Ensemble (CV cross-product)
 
-`CrossProductEnsemble` enumerates the joint support of the model's
+`CrossProductEnsemble` enumerates the joint support of a `Scenario`'s
 `CategoricalIndex` instances into weighted scenarios.  Each categorical
 combination also draws `n_samples_per_combo` independent Monte-Carlo samples
-of every distribution-backed abstract index that is *not* listed in `exclude`
-(PVs are excluded because they are swept on the grid in step 3 instead).
+of every distribution-backed abstract index that is not a *parameter* index
+(indexes declared as `parameter_axes` on the `Scenario` are swept on the grid
+in step 3 instead).
 The default `n_samples_per_combo=1` gives one sample per combination; increase
 it to reduce variance when stochastic capacities are retained in the ensemble:
 
 ```python
 from civic_digital_twins.dt_model import CrossProductEnsemble, Scenario
 
-scenario = Scenario(model, overrides={CV_weather: ["good", "unsettled", "bad"]})
+scenario = Scenario(
+    model,
+    overrides={CV_weather: ["good", "unsettled", "bad"]},
+    parameter_axes=[PV_tourists, PV_excursionists],
+)
 ensemble = CrossProductEnsemble(
     scenario,
     max_categorical_size=20,
-    exclude=model.pvs,
 )
 ```
 

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -715,11 +715,11 @@ The default `n_samples_per_combo=1` gives one sample per combination; increase
 it to reduce variance when stochastic capacities are retained in the ensemble:
 
 ```python
-from civic_digital_twins.dt_model import CrossProductEnsemble
+from civic_digital_twins.dt_model import CrossProductEnsemble, Scenario
 
+scenario = Scenario(model, overrides={CV_weather: ["good", "unsettled", "bad"]})
 ensemble = CrossProductEnsemble(
-    model,
-    restrictions={CV_weather: ["good", "unsettled", "bad"]},
+    scenario,
     max_categorical_size=20,
     exclude=model.pvs,
 )
@@ -740,7 +740,7 @@ from civic_digital_twins.dt_model import Evaluation
 tt = np.linspace(0, 50_000, 101)   # tourist presence axis
 ee = np.linspace(0, 50_000, 101)   # excursionist presence axis
 
-result = Evaluation(model).evaluate(
+result = Evaluation(scenario).evaluate(
     ensemble=ensemble,
     parameters={PV_tourists: tt, PV_excursionists: ee},
 )

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -271,6 +271,7 @@ def _demo_18_19_overtourism() -> None:
         GenericIndex,
         Index,
         Model,
+        Scenario,
     )
 
     CV_weather = CategoricalIndex(
@@ -320,9 +321,9 @@ def _demo_18_19_overtourism() -> None:
     )
 
     # Block 18 — CrossProductEnsemble
+    scenario = Scenario(model, overrides={CV_weather: ["good", "unsettled", "bad"]})
     ensemble = CrossProductEnsemble(
-        model,
-        restrictions={CV_weather: ["good", "unsettled", "bad"]},
+        scenario,
         max_categorical_size=20,
         exclude=model.pvs,
     )
@@ -331,7 +332,7 @@ def _demo_18_19_overtourism() -> None:
     tt = np.linspace(0, 50_000, 101)  # tourist presence axis
     ee = np.linspace(0, 50_000, 101)  # excursionist presence axis
 
-    result = Evaluation(model).evaluate(
+    result = Evaluation(scenario).evaluate(
         ensemble=ensemble,
         parameters={PV_tourists: tt, PV_excursionists: ee},
     )

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -321,11 +321,14 @@ def _demo_18_19_overtourism() -> None:
     )
 
     # Block 18 — CrossProductEnsemble
-    scenario = Scenario(model, overrides={CV_weather: ["good", "unsettled", "bad"]})
+    scenario = Scenario(
+        model,
+        overrides={CV_weather: ["good", "unsettled", "bad"]},
+        parameter_axes=[PV_tourists, PV_excursionists],
+    )
     ensemble = CrossProductEnsemble(
         scenario,
         max_categorical_size=20,
-        exclude=model.pvs,
     )
 
     # Block 19 — Grid Evaluation with CrossProductEnsemble

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -21,6 +21,7 @@ from civic_digital_twins.dt_model import (  # noqa: E402
     CrossProductEnsemble,
     Distribution,
     DistributionIndex,
+    DomainValue,
     Evaluation,
     GenericIndex,
     Index,
@@ -155,13 +156,17 @@ assert model.constraints[0] is C_beach
 # overtourism-getting-started.md §5 — Ensemble
 # ---------------------------------------------------------------------------
 
-scenario_overrides = {
+scenario_overrides: dict[GenericIndex, DomainValue] = {
     CV_season: ["low", "high"],
     CV_weather: ["good", "unsettled", "bad"],
 }
 
-scenario_obj = Scenario(model, overrides=scenario_overrides)  # type: ignore[arg-type]
-ensemble = CrossProductEnsemble(scenario_obj, max_categorical_size=10, exclude=model.pvs)
+scenario_obj = Scenario(
+    model,
+    overrides=scenario_overrides,
+    parameter_axes=model.pvs,
+)
+ensemble = CrossProductEnsemble(scenario_obj, max_categorical_size=10)
 # 2 × 3 = 6 scenarios (max_categorical_size=10 >= support sizes 2 and 3,
 # so all CV values are enumerated rather than sampled randomly)
 assert len(ensemble) == 6

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -155,12 +155,13 @@ assert model.constraints[0] is C_beach
 # overtourism-getting-started.md §5 — Ensemble
 # ---------------------------------------------------------------------------
 
-scenario: dict[CategoricalIndex, list[str]] = {
+scenario_overrides = {
     CV_season: ["low", "high"],
     CV_weather: ["good", "unsettled", "bad"],
 }
 
-ensemble = CrossProductEnsemble(Scenario(model), restrictions=scenario, max_categorical_size=10, exclude=model.pvs)
+scenario_obj = Scenario(model, overrides=scenario_overrides)  # type: ignore[arg-type]
+ensemble = CrossProductEnsemble(scenario_obj, max_categorical_size=10, exclude=model.pvs)
 # 2 × 3 = 6 scenarios (max_categorical_size=10 >= support sizes 2 and 3,
 # so all CV values are enumerated rather than sampled randomly)
 assert len(ensemble) == 6
@@ -174,7 +175,7 @@ assert abs(ensemble.ensemble_weights[0].sum() - 1.0) < 1e-10
 
 visitors_axis = np.linspace(0, 20_000, 201)
 
-result = Evaluation(Scenario(model)).evaluate(
+result = Evaluation(scenario_obj).evaluate(
     ensemble=ensemble,
     parameters={PV_visitors: visitors_axis},
 )

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -86,6 +86,7 @@ from civic_digital_twins.dt_model import (
     GenericIndex,
     Index,
     Model,
+    Scenario,
     define,
     graph,
     inputs,
@@ -938,7 +939,7 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
         self._e_sample = e_sample
         self._target_presence_samples = target_presence_samples
 
-    def _pre_compute(self, scenario: Any, config: EvaluationConfig) -> tuple[np.ndarray, np.ndarray, dict]:
+    def _pre_compute(self, config: EvaluationConfig) -> tuple[np.ndarray, np.ndarray, dict]:
         """Pre-compute parameter axes and presence samples (no result dependency).
 
         Used by both :meth:`evaluate` and :meth:`run_async` to share the
@@ -946,8 +947,6 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
 
         Parameters
         ----------
-        scenario : Scenario
-            The scenario being evaluated.
         config : EvaluationConfig
             Evaluation parameters; ``ensemble_size`` controls the cross-product
             size for the sampling ensemble.
@@ -959,18 +958,15 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
             axes and ``pv_samples`` maps each presence index to its samples.
         """
         model = self._model
+        pvs = [model.inputs.pv_tourists, model.inputs.pv_excursionists]
         tt = np.linspace(0, self._t_max, self._t_sample + 1)
         ee = np.linspace(0, self._e_max, self._e_sample + 1)
+        sampling_scenario = Scenario(model, parameter_axes=pvs)
         sampling_ensemble = CrossProductEnsemble(
-            type(scenario)(model),
+            sampling_scenario,
             max_categorical_size=config.ensemble_size,
-            exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
         )
-        pv_samples = sample_across(
-            sampling_ensemble,
-            [model.inputs.pv_tourists, model.inputs.pv_excursionists],
-            total=self._target_presence_samples,
-        )
+        pv_samples = sample_across(sampling_ensemble, pvs, total=self._target_presence_samples)
         return tt, ee, pv_samples
 
     def _build_output(
@@ -1051,12 +1047,8 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
             parameter axes, and a resume payload.
         """
         model = self._model
-        tt, ee, pv_samples = self._pre_compute(scenario, config)
-        ensemble = CrossProductEnsemble(
-            scenario,
-            max_categorical_size=config.ensemble_size,
-            exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
-        )
+        tt, ee, pv_samples = self._pre_compute(config)
+        ensemble = CrossProductEnsemble(scenario, max_categorical_size=config.ensemble_size)
         result = Evaluation(scenario).evaluate(
             ensemble=ensemble,
             parameters={model.inputs.pv_tourists: tt, model.inputs.pv_excursionists: ee},
@@ -1092,17 +1084,12 @@ class MolvenoEvaluator(ModelEvaluator[MolvenoModel, MolvenoOutput]):
             Handle whose :meth:`~dt_model.simulation.runner.ModelRunHandle.get`
             returns a :class:`MolvenoOutput`.
         """
-        model = self._model
-        tt, ee, pv_samples = self._pre_compute(scenario, config)
-        ensemble = CrossProductEnsemble(
-            scenario,
-            max_categorical_size=config.ensemble_size,
-            exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
-        )
+        tt, ee, pv_samples = self._pre_compute(config)
+        ensemble = CrossProductEnsemble(scenario, max_categorical_size=config.ensemble_size)
         future = _get_default_executor().submit(
             Evaluation(scenario).evaluate,
             ensemble=ensemble,
-            parameters={model.inputs.pv_tourists: tt, model.inputs.pv_excursionists: ee},
+            parameters={self._model.inputs.pv_tourists: tt, self._model.inputs.pv_excursionists: ee},
         )
 
         def _post(result: EvaluationResult) -> MolvenoOutput:

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -184,15 +184,19 @@ uses `.constraints`.  For a production model with multiple sub-models see
 ## 5 — Ensemble
 
 ```python
-from civic_digital_twins.dt_model import CrossProductEnsemble, Scenario
+from civic_digital_twins.dt_model import CrossProductEnsemble, DomainValue, GenericIndex, Scenario
 
-scenario_overrides = {
+scenario_overrides: dict[GenericIndex, DomainValue] = {
     CV_season:  ["low", "high"],
     CV_weather: ["good", "unsettled", "bad"],
 }
 
-scenario_obj = Scenario(model, overrides=scenario_overrides)
-ensemble = CrossProductEnsemble(scenario_obj, max_categorical_size=10, exclude=model.pvs)
+scenario_obj = Scenario(
+    model,
+    overrides=scenario_overrides,
+    parameter_axes=model.pvs,
+)
+ensemble = CrossProductEnsemble(scenario_obj, max_categorical_size=10)
 # 2 × 3 = 6 scenarios (all CV combinations enumerated)
 ```
 
@@ -200,14 +204,15 @@ ensemble = CrossProductEnsemble(scenario_obj, max_categorical_size=10, exclude=m
 abstract indexes, enumerates all combinations of categorical CV values, and
 materialises the results into a single batched ENSEMBLE axis — here
 2 × 3 = 6 scenarios, one per (season, weather) pair.  Each scenario also
-includes one sample of every distribution-backed non-excluded abstract index
+includes one sample of every distribution-backed non-parameter abstract index
 (here: `I_C_beach`).
 
-Passing a `list[str]` override in `Scenario` restricts each categorical to the
-listed subset and renormalises the original model probabilities over those
-outcomes automatically.  The `exclude` parameter marks PARAMETER-axis indexes
-(presence variables) so they are not included in the ensemble cross-product.
-`max_categorical_size` controls random sampling when a categorical’s support
+`Scenario(model, overrides={…: [...]})` restricts each categorical to a
+subset of its support and renormalises the probabilities.  Presence-variable
+indexes declared as ``parameter_axes`` on the :class:`~dt_model.Scenario`
+are automatically excluded from the ensemble cross-product and swept over
+the grid in step 6 instead.
+`max_categorical_size` controls random sampling when a categorical's support
 exceeds the size threshold; for the small finite CVs above every value is
 enumerated and `max_categorical_size` is unused.
 

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -186,12 +186,13 @@ uses `.constraints`.  For a production model with multiple sub-models see
 ```python
 from civic_digital_twins.dt_model import CrossProductEnsemble, Scenario
 
-scenario: dict[CategoricalIndex, list[str]] = {
+scenario_overrides = {
     CV_season:  ["low", "high"],
     CV_weather: ["good", "unsettled", "bad"],
 }
 
-ensemble = CrossProductEnsemble(Scenario(model), restrictions=scenario, max_categorical_size=10, exclude=model.pvs)
+scenario_obj = Scenario(model, overrides=scenario_overrides)
+ensemble = CrossProductEnsemble(scenario_obj, max_categorical_size=10, exclude=model.pvs)
 # 2 × 3 = 6 scenarios (all CV combinations enumerated)
 ```
 
@@ -202,10 +203,11 @@ materialises the results into a single batched ENSEMBLE axis — here
 includes one sample of every distribution-backed non-excluded abstract index
 (here: `I_C_beach`).
 
-The `restrictions` parameter projects each categorical to a subset of its
-support.  The `exclude` parameter marks PARAMETER-axis indexes (presence
-variables) so they are not included in the ensemble cross-product.
-`max_categorical_size` controls random sampling when a categorical's support
+Passing a `list[str]` override in `Scenario` restricts each categorical to the
+listed subset and renormalises the original model probabilities over those
+outcomes automatically.  The `exclude` parameter marks PARAMETER-axis indexes
+(presence variables) so they are not included in the ensemble cross-product.
+`max_categorical_size` controls random sampling when a categorical’s support
 exceeds the size threshold; for the small finite CVs above every value is
 enumerated and `max_categorical_size` is unused.
 
@@ -220,7 +222,7 @@ from civic_digital_twins.dt_model import Evaluation, Scenario
 
 visitors_axis = np.linspace(0, 20_000, 201)
 
-result = Evaluation(Scenario(model)).evaluate(
+result = Evaluation(scenario_obj).evaluate(
     ensemble=ensemble,
     parameters={PV_visitors: visitors_axis},
 )

--- a/tests/dt_model/examples/test_molveno_runner.py
+++ b/tests/dt_model/examples/test_molveno_runner.py
@@ -43,8 +43,8 @@ def evaluator(model: MolvenoModel) -> MolvenoEvaluator:
 
 @pytest.fixture(scope="module")
 def scenario(model: MolvenoModel) -> Scenario:
-    """Return a base scenario with no overrides."""
-    return Scenario(model)
+    """Return a base scenario with no overrides but the PVs declared as parameter_axes."""
+    return Scenario(model, parameter_axes=[model.inputs.pv_tourists, model.inputs.pv_excursionists])
 
 
 @pytest.fixture(scope="module")
@@ -349,7 +349,8 @@ def test_evaluate_with_str_override(
     config: EvaluationConfig,
 ) -> None:
     """evaluate() must work with a str override on a CategoricalIndex."""
-    scenario = Scenario(model, overrides={model.inputs.cv_weather: "good"})
+    pvs = [model.inputs.pv_tourists, model.inputs.pv_excursionists]
+    scenario = Scenario(model, overrides={model.inputs.cv_weather: "good"}, parameter_axes=pvs)
     out = evaluator.evaluate(scenario, config)
     assert isinstance(out, MolvenoOutput)
     assert out.field.shape == (_T_SAMPLE + 1, _E_SAMPLE + 1)
@@ -361,7 +362,12 @@ def test_evaluate_with_dict_override(
     config: EvaluationConfig,
 ) -> None:
     """evaluate() must work with a dict override on a CategoricalIndex."""
-    scenario = Scenario(model, overrides={model.inputs.cv_weather: {"good": 0.7, "unsettled": 0.3}})
+    pvs = [model.inputs.pv_tourists, model.inputs.pv_excursionists]
+    scenario = Scenario(
+        model,
+        overrides={model.inputs.cv_weather: {"good": 0.7, "unsettled": 0.3}},
+        parameter_axes=pvs,
+    )
     out = evaluator.evaluate(scenario, config)
     assert isinstance(out, MolvenoOutput)
     assert out.field.shape == (_T_SAMPLE + 1, _E_SAMPLE + 1)

--- a/tests/dt_model/examples/test_overtourism_molveno.py
+++ b/tests/dt_model/examples/test_overtourism_molveno.py
@@ -21,10 +21,12 @@ from civic_digital_twins.dt_model import (
     CrossProductEnsemble,
     Evaluation,
     ModelContractWarning,
+    Scenario,
 )
 from civic_digital_twins.dt_model.model.index import Distribution, DistributionIndex, GenericIndex, Index
 
 model = MolvenoModel(inputs=MolvenoModel.default_inputs())
+_pvs = [model.inputs.pv_tourists, model.inputs.pv_excursionists]
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -39,7 +41,7 @@ def compute_field(model, ensemble, tt, ee):
     - ``field_elements`` maps each Constraint to a ``(tt.size, ee.size)`` array
     - ``result`` is the :class:`~dt_model.simulation.evaluation.EvaluationResult`
     """
-    result = Evaluation(model).evaluate(
+    result = Evaluation(Scenario(model, parameter_axes=_pvs)).evaluate(
         ensemble=ensemble, parameters={model.inputs.pv_tourists: tt, model.inputs.pv_excursionists: ee}
     )
 
@@ -122,13 +124,15 @@ def excursionists():
 def good_weather_scenarios():
     """Single-member ensemble: good weather, monday, high season."""
     return CrossProductEnsemble(
-        model,
-        restrictions={
-            model.inputs.cv_weekday: ["monday"],
-            model.inputs.cv_season: ["high"],
-            model.inputs.cv_weather: ["good"],
-        },
-        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
+        Scenario(
+            model,
+            overrides={
+                model.inputs.cv_weekday: ["monday"],
+                model.inputs.cv_season: ["high"],
+                model.inputs.cv_weather: ["good"],
+            },
+            parameter_axes=_pvs,
+        ),
     )
 
 
@@ -174,12 +178,9 @@ def test_evaluate_axes_high_presence_is_unsustainable(good_weather_scenarios):
 
 def test_ensemble_based_evaluation(tourists, excursionists):
     """CrossProductEnsemble-based evaluation produces a valid sustainability field."""
-    scenario: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "bad"]}
     ensemble = CrossProductEnsemble(
-        model,
-        restrictions=scenario,
+        Scenario(model, overrides={model.inputs.cv_weather: ["good", "bad"]}, parameter_axes=_pvs),
         max_categorical_size=5,
-        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
     )
 
     field, field_elements, _ = compute_field(model, ensemble, tourists, excursionists)
@@ -204,13 +205,15 @@ def test_fixed_ensemble():
 
     # Build single-member scenarios with distribution-backed index samples.
     ensemble = CrossProductEnsemble(
-        model,
-        restrictions={
-            model.inputs.cv_weekday: ["monday"],
-            model.inputs.cv_season: ["high"],
-            model.inputs.cv_weather: ["good"],
-        },
-        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
+        Scenario(
+            model,
+            overrides={
+                model.inputs.cv_weekday: ["monday"],
+                model.inputs.cv_season: ["high"],
+                model.inputs.cv_weather: ["good"],
+            },
+            parameter_axes=_pvs,
+        ),
         rng=np.random.default_rng(4),
     )
     _, got, _ = compute_field(model, ensemble, tourists, excursionists)
@@ -269,12 +272,9 @@ def test_fixed_ensemble():
 
 def test_multiple_ensemble_members():
     """Test with multiple ensemble members to catch shape issues."""
-    scenario: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "bad"]}
     ens = CrossProductEnsemble(
-        model,
-        restrictions=scenario,
+        Scenario(model, overrides={model.inputs.cv_weather: ["good", "bad"]}, parameter_axes=_pvs),
         max_categorical_size=10,
-        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
     )
     tourists = np.array([1000, 5000, 10000])
     excursionists = np.array([1000, 5000, 10000])
@@ -581,12 +581,9 @@ def test_presence_transformation_indexes_in_root_indexes():
 
 def test_bug_37():
     """Regression for https://github.com/fbk-most/dt-model/issues/37."""
-    situation: dict[CategoricalIndex, list[str]] = {model.inputs.cv_weather: ["good", "unsettled", "bad"]}
     ensemble = CrossProductEnsemble(
-        model,
-        restrictions=situation,
+        Scenario(model, overrides={model.inputs.cv_weather: ["good", "unsettled", "bad"]}, parameter_axes=_pvs),
         max_categorical_size=20,
-        exclude=[model.inputs.pv_tourists, model.inputs.pv_excursionists],
     )
 
     tourists = np.array([1000, 5000, 10000])

--- a/tests/dt_model/simulation/test_cross_product_ensemble.py
+++ b/tests/dt_model/simulation/test_cross_product_ensemble.py
@@ -675,6 +675,22 @@ def test_cat_samples_no_rng_monte_carlo():
 
 
 # ---------------------------------------------------------------------------
+# Scenario.parameter_axes auto-exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_cpe_parameter_axes_auto_excluded():
+    """CrossProductEnsemble auto-excludes indexes listed in Scenario.parameter_axes."""
+    season = CategoricalIndex("season", {"summer": 0.5, "winter": 0.5})
+    pv = Index("presence", None)
+    model = _simple_model(season, pv)
+    ens = CrossProductEnsemble(Scenario(model, parameter_axes=[pv]))
+    a = ens.assignments()
+    assert season in a
+    assert pv not in a
+
+
+# ---------------------------------------------------------------------------
 # Deprecation warnings
 # ---------------------------------------------------------------------------
 
@@ -685,3 +701,12 @@ def test_cpe_restrictions_deprecated():
     model = _simple_model(season)
     with pytest.warns(DeprecationWarning, match="restrictions="):
         CrossProductEnsemble(model, restrictions={season: ["summer"]})
+
+
+def test_cpe_exclude_deprecated():
+    """CrossProductEnsemble.exclude= emits DeprecationWarning."""
+    season = CategoricalIndex("season", {"summer": 0.5, "winter": 0.5})
+    pv = Index("presence", None)
+    model = _simple_model(season, pv)
+    with pytest.warns(DeprecationWarning, match="exclude="):
+        CrossProductEnsemble(Scenario(model), exclude=[pv])

--- a/tests/dt_model/simulation/test_cross_product_ensemble.py
+++ b/tests/dt_model/simulation/test_cross_product_ensemble.py
@@ -672,3 +672,16 @@ def test_cat_samples_no_rng_monte_carlo():
     # rng=None means _cat_samples uses np.random.choice
     ens = CrossProductEnsemble(model, max_categorical_size=2, rng=None)
     assert ens.assignments()[season].shape == (2,)
+
+
+# ---------------------------------------------------------------------------
+# Deprecation warnings
+# ---------------------------------------------------------------------------
+
+
+def test_cpe_restrictions_deprecated():
+    """CrossProductEnsemble.restrictions= emits DeprecationWarning."""
+    season = CategoricalIndex("season", {"summer": 0.5, "winter": 0.5})
+    model = _simple_model(season)
+    with pytest.warns(DeprecationWarning, match="restrictions="):
+        CrossProductEnsemble(model, restrictions={season: ["summer"]})

--- a/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
+++ b/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
@@ -559,3 +559,76 @@ def test_scenario_override_index_in_model_does_not_raise():
     # Both a and b are in the model — no error expected.
     scenario = Scenario(model, overrides={a: 10.0, b: 20.0})
     assert scenario.overrides == {a: 10.0, b: 20.0}
+
+
+# ---------------------------------------------------------------------------
+# CategoricalIndex: list[str] override
+# ---------------------------------------------------------------------------
+
+
+def test_categorical_list_override_restricts_and_renormalises():
+    """list[str] override restricts to subset and renormalises original probabilities."""
+    # Model: good=0.3, unsettled=0.5, bad=0.2
+    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
+    model = _make_model(cat)
+    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
+    # Renormalised: total=0.8, good=0.375, unsettled=0.625
+    outcomes = scenario.effective_outcomes(cat)
+    assert outcomes == pytest.approx({"good": 0.375, "unsettled": 0.625})
+
+
+def test_categorical_list_override_stored_as_dict():
+    """list[str] override is stored internally as a dict[str, float]."""
+    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
+    model = _make_model(cat)
+    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
+    stored = scenario.overrides[cat]
+    assert isinstance(stored, dict)
+    assert set(stored.keys()) == {"good", "unsettled"}
+
+
+def test_categorical_list_override_single_value():
+    """list[str] with one element gives weight 1.0 for that element."""
+    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
+    model = _make_model(cat)
+    scenario = Scenario(model, overrides={cat: ["bad"]})  # type: ignore[dict-item]
+    outcomes = scenario.effective_outcomes(cat)
+    assert outcomes == pytest.approx({"bad": 1.0})
+
+
+def test_categorical_list_override_empty_raises():
+    """Empty list[str] override raises ValueError."""
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    model = _make_model(cat)
+    with pytest.raises(ValueError, match="must not be empty"):
+        Scenario(model, overrides={cat: []})  # type: ignore[dict-item]
+
+
+def test_categorical_list_override_unknown_outcome_raises():
+    """list[str] with unknown outcome raises ValueError."""
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    model = _make_model(cat)
+    with pytest.raises(ValueError, match="outside its support"):
+        Scenario(model, overrides={cat: ["good", "unknown"]})  # type: ignore[dict-item]
+
+
+def test_categorical_list_override_in_cross_product_ensemble():
+    """CrossProductEnsemble respects list[str] override from Scenario."""
+    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
+    model = _make_model(cat)
+    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
+    ens = CrossProductEnsemble(scenario)
+    assert ens.size == 2
+    assigned = set(ens.assignments()[cat].tolist())
+    assert assigned == {"good", "unsettled"}
+    weights = ens.ensemble_weights[0]
+    weight_by_value = {str(v): float(w) for v, w in zip(ens.assignments()[cat], weights)}
+    assert weight_by_value == pytest.approx({"good": 0.375, "unsettled": 0.625})
+
+
+def test_cross_product_ensemble_restrictions_deprecated():
+    """CrossProductEnsemble.restrictions= emits DeprecationWarning."""
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    model = _make_model(cat)
+    with pytest.warns(DeprecationWarning, match="restrictions="):
+        CrossProductEnsemble(model, restrictions={cat: ["good"]})

--- a/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
+++ b/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
@@ -235,6 +235,71 @@ def test_categorical_rejects_wrong_type():
         Scenario(model, overrides={mode: 42.0})  # type: ignore[dict-item]
 
 
+# ---------------------------------------------------------------------------
+# CategoricalIndex: list[str] override
+# ---------------------------------------------------------------------------
+
+
+def test_categorical_list_override_restricts_and_renormalises():
+    """list[str] override restricts to subset and renormalises original probabilities."""
+    # Model: good=0.3, unsettled=0.5, bad=0.2
+    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
+    model = _make_model(cat)
+    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
+    # Renormalised: total=0.8, good=0.375, unsettled=0.625
+    outcomes = scenario.effective_outcomes(cat)
+    assert outcomes == pytest.approx({"good": 0.375, "unsettled": 0.625})
+
+
+def test_categorical_list_override_stored_as_dict():
+    """list[str] override is stored internally as a dict[str, float]."""
+    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
+    model = _make_model(cat)
+    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
+    stored = scenario.overrides[cat]
+    assert isinstance(stored, dict)
+    assert set(stored.keys()) == {"good", "unsettled"}
+
+
+def test_categorical_list_override_single_value():
+    """list[str] with one element gives weight 1.0 for that element."""
+    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
+    model = _make_model(cat)
+    scenario = Scenario(model, overrides={cat: ["bad"]})  # type: ignore[dict-item]
+    outcomes = scenario.effective_outcomes(cat)
+    assert outcomes == pytest.approx({"bad": 1.0})
+
+
+def test_categorical_list_override_empty_raises():
+    """Empty list[str] override raises ValueError."""
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    model = _make_model(cat)
+    with pytest.raises(ValueError, match="must not be empty"):
+        Scenario(model, overrides={cat: []})  # type: ignore[dict-item]
+
+
+def test_categorical_list_override_unknown_outcome_raises():
+    """list[str] with unknown outcome raises ValueError."""
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    model = _make_model(cat)
+    with pytest.raises(ValueError, match="outside its support"):
+        Scenario(model, overrides={cat: ["good", "unknown"]})  # type: ignore[dict-item]
+
+
+def test_categorical_list_override_in_cross_product_ensemble():
+    """CrossProductEnsemble respects list[str] override from Scenario."""
+    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
+    model = _make_model(cat)
+    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
+    ens = CrossProductEnsemble(scenario)
+    assert ens.size == 2
+    assigned = set(ens.assignments()[cat].tolist())
+    assert assigned == {"good", "unsettled"}
+    weights = ens.ensemble_weights[0]
+    weight_by_value = {str(v): float(w) for v, w in zip(ens.assignments()[cat], weights)}
+    assert weight_by_value == pytest.approx({"good": 0.375, "unsettled": 0.625})
+
+
 def test_conditional_categorical_concrete_pin():
     """ConditionalCategoricalIndex overridden with a valid str becomes concrete."""
     season = CategoricalIndex("season", {"summer": 0.5, "winter": 0.5})
@@ -562,68 +627,8 @@ def test_scenario_override_index_in_model_does_not_raise():
 
 
 # ---------------------------------------------------------------------------
-# CategoricalIndex: list[str] override
+# CrossProductEnsemble deprecation warnings
 # ---------------------------------------------------------------------------
-
-
-def test_categorical_list_override_restricts_and_renormalises():
-    """list[str] override restricts to subset and renormalises original probabilities."""
-    # Model: good=0.3, unsettled=0.5, bad=0.2
-    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
-    model = _make_model(cat)
-    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
-    # Renormalised: total=0.8, good=0.375, unsettled=0.625
-    outcomes = scenario.effective_outcomes(cat)
-    assert outcomes == pytest.approx({"good": 0.375, "unsettled": 0.625})
-
-
-def test_categorical_list_override_stored_as_dict():
-    """list[str] override is stored internally as a dict[str, float]."""
-    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
-    model = _make_model(cat)
-    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
-    stored = scenario.overrides[cat]
-    assert isinstance(stored, dict)
-    assert set(stored.keys()) == {"good", "unsettled"}
-
-
-def test_categorical_list_override_single_value():
-    """list[str] with one element gives weight 1.0 for that element."""
-    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
-    model = _make_model(cat)
-    scenario = Scenario(model, overrides={cat: ["bad"]})  # type: ignore[dict-item]
-    outcomes = scenario.effective_outcomes(cat)
-    assert outcomes == pytest.approx({"bad": 1.0})
-
-
-def test_categorical_list_override_empty_raises():
-    """Empty list[str] override raises ValueError."""
-    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
-    model = _make_model(cat)
-    with pytest.raises(ValueError, match="must not be empty"):
-        Scenario(model, overrides={cat: []})  # type: ignore[dict-item]
-
-
-def test_categorical_list_override_unknown_outcome_raises():
-    """list[str] with unknown outcome raises ValueError."""
-    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
-    model = _make_model(cat)
-    with pytest.raises(ValueError, match="outside its support"):
-        Scenario(model, overrides={cat: ["good", "unknown"]})  # type: ignore[dict-item]
-
-
-def test_categorical_list_override_in_cross_product_ensemble():
-    """CrossProductEnsemble respects list[str] override from Scenario."""
-    cat = CategoricalIndex("weather", {"good": 0.3, "unsettled": 0.5, "bad": 0.2})
-    model = _make_model(cat)
-    scenario = Scenario(model, overrides={cat: ["good", "unsettled"]})  # type: ignore[dict-item]
-    ens = CrossProductEnsemble(scenario)
-    assert ens.size == 2
-    assigned = set(ens.assignments()[cat].tolist())
-    assert assigned == {"good", "unsettled"}
-    weights = ens.ensemble_weights[0]
-    weight_by_value = {str(v): float(w) for v, w in zip(ens.assignments()[cat], weights)}
-    assert weight_by_value == pytest.approx({"good": 0.375, "unsettled": 0.625})
 
 
 def test_cross_product_ensemble_restrictions_deprecated():
@@ -632,3 +637,85 @@ def test_cross_product_ensemble_restrictions_deprecated():
     model = _make_model(cat)
     with pytest.warns(DeprecationWarning, match="restrictions="):
         CrossProductEnsemble(model, restrictions={cat: ["good"]})
+
+
+def test_cross_product_ensemble_exclude_deprecated():
+    """CrossProductEnsemble.exclude= emits DeprecationWarning."""
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    pv = ConditionalDistributionIndex(
+        "presence",
+        parents=[cat],
+        factory=lambda weather: stats.norm(loc=100.0, scale=10.0),
+    )
+    model = _make_model(cat, pv)
+    with pytest.warns(DeprecationWarning, match="exclude="):
+        CrossProductEnsemble(Scenario(model), exclude=[pv])
+
+
+# ---------------------------------------------------------------------------
+# CrossProductEnsemble: Scenario.parameter_axes auto-exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_cross_product_ensemble_skips_parameter_axes_index():
+    """CrossProductEnsemble automatically skips indexes listed in Scenario.parameter_axes."""
+    import warnings  # noqa: PLC0415
+
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    pv = ConditionalDistributionIndex(
+        "presence",
+        parents=[cat],
+        factory=lambda weather: stats.norm(loc=100.0, scale=10.0),
+    )
+    model = _make_model(cat, pv)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        ens = CrossProductEnsemble(Scenario(model, parameter_axes=[pv]))
+    assert pv not in ens.assignments()
+    assert cat in ens.assignments()
+
+
+def test_cross_product_ensemble_parameter_axes_no_warning():
+    """CrossProductEnsemble does not emit DeprecationWarning for Scenario.parameter_axes indexes."""
+    import warnings  # noqa: PLC0415
+
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    pv = ConditionalDistributionIndex(
+        "presence",
+        parents=[cat],
+        factory=lambda weather: stats.norm(loc=100.0, scale=10.0),
+    )
+    model = _make_model(cat, pv)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        CrossProductEnsemble(Scenario(model, parameter_axes=[pv]))
+    deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(deprecation_warnings) == 0, f"Unexpected DeprecationWarning: {deprecation_warnings}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario.parameter_axes validation
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_parameter_axes_foreign_index_raises():
+    """Scenario rejects a parameter_axes entry from a different model."""
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    pv = ConditionalDistributionIndex("presence", parents=[cat], factory=lambda weather: stats.norm())
+    _make_model(cat, pv)  # pv belongs to this model only
+    model_b = _make_model(cat)  # pv not in this model
+    with pytest.raises(ValueError, match="not part of this model"):
+        Scenario(model_b, parameter_axes=[pv])
+
+
+def test_evaluation_raises_when_parameter_axes_not_in_parameters():
+    """Evaluation.evaluate() raises ValueError when scenario.parameter_axes are absent from parameters=."""
+    cat = CategoricalIndex("weather", {"good": 0.5, "bad": 0.5})
+    pv = ConditionalDistributionIndex(
+        "presence", parents=[cat], factory=lambda weather: stats.norm(loc=100.0, scale=10.0)
+    )
+    model = _make_model(cat, pv)
+    scenario = Scenario(model, parameter_axes=[pv])
+    ens = CrossProductEnsemble(scenario)  # pv excluded from ensemble
+    with pytest.raises(ValueError, match="parameter_axes"):
+        Evaluation(scenario).evaluate(ensemble=ens)  # pv not in parameters=


### PR DESCRIPTION
## Summary

- `Scenario` gains `parameter_axes: Iterable[GenericIndex]` (closes #165).
  Indexes declared here are excluded from `Scenario.abstract_indexes()` so
  `CrossProductEnsemble` skips them automatically without any `exclude=`
  argument.  `Evaluation.evaluate()` raises `ValueError` when a declared
  parameter axis is absent from `parameters=`, turning the previously silent
  two-place duplication into a checked invariant.
- `CategoricalIndex` overrides now accept `list[str]` (closes #187).  The list
  restricts sampling to that subset and renormalises the model's original
  probabilities over the listed outcomes at construction time (unknown outcomes
  or an empty list raise `ValueError`).  The renormalised distribution is stored
  internally as `dict[str, float]` so all downstream code works unchanged.
  `DomainValue` is widened to include `list[str]`.
- `CrossProductEnsemble.restrictions=` deprecated — use
  `Scenario(model, overrides={idx: [...]})` instead.
- `CrossProductEnsemble.exclude=` deprecated — use
  `Scenario(model, parameter_axes=[...])` instead.

## Closed issues

Closes #165.
Closes #187.