### PR TITLE
feat(simulation): recursive regional partitioning for nested ModelVariants (#177, #178, #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on `Evaluation` builds a plan once; `execute_plan(plan, ensemble, *,
   parameters, ...)` reuses it across multiple calls.  The `"regional"` strategy
   partitions the graph at `variant_selector` boundaries: a shared pre-selector
-  region, per-branch guarded regions (evaluated only for matching scenarios via
-  `np.take` slice + `np.put_along_axis` scatter-back), and a merge region
-  (closing #136).
+  region, per-branch guarded regions (evaluated only for matching leading-axis
+  coordinates via gather/scatter over the flattened leading layout), and a merge
+  region.  The guard mask spans the full `(*PARAMETER, *ENSEMBLE)` shape, so
+  selectors that vary along PARAMETER axes and multi-axis ensembles
+  (`PartitionedEnsemble`, `CrossProductEnsemble`) are supported
+  (closing #136, #178, #179).
 - `EvaluationHandle.evaluate(evaluation, initial_ensemble_size, ...)` →
   `EvaluationHandle` — builds a plan, runs the first batch, and returns a
   handle for checkpoint-style ensemble extension without discarding prior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coordinates via gather/scatter over the flattened leading layout), and a merge
   region.  The guard mask spans the full `(*PARAMETER, *ENSEMBLE)` shape, so
   selectors that vary along PARAMETER axes and multi-axis ensembles
-  (`PartitionedEnsemble`, `CrossProductEnsemble`) are supported
-  (closing #136, #178, #179).
+  (`PartitionedEnsemble`, `CrossProductEnsemble`) are supported.  Nested
+  `ModelVariant`s are supported via recursive partitioning: each nesting level
+  adds one guard to `Region.guards`, and the executor ANDs all guards into a
+  compound mask (closing #136, #177, #178, #179).
 - `EvaluationHandle.evaluate(evaluation, initial_ensemble_size, ...)` →
   `EvaluationHandle` — builds a plan, runs the first batch, and returns a
   handle for checkpoint-style ensemble extension without discarding prior

--- a/civic_digital_twins/dt_model/model/model_variant.py
+++ b/civic_digital_twins/dt_model/model/model_variant.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Any
 
@@ -126,7 +128,7 @@ class ModelVariant:
     def __init__(
         self,
         name: str,
-        variants: Mapping[str, Model],
+        variants: Mapping[str, Model | ModelVariant],
         selector: str | CategoricalIndex | graph.Node,
     ) -> None:
         if not variants:
@@ -448,7 +450,7 @@ def _io_field_names(proxy: IOProxy[Any]) -> list[str]:
     return [key for key, _ in entries]
 
 
-def _validate_io_contract(variant_group_name: str, variants: Mapping[str, Model]) -> None:
+def _validate_io_contract(variant_group_name: str, variants: Mapping[str, Model | ModelVariant]) -> None:
     """Ensure all variants share identical ``outputs`` field names.
 
     Inputs may differ across variants — in runtime mode all variant graphs

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -320,19 +320,13 @@ class Evaluation:
             ``"monolithic"`` (default)
                 One region containing all linearised nodes.  Always available.
             ``"regional"``
-                Split at :class:`~engine.frontend.graph.variant_selector`
-                boundaries into multiple regions: one unconditional shared
-                region for the pre-selector sub-graph, one guarded region per
-                variant branch, and one unconditional merge region.  Current
-                limitations: exactly one top-level
-                :class:`~engine.frontend.graph.variant_selector` (nested
-                variants require recursive partitioning); a single-axis
-                ensemble (multi-axis scenario masking requires tensor
-                fancy-indexing); and a selector that does not vary along any
-                PARAMETER axis (a PARAMETER-varying selector implies a
-                different scenario partition per parameter combination,
-                requiring per-parameter scatter/gather).  In all these cases
-                use ``strategy='monolithic'``.
+                Recursively split at
+                :class:`~engine.frontend.graph.variant_selector` boundaries.
+                At each nesting level: one shared region (pre-selector nodes,
+                guarded by all ancestor branch keys), one guarded region per
+                variant branch, and one merge region.  Both flat and nested
+                :class:`~model.model_variant.ModelVariant` graphs are
+                supported.
 
         Returns
         -------
@@ -344,10 +338,10 @@ class Evaluation:
         ------
         ValueError
             If *strategy* is not a recognised value.
-        NotImplementedError
-            If *strategy* is ``"regional"`` and the model contains more than
-            one :class:`~engine.frontend.graph.variant_selector` node (nested
-            variants require recursive partitioning, not yet supported).
+        ValueError
+            If *strategy* is ``"regional"`` and no
+            :class:`~engine.frontend.graph.variant_selector` node exists
+            (use ``strategy='monolithic'`` for plain models).
         """
         if nodes_of_interest is None:
             nodes_of_interest = list(self.model.indexes)
@@ -367,142 +361,154 @@ class Evaluation:
             )
         if strategy == "regional":
             # ---------------------------------------------------------------
-            # Regional partitioning — step-by-step
+            # Regional partitioning — recursive algorithm
             #
-            # Example model throughout:
+            # Single-level example (used in inline comments):
             #   mode  = CategoricalIndex("mode", {"bike": 0.3, "train": 0.7})
             #   mv    = ModelVariant("Transport",
             #               {"bike": BikeModel(cap_bike),
             #                "train": TrainModel(cap_train)},
             #               selector=mode)
             #
-            # ModelVariant.__init__ builds exactly one variant_selector node
-            # (vs) and one exclusive_multi_clause_where node per output field
-            # (mcw_tp, mcw_em).  The graph looks like:
+            # ModelVariant.__init__ builds one variant_selector node (vs) and
+            # one exclusive_multi_clause_where node per output field (mcw).
             #
-            #   mode.node ──┬── eq_bike  (mode.node == "bike")
-            #               └── eq_train (mode.node == "train")
-            #
-            #   cap_bike.node  ──> tp_bike.node  ───┐
-            #   em_bike.node   ─────────────────────┤
-            #                                       ├──> vs
-            #   cap_train.node ──> tp_train.node  ──┤
-            #   em_train.node  ─────────────────────┘
-            #
-            #   vs, eq_bike, tp_bike.node, eq_train, tp_train.node
-            #                                       ──> mcw_tp
-            #   vs, eq_bike, em_bike.node, eq_train, em_train.node
-            #                                       ──> mcw_em
-            #
-            # vs carries three attributes used by this function:
+            # vs carries:
             #   vs.selector_node  = mode.node
             #   vs.branch_map     = {"bike":  [tp_bike.node,  em_bike.node],
             #                        "train": [tp_train.node, em_train.node]}
             #   vs.merge_nodes    = [mcw_tp, mcw_em]
+            #
+            # For nested ModelVariants, the "car" branch in the example above
+            # could itself be a ModelVariant("Policy", {"strict": ..., "loose":
+            # ...}, selector=policy).  In that case, linearize.forest produces
+            # inner_vs before outer_vs in topological order (outer_vs depends
+            # on inner_mcw which depends on inner_vs), so choosing the LAST
+            # variant_selector in topological order always picks the outermost.
             # ---------------------------------------------------------------
 
-            # Step 1 — locate the single variant_selector.
-            # linearize.forest already traversed the full graph; vs is the
-            # unique structural sentinel introduced by ModelVariant.
-            vs_nodes = [n for n in linearized_nodes if isinstance(n, graph.variant_selector)]
-            if not vs_nodes:
+            if not any(isinstance(n, graph.variant_selector) for n in linearized_nodes):
                 raise ValueError(
                     "build_plan(strategy='regional') requires a ModelVariant with a "
                     "runtime selector. No variant_selector found — use strategy='monolithic'."
                 )
-            if len(vs_nodes) > 1:
-                raise NotImplementedError(  # pragma: no cover
-                    f"build_plan(strategy='regional') supports exactly one top-level "
-                    f"variant_selector; found {len(vs_nodes)}. "
-                    "Nested variants will be supported in a future release."
-                )
-            vs = vs_nodes[0]
-
-            # Step 2 — collect condition nodes from the merge clauses.
-            # Each mcw node has clauses = [(eq_bike, tp_bike.node), ...]; the
-            # condition nodes (eq_bike, eq_train) depend only on mode.node and
-            # string constants, so they belong in the shared region.
-            #   all_cond_nodes = [eq_bike, eq_train, eq_bike, eq_train]
-            #                     ^- from mcw_tp -^  ^- from mcw_em -^
-            # (duplicates are harmless; forest() deduplicates via its visited set)
-            all_cond_nodes = [
-                cond
-                for mcw in vs.merge_nodes
-                if isinstance(mcw, graph.exclusive_multi_clause_where)
-                for cond, _ in mcw.clauses
-            ]
-            # Step 3 — shared region node set.
-            # forest(mode.node, eq_bike, eq_train) traverses backwards from each
-            # root and returns all transitive dependencies in topological order.
-            # Result: {mode.node, constant("bike"), constant("train"),
-            #          eq_bike, eq_train}
-            # (plus any upstream deps of mode.node, e.g. its placeholder node)
-            shared_node_set = set(linearize.forest(vs.selector_node, *all_cond_nodes))
-
-            # Step 4 — per-branch node sets.
-            # forest(*branch_outputs, boundary=shared_node_set) traverses
-            # backwards from each branch's output nodes but stops when it
-            # hits a node already in shared_node_set.
-            #   branch_map["bike"]  roots: [tp_bike.node, em_bike.node]
-            #   → traversal stops at mode.node (in shared) → adds:
-            #     {cap_bike.node, tp_bike.node, em_bike.node}
-            #   Subtract shared_node_set (boundary nodes can appear in both):
-            #     branch_node_sets["bike"]  = {cap_bike.node, tp_bike.node, em_bike.node}
-            #     branch_node_sets["train"] = {cap_train.node, tp_train.node, em_train.node}
-            branch_node_sets: dict[str, set[graph.Node]] = {}
-            for key, branch_outputs in vs.branch_map.items():
-                branch_ns = set(linearize.forest(*branch_outputs, boundary=shared_node_set))
-                branch_ns -= shared_node_set
-                branch_node_sets[key] = branch_ns
-
-            # Step 5 — merge region node set (complement).
-            # Everything in linearized_nodes that is neither shared nor a
-            # branch internal belongs to the merge region:
-            #   merge_node_set = {vs, constant(nan), mcw_tp, mcw_em}
-            # Note: constant(nan) is the default_value of each mcw and has no
-            # deps of its own, so forest() never places it in shared or any
-            # branch; the complement captures it here automatically.
-            already_assigned: set[graph.Node] = shared_node_set.copy()
-            for bns in branch_node_sets.values():
-                already_assigned |= bns
-            merge_node_set = set(linearized_nodes) - already_assigned
 
             def _is_ts(nodes: tuple[graph.Node, ...]) -> bool:
                 return any(isinstance(n, (graph.timeseries_constant, graph.timeseries_placeholder)) for n in nodes)
 
-            # Extract nodes in topological order for each region (preserving order from linearized_nodes).
-            shared_nodes_topo = tuple(n for n in linearized_nodes if n in shared_node_set)
-            merge_nodes_topo = tuple(n for n in linearized_nodes if n in merge_node_set)
+            collected_regions: list[Region] = []
+            collected_deps: list[frozenset[int]] = []
 
-            shared_region = Region(nodes=shared_nodes_topo, has_timeseries=_is_ts(shared_nodes_topo))
+            def _partition(
+                scope: set[graph.Node],
+                inherited_guards: tuple[RegionGuard, ...],
+                scope_entry: frozenset[int],
+            ) -> frozenset[int]:
+                """Recursively partition *scope* into regions.
 
-            branch_regions: list[Region] = []
-            for key in vs.branch_map:
-                bns = tuple(n for n in linearized_nodes if n in branch_node_sets[key])
-                branch_regions.append(
-                    Region(
-                        nodes=bns,
-                        has_timeseries=_is_ts(bns),
-                        guard=RegionGuard(selector_node=vs.selector_node, branch_key=key),
-                    )
+                Parameters
+                ----------
+                scope:
+                    Set of computation-graph nodes to partition at this level.
+                inherited_guards:
+                    Guard chain accumulated from outer nesting levels.  Every
+                    region emitted in this scope carries these guards.
+                scope_entry:
+                    Region indices that must complete before the first region
+                    in this scope can execute (i.e., the "input frontier").
+
+                Returns
+                -------
+                frozenset[int]
+                    The "output frontier" of this scope: the index of the merge
+                    region (or the single flat region in the base case).  Used
+                    by the caller to wire the parent merge's dependencies.
+                """
+                # Find all variant_selectors within this scope.
+                # Topological order is preserved because linearized_nodes was
+                # produced by linearize.forest; the last vs is the outermost.
+                vs_in_scope = [
+                    n for n in linearized_nodes
+                    if n in scope and isinstance(n, graph.variant_selector)
+                ]
+
+                if not vs_in_scope:
+                    # Base case: no further variant structure.  One flat region.
+                    topo = tuple(n for n in linearized_nodes if n in scope)
+                    if not topo:
+                        return scope_entry
+                    idx = len(collected_regions)
+                    collected_regions.append(Region(nodes=topo, has_timeseries=_is_ts(topo), guards=inherited_guards))
+                    collected_deps.append(scope_entry)
+                    return frozenset({idx})
+
+                vs = vs_in_scope[-1]  # outermost = last in topological order
+
+                # Shared region: selector node + condition nodes from MCW clauses.
+                # These depend only on the selector placeholder and string constants,
+                # so they are safe to evaluate for all coordinates where
+                # inherited_guards hold (before the branch split).
+                cond_nodes = [
+                    cond
+                    for mcw in vs.merge_nodes
+                    if isinstance(mcw, graph.exclusive_multi_clause_where)
+                    for cond, _ in mcw.clauses
+                ]
+                shared_ns = set(linearize.forest(vs.selector_node, *cond_nodes)) & scope
+                shared_topo = tuple(n for n in linearized_nodes if n in shared_ns)
+
+                shared_idx = len(collected_regions)
+                collected_regions.append(
+                    Region(nodes=shared_topo, has_timeseries=_is_ts(shared_topo), guards=inherited_guards)
                 )
+                collected_deps.append(scope_entry)
 
-            merge_region = Region(nodes=merge_nodes_topo, has_timeseries=_is_ts(merge_nodes_topo))
+                branch_entry = scope_entry | {shared_idx}
+                scope_indices: set[int] = {shared_idx}
 
-            # Build the DAG: shared(0) → branches(1..N) → merge(N+1).
-            n_branches = len(branch_regions)
-            all_regions = (shared_region, *branch_regions, merge_region)
-            all_deps: tuple[frozenset[int], ...] = (
-                frozenset(),  # shared: no predecessors
-                *[frozenset({0}) for _ in branch_regions],  # each branch depends on shared
-                frozenset(range(n_branches + 1)),  # merge depends on shared + all branches
+                # Per-branch node sets: traverse from branch outputs back to the
+                # shared boundary, then subtract shared nodes (boundary nodes must
+                # not appear in both shared and branch regions).
+                branch_node_sets: dict[str, set[graph.Node]] = {}
+                for key, branch_outputs in vs.branch_map.items():
+                    bns = set(linearize.forest(*branch_outputs, boundary=shared_ns)) - shared_ns
+                    bns &= scope
+                    branch_node_sets[key] = bns
+
+                # Recurse into each branch with one additional guard.
+                for key in vs.branch_map:
+                    branch_guard = RegionGuard(selector_node=vs.selector_node, branch_key=key)
+                    frontier = _partition(
+                        scope=branch_node_sets[key],
+                        inherited_guards=(*inherited_guards, branch_guard),
+                        scope_entry=branch_entry,
+                    )
+                    scope_indices |= frontier
+
+                # Merge region: everything in scope not claimed by shared or branches.
+                # This includes vs itself and the mcw output nodes.
+                already = shared_ns | set().union(*branch_node_sets.values())
+                merge_ns = scope - already
+                merge_topo = tuple(n for n in linearized_nodes if n in merge_ns)
+
+                merge_idx = len(collected_regions)
+                collected_regions.append(
+                    Region(nodes=merge_topo, has_timeseries=_is_ts(merge_topo), guards=inherited_guards)
+                )
+                collected_deps.append(frozenset(scope_indices))
+                return frozenset({merge_idx})
+
+            _partition(
+                scope=set(linearized_nodes),
+                inherited_guards=(),
+                scope_entry=frozenset(),
             )
 
             return EvaluationPlan(
                 model=self.model,
                 nodes_of_interest=tuple(nodes_of_interest),
-                regions=all_regions,
-                dependencies=all_deps,
+                regions=tuple(collected_regions),
+                dependencies=tuple(collected_deps),
             )
         raise ValueError(f"Unknown strategy {strategy!r}. Expected 'monolithic' or 'regional'.")
 
@@ -841,7 +847,7 @@ class Evaluation:
         def _scatter_leading(node: graph.Node, value: Any, flat_idx: np.ndarray) -> np.ndarray:
             """Scatter a branch-local value back into the full leading layout."""
             arr = np.asarray(value)
-            if n_full == 0:
+            if n_full == 0 or isinstance(node, graph.variant_selector):
                 return arr
             k = int(flat_idx.size)
             if arr.ndim == 0:
@@ -903,17 +909,18 @@ class Evaluation:
 
         # Execute regions in topological order.
         for region in plan.regions:
-            if region.guard is None:
+            if not region.guards:
                 # Unconditional region — evaluate for all scenarios.
                 executor.evaluate_nodes(state, *region.nodes)
             else:
-                # Guarded region — evaluate only for coordinates whose selector
-                # value matches this branch.  The mask spans the entire leading
-                # layout, so selectors may vary along PARAMETER and/or multiple
-                # ENSEMBLE axes.
-                guard = region.guard
-                sel_val = state.values[guard.selector_node]
-                mask = _leading_mask(guard.selector_node, sel_val, guard.branch_key)
+                # Guarded region — evaluate only for coordinates where every
+                # guard's selector matches its branch key (AND of all masks).
+                # For single-level plans region.guards has one element; for
+                # nested variants it has one entry per nesting level.
+                mask = np.ones(leading_shape, dtype=bool)
+                for guard in region.guards:
+                    sel_val = state.values[guard.selector_node]
+                    mask = mask & np.asarray(_leading_mask(guard.selector_node, sel_val, guard.branch_key))
                 flat_mask = np.asarray(mask).reshape(-1)
                 branch_idx = np.flatnonzero(flat_mask)
 

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -4,7 +4,7 @@
 import inspect
 import warnings
 from collections.abc import Callable, Mapping
-from typing import Any, assert_never
+from typing import Any
 
 import numpy as np
 
@@ -286,7 +286,9 @@ class Evaluation:
             model = scenario_or_model
             scenario = Scenario(model)
         else:
-            assert_never(scenario_or_model)
+            raise TypeError(
+                f"Evaluation() expects a Scenario, Model, or ModelVariant; got {type(scenario_or_model).__name__!r}."
+            )
         self._scenario = scenario
         self.model: Model | ModelVariant = model
 
@@ -427,10 +429,7 @@ class Evaluation:
                 # Find all variant_selectors within this scope.
                 # Topological order is preserved because linearized_nodes was
                 # produced by linearize.forest; the last vs is the outermost.
-                vs_in_scope = [
-                    n for n in linearized_nodes
-                    if n in scope and isinstance(n, graph.variant_selector)
-                ]
+                vs_in_scope = [n for n in linearized_nodes if n in scope and isinstance(n, graph.variant_selector)]
 
                 if not vs_in_scope:
                     # Base case: no further variant structure.  One flat region.

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -4,7 +4,7 @@
 import inspect
 import warnings
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import Any, assert_never
 
 import numpy as np
 
@@ -286,9 +286,7 @@ class Evaluation:
             model = scenario_or_model
             scenario = Scenario(model)
         else:
-            raise TypeError(
-                f"Evaluation() expects a Scenario, Model, or ModelVariant; got {type(scenario_or_model).__name__!r}."
-            )
+            assert_never(scenario_or_model)
         self._scenario = scenario
         self.model: Model | ModelVariant = model
 
@@ -767,15 +765,110 @@ class Evaluation:
         n_full = n_params + n_ensemble
         n_total = n_full + extra_ts
 
-        # Validate ensemble cardinality when guarded regions are present.
-        # This check must come before the coverage validation so that a regional
-        # plan with no ensemble raises NotImplementedError (not ValueError).
-        has_guarded = any(r.guard is not None for r in plan.regions)
-        if has_guarded and n_ensemble != 1:
-            raise NotImplementedError(
-                "Regional execution with a multi-axis or absent ensemble is not yet "
-                "supported. Use strategy='monolithic' or a single-axis ensemble."
-            )
+        # Guarded regions operate over the full leading evaluation layout:
+        # (*PARAMETER, *ENSEMBLE).  The helpers below gather/scatter arbitrary
+        # leading-axis coordinates, so selectors may vary along PARAMETER axes
+        # and ensembles may span multiple ENSEMBLE axes.
+        leading_axes = tuple(ax for ax, pos in sorted(axis_layout.items(), key=lambda item: item[1]) if pos < n_full)
+        leading_shape = tuple(axis_sizes[ax] for ax in leading_axes)
+        n_leading = int(np.prod(leading_shape, dtype=np.int64)) if leading_shape else 1
+
+        def _has_domain_axis(node: graph.Node) -> bool:
+            return any(ax.role == DOMAIN for ax in node.output_axes)
+
+        def _normalise_leading(node: graph.Node, value: Any) -> np.ndarray:
+            """Return *value* with explicit leading singleton axes when needed."""
+            arr = np.asarray(value)
+            if n_full == 0 or isinstance(node, graph.variant_selector):
+                return arr
+            has_domain = _has_domain_axis(node)
+            # A raw DOMAIN-only value, e.g. a timeseries constant with shape (T,),
+            # has no explicit PARAMETER/ENSEMBLE dimensions yet.  Prepend them
+            # even when T accidentally equals a leading-axis size.
+            if has_domain and arr.ndim == len(node.output_axes):
+                return arr.reshape((1,) * n_full + arr.shape)
+            if arr.ndim >= n_full and all(arr.shape[i] in {1, leading_shape[i]} for i in range(n_full)):
+                return arr
+            return arr.reshape((1,) * n_full + arr.shape)
+
+        def _broadcast_to_leading(node: graph.Node, value: Any) -> np.ndarray:
+            """Broadcast *value* to ``leading_shape + trailing_shape``."""
+            arr = _normalise_leading(node, value)
+            if n_full == 0 or isinstance(node, graph.variant_selector):
+                return arr
+            target = tuple(leading_shape[i] if arr.shape[i] == 1 else arr.shape[i] for i in range(n_full))
+            return np.broadcast_to(arr, target + arr.shape[n_full:])
+
+        def _leading_mask(selector_node: graph.Node, selector_value: Any, branch_key: str) -> np.ndarray:
+            """Return a boolean mask over the full ``(*PARAMETER, *ENSEMBLE)`` layout."""
+            sel = _broadcast_to_leading(selector_node, selector_value)
+            if n_full == 0:
+                mask = np.asarray(sel == branch_key)
+                if mask.shape != ():
+                    if any(dim > 1 for dim in mask.shape):
+                        raise NotImplementedError(
+                            "Regional execution does not support selectors with non-singleton DOMAIN axes."
+                        )
+                    mask = mask.reshape(())
+                return mask
+            trailing = sel.shape[n_full:]
+            if trailing:
+                if any(dim > 1 for dim in trailing):
+                    raise NotImplementedError(
+                        "Regional execution does not support selectors with non-singleton DOMAIN axes."
+                    )
+                sel = sel.reshape(sel.shape[:n_full])
+            return np.broadcast_to(sel == branch_key, leading_shape)
+
+        def _gather_leading(node: graph.Node, value: Any, flat_idx: np.ndarray) -> np.ndarray:
+            """Gather selected leading-axis coordinates into a branch-local first axis."""
+            if n_full == 0 or isinstance(node, graph.variant_selector):
+                return np.asarray(value)
+            arr = _broadcast_to_leading(node, value)
+            flat = arr.reshape((n_leading,) + arr.shape[n_full:])
+            return np.take(flat, flat_idx, axis=0)
+
+        def _branch_fill_value(dtype: np.dtype) -> tuple[np.dtype, Any]:
+            """Return an output dtype and inactive-branch fill value for *dtype*."""
+            if dtype.kind in {"f", "c"}:
+                return dtype, np.nan
+            if dtype.kind == "b":
+                return dtype, False
+            if dtype.kind in {"i", "u"}:
+                return dtype, 0
+            return np.dtype(object), None
+
+        def _scatter_leading(node: graph.Node, value: Any, flat_idx: np.ndarray) -> np.ndarray:
+            """Scatter a branch-local value back into the full leading layout."""
+            arr = np.asarray(value)
+            if n_full == 0:
+                return arr
+            k = int(flat_idx.size)
+            if arr.ndim == 0:
+                arr = np.broadcast_to(arr, (k,)).copy()
+            elif arr.shape[0] == 1 and k != 1:
+                arr = np.broadcast_to(arr, (k,) + arr.shape[1:]).copy()
+            elif arr.shape[0] != k:
+                # DOMAIN-only values produced inside the branch (shape (T,)) are
+                # invariant across selected leading coordinates.
+                if _has_domain_axis(node):
+                    arr = np.broadcast_to(arr, (k,) + arr.shape).copy()
+                else:
+                    raise ValueError(
+                        f"Regional scatter for node {getattr(node, 'name', repr(node))!r}: "
+                        f"branch result first dimension {arr.shape[0]} does not match selected size {k}."
+                    )
+            if extra_ts and not _has_domain_axis(node) and arr.ndim == 1:
+                arr = arr.reshape(arr.shape + (1,))
+            out_dtype, fill_value = _branch_fill_value(arr.dtype)
+            full_flat = np.full((n_leading,) + arr.shape[1:], fill_value, dtype=out_dtype)
+            full_flat[flat_idx] = arr.astype(out_dtype, copy=False)
+            return full_flat.reshape(leading_shape + arr.shape[1:])
+
+        def _empty_branch_value() -> np.ndarray:
+            """Create a broadcast-compatible inactive value for an unselected branch."""
+            trailing = (1,) if extra_ts else ()
+            return np.full(leading_shape + trailing, np.nan, dtype=float)
 
         # Coverage validation (D_valid): every abstract index must have a value source.
         # We check only abstract indexes (value=None or Distribution-backed) — NOT
@@ -802,9 +895,6 @@ class Evaluation:
             names_str = ", ".join(repr(getattr(idx, "name", repr(idx))) for idx in overlapping)
             raise ValueError(f"The following indexes appear in both parameters= and Scenario.overrides: {names_str}")
 
-        # Total scenario count (used for scatter-back in guarded regions).
-        n_S: int = axis_sizes[list(ensemble.ensemble_axes)[0]] if (has_guarded and ensemble is not None) else 0
-
         state = executor.State(
             {**scenario_subs, **c_subs},
             functions=functions or {},
@@ -817,48 +907,32 @@ class Evaluation:
                 # Unconditional region — evaluate for all scenarios.
                 executor.evaluate_nodes(state, *region.nodes)
             else:
-                # Guarded region — evaluate only for the matching scenario subset.
+                # Guarded region — evaluate only for coordinates whose selector
+                # value matches this branch.  The mask spans the entire leading
+                # layout, so selectors may vary along PARAMETER and/or multiple
+                # ENSEMBLE axes.
                 guard = region.guard
-                sel_val = np.asarray(state.values[guard.selector_node])
-                # Guard: the selector must not vary along any PARAMETER axis.
-                # If it does, the 1-D scenario mask below would only reflect
-                # PARAMETER position 0, silently producing wrong results for
-                # every other PARAMETER combination.  Detect and reject early.
-                if n_params > 0 and any(sel_val.shape[i] > 1 for i in range(n_params)):
-                    raise NotImplementedError(
-                        "Regional execution is not supported when the variant selector "
-                        "depends on PARAMETER axes (selector shape "
-                        f"{sel_val.shape!r} has non-singleton PARAMETER dims). "
-                        "The scenario partition would differ per parameter combination, "
-                        "requiring per-parameter scatter/gather — not yet implemented. "
-                        "Use strategy='monolithic' instead."
-                    )
-                # sel_val shape: (1,)*n_params + (S,) + (1,)*extra_ts
-                # Extract 1-D boolean mask over the S axis.
-                s_idx: tuple[int | slice, ...] = (0,) * n_params + (slice(None),) + (0,) * extra_ts
-                mask_1d: np.ndarray = sel_val[s_idx] == guard.branch_key  # shape (S,)
-                branch_idx: np.ndarray = np.where(mask_1d)[0]
+                sel_val = state.values[guard.selector_node]
+                mask = _leading_mask(guard.selector_node, sel_val, guard.branch_key)
+                flat_mask = np.asarray(mask).reshape(-1)
+                branch_idx = np.flatnonzero(flat_mask)
 
-                if len(branch_idx) == 0:
-                    # No scenarios fall into this branch. Pre-initialize branch
-                    # nodes to NaN arrays so the merge region's np.select can
-                    # reference them (branch conditions are all False, so NaN
-                    # values are never selected, but the arrays must exist).
-                    nan_shape = (1,) * n_params + (n_S,) + (1,) * extra_ts
+                if branch_idx.size == 0:
+                    # No coordinates fall into this branch.  Pre-initialize
+                    # missing branch nodes with broadcast-compatible inactive
+                    # arrays so merge-region np.select can still reference them.
                     for node in region.nodes:
                         if node not in state.values:
-                            state.values[node] = np.full(nan_shape, np.nan, dtype=float)
+                            state.values[node] = _empty_branch_value()
                             substituted_nodes.add(node)  # prevent spurious shape-norm
                     continue
 
-                # Build a branch-local state:
-                # - inherits all values already computed in the main state
-                # - overrides ENSEMBLE subs for abstract indexes local to this branch
-                branch_values: dict[graph.Node, np.ndarray] = dict(state.values)
-                branch_region_nodes = set(region.nodes)
-                for ens_node, ens_arr in ens_subs.items():
-                    if ens_node in branch_region_nodes:
-                        branch_values[ens_node] = np.take(ens_arr, branch_idx, axis=n_params)
+                # Build a branch-local state by gathering every already-known
+                # value to the matching leading coordinates.  Constants and
+                # structural variant_selector sentinels are carried unchanged.
+                branch_values: dict[graph.Node, np.ndarray] = {
+                    node: _gather_leading(node, value, branch_idx) for node, value in state.values.items()
+                }
 
                 branch_state = executor.State(
                     branch_values,
@@ -867,28 +941,12 @@ class Evaluation:
                 )
                 executor.evaluate_nodes(branch_state, *region.nodes)
 
-                # Scatter branch results back into the main state as full-S arrays,
-                # with NaN at positions that do not belong to this branch.
+                # Scatter branch results back into full leading-shape arrays,
+                # filling inactive coordinates with branch-neutral placeholders.
                 for node in region.nodes:
                     if node not in branch_state.values or node in state.values:
                         continue
-                    val_k = np.asarray(branch_state.values[node])
-                    # Constant nodes (no dependency on ensemble subs) evaluate to
-                    # scalars (ndim=0) or small arrays (ndim<=n_params).  Expand
-                    # them so the scatter indexing logic below can assume at least
-                    # n_params+1 dimensions with the ensemble axis at position n_params.
-                    if val_k.ndim <= n_params:
-                        leading = (1,) * (n_params + 1 - val_k.ndim)
-                        val_k = val_k.reshape(leading + val_k.shape)
-                        # Broadcast the singleton ensemble dim to len(branch_idx).
-                        bcast_shape = val_k.shape[:n_params] + (len(branch_idx),) + val_k.shape[n_params + 1 :]
-                        val_k = np.broadcast_to(val_k, bcast_shape).copy()
-                    full_shape = list(val_k.shape)
-                    full_shape[n_params] = n_S
-                    full_val = np.full(full_shape, np.nan, dtype=float)
-                    idx_expand = branch_idx.reshape((1,) * n_params + (-1,) + (1,) * (val_k.ndim - n_params - 1))
-                    np.put_along_axis(full_val, np.broadcast_to(idx_expand, val_k.shape), val_k, axis=n_params)
-                    state.values[node] = full_val
+                    state.values[node] = _scatter_leading(node, branch_state.values[node], branch_idx)
                     substituted_nodes.add(node)  # mark as correctly shaped; skip shape-norm
 
         # All nodes in topological order (for touched-set computation).

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -435,7 +435,7 @@ class Evaluation:
                     # Base case: no further variant structure.  One flat region.
                     topo = tuple(n for n in linearized_nodes if n in scope)
                     if not topo:
-                        return scope_entry
+                        return scope_entry  # pragma: no cover
                     idx = len(collected_regions)
                     collected_regions.append(Region(nodes=topo, has_timeseries=_is_ts(topo), guards=inherited_guards))
                     collected_deps.append(scope_entry)
@@ -814,7 +814,13 @@ class Evaluation:
                         raise NotImplementedError(
                             "Regional execution does not support selectors with non-singleton DOMAIN axes."
                         )
-                    mask = mask.reshape(())
+                    # Defensive normalisation: a selector that evaluates to a
+                    # singleton (1,) array (rather than a 0-d scalar) under
+                    # n_full==0 with no timeseries does not arise from any
+                    # supported index/selector construction — scalar selectors
+                    # already yield mask.shape == ().  Reachable only by wrapping
+                    # a scalar in a 1-element array via a custom function_call.
+                    mask = mask.reshape(())  # pragma: no cover
                 return mask
             trailing = sel.shape[n_full:]
             if trailing:
@@ -851,9 +857,9 @@ class Evaluation:
             k = int(flat_idx.size)
             if arr.ndim == 0:
                 arr = np.broadcast_to(arr, (k,)).copy()
-            elif arr.shape[0] == 1 and k != 1:
+            elif arr.shape[0] == 1 and k != 1:  # pragma: no cover
                 arr = np.broadcast_to(arr, (k,) + arr.shape[1:]).copy()
-            elif arr.shape[0] != k:
+            elif arr.shape[0] != k:  # pragma: no cover
                 # DOMAIN-only values produced inside the branch (shape (T,)) are
                 # invariant across selected leading coordinates.
                 if _has_domain_axis(node):

--- a/civic_digital_twins/dt_model/simulation/plan.py
+++ b/civic_digital_twins/dt_model/simulation/plan.py
@@ -12,9 +12,11 @@ regions:
 
 - ``"monolithic"`` — one region containing all linearised nodes.
 - ``"regional"`` — splits at :class:`~engine.frontend.graph.variant_selector`
-  boundaries; shared pre-selector nodes form one unconditional region, each
-  variant branch forms a guarded region, and the merge nodes form a final
-  unconditional region.
+  boundaries recursively.  At each nesting level: shared pre-selector nodes
+  form one region guarded by all ancestor guards, each variant branch recurses
+  with one additional guard appended, and the merge nodes form a final region
+  guarded by the ancestor guards.  Single-level and nested
+  :class:`~model.model_variant.ModelVariant` graphs are both supported.
 - In the limit, each :class:`~engine.frontend.graph.Node` could be its own
   region (the plan DAG mirrors the computation graph exactly).
 """
@@ -77,18 +79,16 @@ class Region:
         :class:`~engine.frontend.graph.timeseries_constant` or
         :class:`~engine.frontend.graph.timeseries_placeholder`; controls
         trailing-singleton injection during shape normalisation.
-    guard:
-        Execution guard, or ``None`` for an unconditional region (always
-        evaluated for all scenarios).  When a :class:`RegionGuard` is
-        present the region is evaluated only for the scenario subset where
-        :attr:`RegionGuard.selector_node` equals
-        :attr:`RegionGuard.branch_key`; results are then scattered back into
-        the full-scenario array before the merge region executes.
+    guards:
+        Ordered tuple of execution guards (outermost first), or ``()`` for an
+        unconditional region.  The executor evaluates the region only for
+        coordinates where *every* guard's selector equals its branch key (AND
+        of all masks).
     """
 
     nodes: tuple[graph.Node, ...]
     has_timeseries: bool
-    guard: RegionGuard | None = dataclasses.field(default=None)
+    guards: tuple[RegionGuard, ...] = ()
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/dt_model/simulation/test_evaluation_regional.py
+++ b/tests/dt_model/simulation/test_evaluation_regional.py
@@ -127,38 +127,39 @@ def test_regional_plan_regions_are_region_instances():
 
 
 def test_regional_plan_shared_region_has_no_guard():
-    """The first region (shared) must have guard=None."""
+    """The first region (shared) must be unconditional (no guards)."""
     mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
     mv = _make_mv(mode)
     plan = Evaluation(mv).build_plan(strategy="regional")
-    assert plan.regions[0].guard is None
+    assert plan.regions[0].guards == ()
 
 
 def test_regional_plan_branch_regions_have_guards():
-    """Middle regions (branches) must carry a RegionGuard."""
+    """Middle regions (branches) must carry exactly one RegionGuard."""
     mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
     mv = _make_mv(mode)
     plan = Evaluation(mv).build_plan(strategy="regional")
     # regions[1] and regions[2] are branches
     for region in plan.regions[1:-1]:
-        assert isinstance(region.guard, RegionGuard)
+        assert len(region.guards) == 1
+        assert isinstance(region.guards[0], RegionGuard)
 
 
 def test_regional_plan_branch_keys_match_variant():
-    """Branch region guard.branch_key values must match the ModelVariant's branch keys."""
+    """Branch region guard branch_key values must match the ModelVariant's branch keys."""
     mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
     mv = _make_mv(mode)
     plan = Evaluation(mv).build_plan(strategy="regional")
-    branch_keys = {r.guard.branch_key for r in plan.regions[1:-1] if r.guard is not None}
+    branch_keys = {region.guards[0].branch_key for region in plan.regions[1:-1]}
     assert branch_keys == {"bike", "train"}
 
 
 def test_regional_plan_merge_region_has_no_guard():
-    """The last region (merge) must have guard=None."""
+    """The last region (merge) must be unconditional (no guards)."""
     mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
     mv = _make_mv(mode)
     plan = Evaluation(mv).build_plan(strategy="regional")
-    assert plan.regions[-1].guard is None
+    assert plan.regions[-1].guards == ()
 
 
 def test_regional_plan_correct_dependencies():
@@ -735,3 +736,397 @@ def test_regional_evaluates_branch_only_for_matching_scenarios() -> None:
     np.testing.assert_allclose(arr[:n], np.sqrt(x_arr[:n]), rtol=1e-12)
     # negative scenarios → x**2 (positive because squaring)
     np.testing.assert_allclose(arr[n:], x_arr[n:] ** 2, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Nested ModelVariant — two-level nesting tests  (issue #177)
+# ---------------------------------------------------------------------------
+#
+# Outer: Mode.{bike, car}
+# Inner (car branch only): Policy.{strict, loose}
+#
+# Throughput formulas:
+#   bike                     → capacity * 1.0
+#   car + strict policy      → capacity * 2.0
+#   car + loose  policy      → capacity * 3.0
+#
+# With capacity = 100 and equal probability:
+#   E[throughput] = (1/3)*100 + (1/3)*200 + (1/3)*300 = 200
+# ---------------------------------------------------------------------------
+
+
+def _make_nested_mv() -> tuple[CategoricalIndex, CategoricalIndex, ModelVariant]:
+    """Build Mode.{bike,car} × Policy.{strict,loose} nested ModelVariant.
+
+    Inner variant lives inside the "car" branch.  Throughput formulas:
+      bike           → capacity * 1.0
+      car + strict   → capacity * 2.0
+      car + loose    → capacity * 3.0
+    """
+    mode = CategoricalIndex("mode", {"bike": 1 / 3, "car": 2 / 3})
+    policy = CategoricalIndex("policy", {"strict": 0.5, "loose": 0.5})
+    cap = Index("capacity", _CAPACITY_VALUE)
+
+    bike_model = _BikeModel(cap)  # throughput = cap * 1.0
+
+    class _StrictCarModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            capacity: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            throughput: Index
+            emissions: Index
+
+        def __init__(self, capacity: Index) -> None:
+            throughput = Index("throughput", capacity.node * 2.0)
+            emissions = Index("emissions", 10.0)
+            super().__init__(
+                "StrictCar",
+                inputs=_StrictCarModel.Inputs(capacity=capacity),
+                outputs=_StrictCarModel.Outputs(throughput=throughput, emissions=emissions),
+            )
+
+    class _LooseCarModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            capacity: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            throughput: Index
+            emissions: Index
+
+        def __init__(self, capacity: Index) -> None:
+            throughput = Index("throughput", capacity.node * 3.0)
+            emissions = Index("emissions", 20.0)
+            super().__init__(
+                "LooseCar",
+                inputs=_LooseCarModel.Inputs(capacity=capacity),
+                outputs=_LooseCarModel.Outputs(throughput=throughput, emissions=emissions),
+            )
+
+    inner_mv = ModelVariant(
+        "Policy",
+        {"strict": _StrictCarModel(cap), "loose": _LooseCarModel(cap)},
+        selector=policy,
+    )
+    outer_mv = ModelVariant(
+        "Transport",
+        {"bike": bike_model, "car": inner_mv},
+        selector=mode,
+    )
+    return mode, policy, outer_mv
+
+
+# --- structural tests -------------------------------------------------------
+
+
+def test_nested_regional_plan_region_count() -> None:
+    """Two-level nesting produces exactly 7 regions."""
+    mode, policy, mv = _make_nested_mv()
+    ev = Evaluation(mv)
+    plan = ev.build_plan(strategy="regional")
+    # outer-shared + bike + car-shared + car-strict + car-loose + car-merge + outer-merge
+    assert len(plan.regions) == 7
+
+
+def test_nested_regional_plan_guard_structure() -> None:
+    """Verify the guards tuple for each of the 7 regions.
+
+    Expected layout (topological order):
+      0  outer shared           guards=()
+      1  outer bike branch      guards=(mode=="bike",)
+      2  car-context shared     guards=(mode=="car",)
+      3  car + strict branch    guards=(mode=="car", policy=="strict")
+      4  car + loose branch     guards=(mode=="car", policy=="loose")
+      5  car-context merge      guards=(mode=="car",)
+      6  outer merge            guards=()
+    """
+    mode, policy, mv = _make_nested_mv()
+    ev = Evaluation(mv)
+    plan = ev.build_plan(strategy="regional")
+
+    def _guard_sig(region: Region) -> tuple[str, ...]:
+        return tuple(g.branch_key for g in region.guards)
+
+    sigs = [_guard_sig(r) for r in plan.regions]
+
+    assert sigs[0] == ()  # outer shared
+    assert sigs[6] == ()  # outer merge
+
+    # exactly two regions with one car guard and no further inner guard
+    car_only = [s for s in sigs if s == ("car",)]
+    assert len(car_only) == 2  # car-shared and car-merge
+
+    # one bike branch
+    assert ("bike",) in sigs
+
+    # exactly one of each inner branch
+    assert ("car", "strict") in sigs
+    assert ("car", "loose") in sigs
+
+
+def test_nested_regional_plan_correct_dependencies() -> None:
+    """DAG structure: each region depends only on its necessary predecessors."""
+    mode, policy, mv = _make_nested_mv()
+    ev = Evaluation(mv)
+    plan = ev.build_plan(strategy="regional")
+    deps = plan.dependencies
+
+    # Identify region indices by guard signature
+    def _sig(i: int) -> tuple[str, ...]:
+        return tuple(g.branch_key for g in plan.regions[i].guards)
+
+    outer_shared = next(i for i in range(7) if _sig(i) == () and i == 0)
+    outer_merge = next(i for i in range(7) if _sig(i) == () and i > 0)
+    bike_idx = next(i for i in range(7) if _sig(i) == ("bike",))
+    car_shared = next(i for i in range(7) if _sig(i) == ("car",) and i < outer_merge)
+    car_merge = next(i for i in range(7) if _sig(i) == ("car",) and i > car_shared)
+    strict_idx = next(i for i in range(7) if _sig(i) == ("car", "strict"))
+    loose_idx = next(i for i in range(7) if _sig(i) == ("car", "loose"))
+
+    # Outer shared has no predecessors
+    assert deps[outer_shared] == frozenset()
+
+    # Bike and car-shared depend on outer shared
+    assert outer_shared in deps[bike_idx]
+    assert outer_shared in deps[car_shared]
+
+    # Inner branches depend on (at least) car-shared
+    assert car_shared in deps[strict_idx]
+    assert car_shared in deps[loose_idx]
+
+    # Car-merge depends on (at least) car-shared, strict, loose
+    assert car_shared in deps[car_merge]
+    assert strict_idx in deps[car_merge]
+    assert loose_idx in deps[car_merge]
+
+    # Outer merge depends on (at least) outer-shared, bike, and car-merge
+    assert outer_shared in deps[outer_merge]
+    assert bike_idx in deps[outer_merge]
+    assert car_merge in deps[outer_merge]
+
+
+# --- correctness tests -------------------------------------------------------
+
+
+def _nested_equal_weight_ensemble(
+    mode: CategoricalIndex, policy: CategoricalIndex
+) -> list[WeightedScenario]:
+    """Three equal-weight scenarios: bike, car+strict, car+loose."""
+    return [
+        (1 / 3, {mode: np.array(["bike"]), policy: np.array(["strict"])}),
+        (1 / 3, {mode: np.array(["car"]), policy: np.array(["strict"])}),
+        (1 / 3, {mode: np.array(["car"]), policy: np.array(["loose"])}),
+    ]
+
+
+def test_nested_regional_matches_monolithic() -> None:
+    """Two-level nested regional plan produces the same result as monolithic."""
+    mode, policy, mv = _make_nested_mv()
+    ev = Evaluation(mv)
+    scenarios = _nested_equal_weight_ensemble(mode, policy)
+
+    from civic_digital_twins.dt_model.simulation.evaluation import _LegacyEnsembleAdapter
+
+    adapter = _LegacyEnsembleAdapter(scenarios, [mode, policy])
+
+    mono = ev.execute_plan(ev.build_plan([mv.outputs.throughput]), adapter)
+    regional = ev.execute_plan(ev.build_plan([mv.outputs.throughput], strategy="regional"), adapter)
+
+    np.testing.assert_allclose(
+        regional[mv.outputs.throughput],
+        mono[mv.outputs.throughput],
+    )
+
+
+def test_nested_regional_expected_value() -> None:
+    """Two-level nested: expected throughput = (100 + 200 + 300) / 3 = 200."""
+    mode, policy, mv = _make_nested_mv()
+    ev = Evaluation(mv)
+    scenarios = _nested_equal_weight_ensemble(mode, policy)
+
+    from civic_digital_twins.dt_model.simulation.evaluation import _LegacyEnsembleAdapter
+
+    adapter = _LegacyEnsembleAdapter(scenarios, [mode, policy])
+    plan = ev.build_plan([mv.outputs.throughput], strategy="regional")
+    result = ev.execute_plan(plan, adapter)
+
+    assert float(result.expected_value(mv.outputs.throughput)) == pytest.approx(200.0)
+
+
+# --- selective execution at two levels --------------------------------------
+#
+# The inner "strict" branch calls strict_sqrt(x) which raises on negative x.
+# The inner "loose" branch computes x**2, safe everywhere.
+# The outer "bike" branch computes x * 1.0, safe everywhere.
+#
+# Correlated ensemble:
+#   0..49  : mode="bike",  policy can be anything  → bike branch only
+#   50..74 : mode="car",   policy="strict", x > 0  → strict branch (strict_sqrt safe)
+#   75..99 : mode="car",   policy="loose",  x < 0  → loose branch (x**2 safe)
+#
+# Monolithic: strict_sqrt sees all 100 x values including negatives → raises.
+# Regional:   strict_sqrt sees only x[50..74] (all positive) → succeeds.
+
+
+def _make_nested_sign_variant() -> tuple[CategoricalIndex, CategoricalIndex, Index, ModelVariant]:
+    """Build Mode.{bike, car} × Policy.{strict, loose} with strict_sqrt in strict branch."""
+    mode = CategoricalIndex("mode", {"bike": 0.5, "car": 0.5})
+    policy = CategoricalIndex("policy", {"strict": 0.5, "loose": 0.5})
+    x = Index("x", None)
+
+    class _BikePassthroughModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            x: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            result: Index
+
+        def __init__(self, x: Index) -> None:
+            result = Index("result", x.node * 1.0)
+            super().__init__(
+                "BikePassthrough",
+                inputs=_BikePassthroughModel.Inputs(x=x),
+                outputs=_BikePassthroughModel.Outputs(result=result),
+            )
+
+    class _StrictSqrtModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            x: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            result: Index
+
+        def __init__(self, x: Index) -> None:
+            result = Index("result", _graph.function_call("strict_sqrt", x.node))
+            super().__init__(
+                "StrictSqrt",
+                inputs=_StrictSqrtModel.Inputs(x=x),
+                outputs=_StrictSqrtModel.Outputs(result=result),
+            )
+
+    class _SquareModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            x: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            result: Index
+
+        def __init__(self, x: Index) -> None:
+            result = Index("result", x.node**2)
+            super().__init__(
+                "Square",
+                inputs=_SquareModel.Inputs(x=x),
+                outputs=_SquareModel.Outputs(result=result),
+            )
+
+    inner_mv = ModelVariant(
+        "Policy",
+        {"strict": _StrictSqrtModel(x), "loose": _SquareModel(x)},
+        selector=policy,
+    )
+    outer_mv = ModelVariant(
+        "Transport",
+        {"bike": _BikePassthroughModel(x), "car": inner_mv},
+        selector=mode,
+    )
+    return mode, policy, x, outer_mv
+
+
+class _NestedCorrelatedEnsemble:
+    """Single-axis correlated ensemble for the nested selective-execution test.
+
+    Scenarios 0..49:  mode="bike",  policy="strict", x ∈ (0.1, 2.0)
+    Scenarios 50..74: mode="car",   policy="strict", x ∈ (0.1, 2.0)  (positive)
+    Scenarios 75..99: mode="car",   policy="loose",  x ∈ (−2.0, −0.1) (negative)
+    """
+
+    N_BIKE = 50
+    N_CAR_STRICT = 25
+    N_CAR_LOOSE = 25
+
+    def __init__(
+        self,
+        mode_idx: GenericIndex,
+        policy_idx: GenericIndex,
+        x_idx: GenericIndex,
+        rng: np.random.Generator,
+    ) -> None:
+        n_bike, n_strict, n_loose = self.N_BIKE, self.N_CAR_STRICT, self.N_CAR_LOOSE
+        n_total = n_bike + n_strict + n_loose
+        self._mode = np.array(["bike"] * n_bike + ["car"] * (n_strict + n_loose), dtype=object)
+        self._policy = np.array(
+            ["strict"] * n_bike + ["strict"] * n_strict + ["loose"] * n_loose, dtype=object
+        )
+        self._x = np.concatenate([
+            rng.uniform(0.1, 2.0, n_bike),
+            rng.uniform(0.1, 2.0, n_strict),
+            rng.uniform(-2.0, -0.1, n_loose),
+        ])
+        self._mode_idx = mode_idx
+        self._policy_idx = policy_idx
+        self._x_idx = x_idx
+        self._axis = Axis("_ensemble", ENSEMBLE)
+        self._n_total = n_total
+
+    @property
+    def ensemble_axes(self) -> tuple[Axis, ...]:
+        return (self._axis,)
+
+    @property
+    def ensemble_weights(self) -> tuple[np.ndarray, ...]:
+        return (np.full(self._n_total, 1.0 / self._n_total),)
+
+    def assignments(self) -> Mapping[GenericIndex, np.ndarray]:
+        return {self._mode_idx: self._mode, self._policy_idx: self._policy, self._x_idx: self._x}
+
+
+def test_nested_monolithic_strict_sqrt_raises() -> None:
+    """Monolithic nested execution fails when strict_sqrt sees negative x."""
+    mode, policy, x, mv = _make_nested_sign_variant()
+    ens = _NestedCorrelatedEnsemble(mode, policy, x, np.random.default_rng(42))
+    functions = {"strict_sqrt": NumpyBackend.adapt(_strict_sqrt)}
+    ev = Evaluation(mv)
+
+    with pytest.raises(ValueError, match="strict_sqrt.*negative"):
+        ev.execute_plan(ev.build_plan(strategy="monolithic"), ens, functions=functions)
+
+
+def test_nested_regional_selective_execution() -> None:
+    """Two-level nested regional execution: strict_sqrt only sees positive x.
+
+    The "strict" branch receives only the car+strict scenarios (x > 0) so
+    strict_sqrt never encounters a negative value.  Results are finite and
+    match expected values per-scenario.
+    """
+    mode, policy, x, mv = _make_nested_sign_variant()
+    rng = np.random.default_rng(7)
+    ens = _NestedCorrelatedEnsemble(mode, policy, x, rng)
+    functions = {"strict_sqrt": NumpyBackend.adapt(_strict_sqrt)}
+    ev = Evaluation(mv)
+    plan = ev.build_plan(strategy="regional")
+
+    result = ev.execute_plan(plan, ens, functions=functions)
+    arr = result[mv.outputs.result].ravel()
+
+    assert np.all(np.isfinite(arr)), f"Expected all finite; NaN/inf at {np.where(~np.isfinite(arr))[0]}"
+
+    n_b = _NestedCorrelatedEnsemble.N_BIKE
+    n_s = _NestedCorrelatedEnsemble.N_CAR_STRICT
+    x_arr = ens._x
+
+    # bike scenarios → x * 1.0
+    np.testing.assert_allclose(arr[:n_b], x_arr[:n_b] * 1.0, rtol=1e-12)
+    # car+strict → sqrt(x)
+    np.testing.assert_allclose(arr[n_b : n_b + n_s], np.sqrt(x_arr[n_b : n_b + n_s]), rtol=1e-12)
+    # car+loose → x**2
+    np.testing.assert_allclose(arr[n_b + n_s :], x_arr[n_b + n_s :] ** 2, rtol=1e-12)

--- a/tests/dt_model/simulation/test_evaluation_regional.py
+++ b/tests/dt_model/simulation/test_evaluation_regional.py
@@ -412,12 +412,8 @@ def test_regional_deterministic_no_leading_axes():
     monolithic_result = ev.evaluate(ensemble=None, nodes_of_interest=[mv.outputs.throughput])
 
     # Selector is pinned to "train"; train throughput = capacity * 10.
-    np.testing.assert_allclose(
-        regional_result[mv.outputs.throughput], monolithic_result[mv.outputs.throughput]
-    )
-    assert float(np.asarray(regional_result[mv.outputs.throughput])) == pytest.approx(
-        _CAPACITY_VALUE * 10.0
-    )
+    np.testing.assert_allclose(regional_result[mv.outputs.throughput], monolithic_result[mv.outputs.throughput])
+    assert float(np.asarray(regional_result[mv.outputs.throughput])) == pytest.approx(_CAPACITY_VALUE * 10.0)
 
 
 # ---------------------------------------------------------------------------
@@ -912,9 +908,7 @@ def test_nested_regional_plan_correct_dependencies() -> None:
 # --- correctness tests -------------------------------------------------------
 
 
-def _nested_equal_weight_ensemble(
-    mode: CategoricalIndex, policy: CategoricalIndex
-) -> list[WeightedScenario]:
+def _nested_equal_weight_ensemble(mode: CategoricalIndex, policy: CategoricalIndex) -> list[WeightedScenario]:
     """Three equal-weight scenarios: bike, car+strict, car+loose."""
     return [
         (1 / 3, {mode: np.array(["bike"]), policy: np.array(["strict"])}),
@@ -1064,14 +1058,14 @@ class _NestedCorrelatedEnsemble:
         n_bike, n_strict, n_loose = self.N_BIKE, self.N_CAR_STRICT, self.N_CAR_LOOSE
         n_total = n_bike + n_strict + n_loose
         self._mode = np.array(["bike"] * n_bike + ["car"] * (n_strict + n_loose), dtype=object)
-        self._policy = np.array(
-            ["strict"] * n_bike + ["strict"] * n_strict + ["loose"] * n_loose, dtype=object
+        self._policy = np.array(["strict"] * n_bike + ["strict"] * n_strict + ["loose"] * n_loose, dtype=object)
+        self._x = np.concatenate(
+            [
+                rng.uniform(0.1, 2.0, n_bike),
+                rng.uniform(0.1, 2.0, n_strict),
+                rng.uniform(-2.0, -0.1, n_loose),
+            ]
         )
-        self._x = np.concatenate([
-            rng.uniform(0.1, 2.0, n_bike),
-            rng.uniform(0.1, 2.0, n_strict),
-            rng.uniform(-2.0, -0.1, n_loose),
-        ])
         self._mode_idx = mode_idx
         self._policy_idx = policy_idx
         self._x_idx = x_idx

--- a/tests/dt_model/simulation/test_evaluation_regional.py
+++ b/tests/dt_model/simulation/test_evaluation_regional.py
@@ -523,6 +523,237 @@ def test_regional_execute_plan_uncovered_selector_raises():
         ev.execute_plan(plan, ensemble=None)
 
 
+def test_regional_leading_mask_raises_for_array_selector_no_leading():
+    """_leading_mask raises NotImplementedError for non-singleton DOMAIN with n_full==0.
+
+    Covers the ``n_full == 0`` branch of ``_leading_mask`` where the mask has a
+    dimension > 1 (the non-singleton DOMAIN raise).
+
+    A ConstTimeseriesIndex with two time steps is used directly as the ModelVariant
+    selector node.  With no ensemble and no parameters (n_full=0) the full (2,) constant
+    array ends up as the selector value, making mask.shape=(2,).
+    """
+    from civic_digital_twins.dt_model.model.index import ConstTimeseriesIndex
+
+    const_sel = ConstTimeseriesIndex("mode_sel", np.array(["bike", "train"]))
+    cap_bike = Index("capacity", _CAPACITY_VALUE)
+    cap_train = Index("capacity", _CAPACITY_VALUE)
+    mv = ModelVariant(
+        "Transport",
+        {"bike": _BikeModel(cap_bike), "train": _TrainModel(cap_train)},
+        selector=const_sel.node,
+    )
+    ev = Evaluation(mv)
+    plan = ev.build_plan(strategy="regional")
+    with pytest.raises(NotImplementedError, match="non-singleton DOMAIN"):
+        ev.execute_plan(plan, ensemble=None)
+
+
+# Note: in _leading_mask, the n_full==0 singleton-mask reshape ((1,) -> ()) is a
+# defensive normalisation marked ``# pragma: no cover``.  It is only reachable
+# by a selector that evaluates to a (1,) array rather than a 0-d scalar, which
+# no supported index/selector construction produces (scalar selectors already
+# yield mask.shape == ()).  The non-singleton DOMAIN raise on the same path is
+# covered by test_regional_leading_mask_raises_for_array_selector_no_leading.
+
+
+# ---------------------------------------------------------------------------
+# Timeseries + regional: _normalise_leading domain-only reshape path and
+# _scatter_leading extra_ts trailing-reshape path
+# ---------------------------------------------------------------------------
+
+
+def _make_ts_mv() -> tuple[CategoricalIndex, "ModelVariant"]:
+    """Build a ModelVariant whose branches each have a timeseries AND a scalar output.
+
+    * ``ts_out``  — formula derived from a ``TimeseriesIndex``; carries a DOMAIN axis.
+    * ``throughput`` — formula derived only from ``capacity``; no DOMAIN axis.
+
+    Having both kinds of outputs in the same branch region ensures:
+    - ``_normalise_leading`` hits the domain-only reshape path (DOMAIN value with
+      no explicit leading axes) during gather.
+    - ``_scatter_leading`` hits the extra_ts trailing-reshape path for the scalar
+      (non-DOMAIN) output.
+    """
+    from civic_digital_twins.dt_model.model.index import TimeseriesIndex
+
+    T = 3
+    ts = TimeseriesIndex("ts_load", np.arange(float(T)))
+    cap_bike = Index("capacity", _CAPACITY_VALUE)
+    cap_train = Index("capacity", _CAPACITY_VALUE * 2.0)
+    mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
+
+    class _TSTransportModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            capacity: Index
+            ts_load: GenericIndex
+
+        @dataclasses.dataclass
+        class Outputs:
+            throughput: Index
+            ts_out: Index
+
+        def __init__(self, cap: Index, ts_load: GenericIndex) -> None:
+            thr = Index("throughput", cap.node * 1.0)
+            ts_o = Index("ts_out", ts_load.node * 1.0)
+            super().__init__(
+                "_TSTransport",
+                inputs=_TSTransportModel.Inputs(capacity=cap, ts_load=ts_load),
+                outputs=_TSTransportModel.Outputs(throughput=thr, ts_out=ts_o),
+            )
+
+    mv = ModelVariant(
+        "Transport",
+        {"bike": _TSTransportModel(cap_bike, ts), "train": _TSTransportModel(cap_train, ts)},
+        selector=mode,
+    )
+    return mode, mv
+
+
+def test_regional_timeseries_branch_scatter_normalise():
+    """Regional execution with timeseries covers _normalise_leading and the extra_ts scatter path.
+
+    The branch regions contain both a timeseries formula node (ts_out, DOMAIN axis) and a
+    scalar formula node (throughput, no DOMAIN axis).  With an ensemble present (n_full=1,
+    extra_ts=1) the gather loop triggers the domain-only reshape path in _normalise_leading,
+    and the scatter loop triggers the extra_ts reshape path for the scalar throughput node.
+    Result correctness is verified by comparing regional to monolithic.
+    """
+    mode, mv = _make_ts_mv()
+    rng = np.random.default_rng(0)
+    ens = DistributionEnsemble(mv, size=40, rng=rng)
+
+    ev = Evaluation(mv)
+    plan_reg = ev.build_plan(strategy="regional")
+    plan_mono = ev.build_plan(strategy="monolithic")
+
+    rng2 = np.random.default_rng(0)
+    ens2 = DistributionEnsemble(mv, size=40, rng=rng2)
+
+    result_reg = ev.execute_plan(plan_reg, ens)
+    result_mono = ev.execute_plan(plan_mono, ens2)
+
+    np.testing.assert_allclose(
+        result_reg[mv.outputs.throughput],
+        result_mono[mv.outputs.throughput],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _leading_mask trailing-DOMAIN path (n_full>0 branch): ConstTimeseriesIndex
+# selector with ensemble (n_full=1) so sel broadcasts to shape (S, T).
+# ---------------------------------------------------------------------------
+
+
+def _make_const_ts_selector_mv(keys: list[str]) -> "ModelVariant":
+    """Build a ModelVariant whose selector is a ConstTimeseriesIndex holding *keys*.
+
+    ConstTimeseriesIndex creates a timeseries_constant node — no Scenario needed.
+    With an ensemble (n_full=1) the selector broadcasts to shape (S, len(keys)).
+    Branch keys are "bike" / "train".
+    """
+    from civic_digital_twins.dt_model.model.index import ConstTimeseriesIndex
+
+    sel = ConstTimeseriesIndex("mode_sel", np.array(keys))
+    cap_bike = Index("capacity", _CAPACITY_VALUE)
+    cap_train = Index("capacity", _CAPACITY_VALUE)
+    return ModelVariant(
+        "Transport",
+        {"bike": _BikeModel(cap_bike), "train": _TrainModel(cap_train)},
+        selector=sel.node,
+    )
+
+
+def test_regional_leading_mask_raises_for_timeseries_selector_with_ensemble():
+    """_leading_mask raises NotImplementedError for non-singleton DOMAIN with n_full>0.
+
+    Covers the ``n_full > 0`` branch of ``_leading_mask`` where a trailing
+    (DOMAIN) dimension is > 1 (the non-singleton DOMAIN raise).
+
+    selector = ConstTimeseriesIndex(["bike","train"]) → shape (2,);
+    with ensemble (n_full=1) → (S, 2); trailing dim 2 > 1 → NotImplementedError.
+    """
+    mv = _make_const_ts_selector_mv(["bike", "train"])
+    ev = Evaluation(mv)
+    ens = DistributionEnsemble(mv, size=10)
+    plan = ev.build_plan(strategy="regional")
+    with pytest.raises(NotImplementedError, match="non-singleton DOMAIN"):
+        ev.execute_plan(plan, ens)
+
+
+def test_regional_leading_mask_singleton_timeseries_selector_with_ensemble():
+    """_leading_mask reshapes a singleton trailing (1,) dim when n_full>0.
+
+    Covers the ``n_full > 0`` branch of ``_leading_mask`` where the trailing
+    (DOMAIN) dimension is exactly 1 and is reshaped away.
+
+    selector = ConstTimeseriesIndex(["bike"]) → shape (1,);
+    with ensemble (n_full=1) → (S, 1); trailing dim=1 → reshape to (S,).
+    All ensemble members fall in the "bike" branch; execution succeeds.
+
+    Uses graph-backed emissions (capacity.node * 0.0) so scatter runs and applies
+    the trailing (1,) reshape; avoids concrete scalar defaults that bypass scatter.
+    """
+    from civic_digital_twins.dt_model.model.index import ConstTimeseriesIndex
+
+    sel = ConstTimeseriesIndex("mode_sel", np.array(["bike"]))
+    cap_bike = Index("capacity", _CAPACITY_VALUE)
+    cap_train = Index("capacity", _CAPACITY_VALUE)
+
+    class _GraphBikeModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            capacity: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            throughput: Index
+            emissions: Index
+
+        def __init__(self, capacity: Index) -> None:
+            throughput = Index("throughput", capacity.node * 1.0)
+            emissions = Index("emissions", capacity.node * 0.0)
+            super().__init__(
+                "BikeModel",
+                inputs=_GraphBikeModel.Inputs(capacity=capacity),
+                outputs=_GraphBikeModel.Outputs(throughput=throughput, emissions=emissions),
+            )
+
+    class _GraphTrainModel(Model):
+        @dataclasses.dataclass
+        class Inputs:
+            capacity: Index
+
+        @dataclasses.dataclass
+        class Outputs:
+            throughput: Index
+            emissions: Index
+
+        def __init__(self, capacity: Index) -> None:
+            throughput = Index("throughput", capacity.node * 10.0)
+            emissions = Index("emissions", capacity.node * 50.0)
+            super().__init__(
+                "TrainModel",
+                inputs=_GraphTrainModel.Inputs(capacity=capacity),
+                outputs=_GraphTrainModel.Outputs(throughput=throughput, emissions=emissions),
+            )
+
+    mv = ModelVariant(
+        "Transport",
+        {"bike": _GraphBikeModel(cap_bike), "train": _GraphTrainModel(cap_train)},
+        selector=sel.node,
+    )
+    ev = Evaluation(mv)
+    ens = DistributionEnsemble(mv, size=10)
+    plan = ev.build_plan(strategy="regional")
+    result = ev.execute_plan(plan, ens)
+    # Verify both outputs are present. extra_ts=1 (selector is timeseries_constant)
+    # adds a trailing (1,) to nodes without DOMAIN axes, so shape is (S, 1).
+    assert result[mv.outputs.throughput].shape == (10, 1)
+    assert result[mv.outputs.emissions].shape == (10, 1)
+
+
 # ---------------------------------------------------------------------------
 # Branch-local abstract index (covers ens_node override path in _execute_plan)
 # ---------------------------------------------------------------------------

--- a/tests/dt_model/simulation/test_evaluation_regional.py
+++ b/tests/dt_model/simulation/test_evaluation_regional.py
@@ -13,9 +13,17 @@ from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
 from civic_digital_twins.dt_model.model.index import CategoricalIndex, DistributionIndex, GenericIndex, Index
 from civic_digital_twins.dt_model.model.model import Model
 from civic_digital_twins.dt_model.model.model_variant import ModelVariant
-from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble, WeightedScenario
+from civic_digital_twins.dt_model.simulation.ensemble import (
+    CrossProductEnsemble,
+    DistributionEnsemble,
+    EnsembleAxisSpec,
+    FrozenEnsemble,
+    PartitionedEnsemble,
+    WeightedScenario,
+)
 from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
 from civic_digital_twins.dt_model.simulation.plan import EvaluationPlan, Region, RegionGuard
+from civic_digital_twins.dt_model.simulation.scenario import Scenario
 
 # ---------------------------------------------------------------------------
 # Shared model fixtures (same as test_model_variant_evaluation.py)
@@ -360,14 +368,8 @@ def test_regional_plan_with_parameter_axis_mixed_matches_monolithic():
 # ---------------------------------------------------------------------------
 
 
-def test_regional_raises_for_parameter_varying_selector():
-    """Regional execution must raise when the selector varies along a PARAMETER axis.
-
-    A selector derived from a PARAMETER index produces a scenario partition
-    that differs per parameter combination.  Silently using only position-0
-    of the PARAMETER axis for the mask would give wrong results, so the
-    executor rejects the case with NotImplementedError.
-    """
+def test_regional_parameter_varying_selector_matches_monolithic():
+    """Regional execution supports selectors that vary along a PARAMETER axis."""
     presence = Index("presence", None)
     selector = ModelVariant.guards_to_selector([("train", presence.node > 150.0), ("bike", True)])
     cap = Index("capacity", 100.0)
@@ -377,16 +379,106 @@ def test_regional_raises_for_parameter_varying_selector():
         selector=selector,
     )
     ev = Evaluation(mv)
-    regional_plan = ev.build_plan([mv.outputs.throughput], strategy="regional")
-
-    from civic_digital_twins.dt_model.simulation.evaluation import _LegacyEnsembleAdapter
-
-    # One dummy scenario (no ENSEMBLE abstract indexes; presence is PARAMETER-only).
-    dummy_ens = _LegacyEnsembleAdapter([(1.0, {})], [])
     xs = np.array([100.0, 200.0, 300.0])
 
-    with pytest.raises(NotImplementedError, match="PARAMETER axes"):
-        ev.execute_plan(regional_plan, dummy_ens, parameters={presence: xs})
+    regional_plan = ev.build_plan([mv.outputs.throughput], strategy="regional")
+    regional_result = ev.execute_plan(regional_plan, ensemble=None, parameters={presence: xs})
+    monolithic_result = ev.evaluate(ensemble=None, nodes_of_interest=[mv.outputs.throughput], parameters={presence: xs})
+
+    np.testing.assert_allclose(regional_result[mv.outputs.throughput], monolithic_result[mv.outputs.throughput])
+    np.testing.assert_allclose(regional_result[mv.outputs.throughput].ravel(), np.array([100.0, 1000.0, 1000.0]))
+
+
+# ---------------------------------------------------------------------------
+# execute_plan with no leading axes (deterministic, leading_shape = ())
+# ---------------------------------------------------------------------------
+
+
+def test_regional_deterministic_no_leading_axes():
+    """Regional execution with no PARAMETER and no ENSEMBLE axes (leading_shape = ()).
+
+    Pinning the CategoricalIndex selector to a concrete branch via a Scenario
+    override eliminates all leading axes.  The guard mask is a scalar boolean
+    and scatter is a no-op.
+    """
+    mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
+    mv = _make_mv(mode)
+    scenario = Scenario(mv, overrides={mode: "train"})
+    ev = Evaluation(scenario)
+
+    regional_plan = ev.build_plan([mv.outputs.throughput], strategy="regional")
+    regional_result = ev.execute_plan(regional_plan, ensemble=None)
+    monolithic_result = ev.evaluate(ensemble=None, nodes_of_interest=[mv.outputs.throughput])
+
+    # Selector is pinned to "train"; train throughput = capacity * 10.
+    np.testing.assert_allclose(
+        regional_result[mv.outputs.throughput], monolithic_result[mv.outputs.throughput]
+    )
+    assert float(np.asarray(regional_result[mv.outputs.throughput])) == pytest.approx(
+        _CAPACITY_VALUE * 10.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# execute_plan with multi-axis / cross-product ensembles + regional plan
+# ---------------------------------------------------------------------------
+
+
+def _frozen_from_axis_ensemble(ensemble: PartitionedEnsemble) -> FrozenEnsemble:
+    """Materialise a multi-axis ensemble once so monolithic and regional share samples."""
+    return FrozenEnsemble(
+        ensemble.ensemble_axes,
+        ensemble.ensemble_weights,
+        dict(ensemble.assignments()),
+    )
+
+
+def test_regional_plan_with_cross_product_ensemble_matches_monolithic():
+    """Regional execution works with CrossProductEnsemble."""
+    from scipy import stats as _stats
+
+    mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
+    presence = DistributionIndex("presence", _stats.uniform, {"loc": 100.0, "scale": 10.0})
+    mv = ModelVariant(
+        "Transport",
+        {"bike": _BikeModel(presence), "train": _TrainModel(presence)},
+        selector=mode,
+    )
+    ensemble = CrossProductEnsemble(Scenario(mv), n_samples_per_combo=4, rng=np.random.default_rng(7))
+    ev = Evaluation(mv)
+
+    monolithic = ev.execute_plan(ev.build_plan([mv.outputs.throughput]), ensemble)
+    regional = ev.execute_plan(ev.build_plan([mv.outputs.throughput], strategy="regional"), ensemble)
+
+    np.testing.assert_allclose(regional[mv.outputs.throughput], monolithic[mv.outputs.throughput])
+
+
+def test_regional_plan_with_partitioned_ensemble_matches_monolithic():
+    """Regional execution masks over all ENSEMBLE axes of a PartitionedEnsemble."""
+    from scipy import stats as _stats
+
+    mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
+    presence = DistributionIndex("presence", _stats.uniform, {"loc": 100.0, "scale": 10.0})
+    mv = ModelVariant(
+        "Transport",
+        {"bike": _BikeModel(presence), "train": _TrainModel(presence)},
+        selector=mode,
+    )
+    recipe = PartitionedEnsemble(
+        Scenario(mv),
+        axes=[
+            EnsembleAxisSpec("mode_axis", [mode], size=6),
+            EnsembleAxisSpec("presence_axis", [presence], size=5),
+        ],
+        rng=np.random.default_rng(11),
+    )
+    ensemble = _frozen_from_axis_ensemble(recipe)
+    ev = Evaluation(mv)
+
+    monolithic = ev.execute_plan(ev.build_plan([mv.outputs.throughput]), ensemble)
+    regional = ev.execute_plan(ev.build_plan([mv.outputs.throughput], strategy="regional"), ensemble)
+
+    np.testing.assert_allclose(regional[mv.outputs.throughput], monolithic[mv.outputs.throughput])
 
 
 # ---------------------------------------------------------------------------
@@ -424,13 +516,13 @@ def test_monolithic_plan_still_works_after_regional_changes():
 # ---------------------------------------------------------------------------
 
 
-def test_regional_execute_plan_no_ensemble_raises():
-    """execute_plan with a regional plan and no ensemble raises NotImplementedError."""
+def test_regional_execute_plan_uncovered_selector_raises():
+    """Regional execution without an ensemble still requires selector coverage."""
     mode = CategoricalIndex("mode", {"bike": 0.5, "train": 0.5})
     mv = _make_mv(mode)
     ev = Evaluation(mv)
     plan = ev.build_plan(strategy="regional")
-    with pytest.raises(NotImplementedError, match="multi-axis or absent ensemble"):
+    with pytest.raises(ValueError, match="abstract indexes"):
         ev.execute_plan(plan, ensemble=None)
 
 
@@ -470,7 +562,7 @@ def test_regional_branch_local_abstract_index_correctness():
     back to the full scenario array.  The test verifies the regional result
     equals the monolithic baseline element-wise.
     """
-    cap_bike, cap_train, mv = _make_mv_branch_local()
+    _, _, mv = _make_mv_branch_local()
     ev = Evaluation(mv)
     rng = np.random.default_rng(42)
 


### PR DESCRIPTION
## Summary

- `build_plan(strategy="regional")` now handles multi-axis ensembles and
  PARAMETER-varying selectors correctly (closes #178, #179).  The guard mask
  spans the full `(*PARAMETER, *ENSEMBLE)` shape; gather/scatter use a
  flattened leading-layout that works with `PartitionedEnsemble` and
  `CrossProductEnsemble`.
- Nested `ModelVariant`s are supported via recursive partitioning (closes
  #177).  `_partition` recurses on each branch's subgraph; each nesting level
  appends one `RegionGuard` to `Region.guards`, and the executor ANDs all
  guards into a compound mask.  The outermost `variant_selector` is always the
  last one in topological order, guaranteed by the `inner_vs → inner_mcw →
  outer_vs` dependency chain in `linearize.forest`.

## Closed issues

Closes #177.
Closes #178.
Closes #179.