### PR TITLE
refactor(simulation)!: centralize axis operations in AxisLayout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ and 4).
 
 ## Important Details
 
-- **Package structure**: `civic_digital_twins/dt_model/` contains the main code with subpackages: `engine/` (DSL compiler), `model/` (higher-level abstractions), `symbols/` (Index, TimeseriesIndex).
+- **Package structure**: `civic_digital_twins/dt_model/` contains the main code with subpackages: `engine/` (DSL compiler), `model/` (indexes, models, contracts), `simulation/` (scenarios, ensembles, evaluation, runners). Top-level modules follow the module-role convention (see README “Conceptual Overview”): `axes.py` is the canonical home of the cross-cutting axis vocabulary; `graph.py` is a curated user façade over `engine/frontend/graph.py`.
 - **Python path**: `pyproject.toml` sets `pythonpath = ["examples"]` so tests can import example packages like `mobility_bologna` and `overtourism_molveno`.
 - **Pyright config**: `pyproject.toml` includes `examples` in both `include` (type-checked) and `extraPaths` (import resolution).
 - **CI uses `--locked`**: Both `ci-dev.yml` and `ci-release.yml` run `uv sync --locked`, which fails if `uv.lock` is out of sync with `pyproject.toml`. Always commit an updated `uv.lock` alongside any `pyproject.toml` change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `AxisLayout` (`civic_digital_twins.dt_model.simulation.axis_layout`) —
+  centralizes the axis-to-numpy-dimension mapping previously duplicated
+  across `evaluation.py`, `handle.py`, and `runner.py`: canonical
+  PARAMETER→ENSEMBLE→DOMAIN dimension ordering enforced at construction,
+  role queries, merge-signature comparison, `with_grown_axis()`, and dict
+  serialization.  Exported from `civic_digital_twins.dt_model`.
+- `EvaluationResult.layout` and `EvaluationResult.factorized_weights` —
+  public accessors replacing direct access to the private
+  `_axis_layout`/`_axis_sizes`/`_factorized_weights` attributes that
+  `handle.py` and `runner.py` previously reached into (the first two are
+  now removed entirely; see below).
+- `TIME_AXIS` — canonical singleton for the time `DOMAIN` axis, replacing
+  five independent `Axis("time", DOMAIN)` constructions across the engine,
+  model, and simulation layers.  Exported from `civic_digital_twins.dt_model`
+  and `civic_digital_twins.dt_model.axes`.
+- `union_axes()` and `filter_by_role()` in `civic_digital_twins.dt_model.axes`
+  — axis-tuple set operations, consolidating a duplicate `_union_axes()` that
+  previously lived in `engine.frontend.graph`.
+
 ### Changed
 
 - Split CI into `ci-dev.yml` (fast: 3.12 only) and `ci-release.yml` (full:
@@ -59,6 +80,21 @@ prior three releases; see their respective `### Deprecated` sections below).
 - **Breaking:** `EvaluationResult.marginalize()` — use
   `EvaluationResult.expected_value()` instead.
 - **Breaking:** `LambdaAdapter` — use `NumpyBackend.adapt()` instead.
+
+Removed without a prior deprecation cycle:
+
+- **Breaking:** `civic_digital_twins.dt_model.model.axis` module — the
+  re-export shim over `civic_digital_twins.dt_model.axes` was never the
+  documented import path (the top-level `civic_digital_twins.dt_model`
+  re-exports already served as the stable one).  Import `Axis`, `AxisRole`,
+  `DOMAIN`, `PARAMETER`, `ENSEMBLE` from `civic_digital_twins.dt_model`
+  (recommended) or `civic_digital_twins.dt_model.axes` instead.
+- **Breaking:** `EvaluationResult(axis_layout=<dict>, axis_sizes=<dict>)` —
+  the transitional `dict[Axis, int]` + `axis_sizes=` constructor form is
+  gone; `axis_layout=` now requires an `AxisLayout` instance.  Only relevant
+  to code constructing `EvaluationResult` directly, which is not the
+  documented flow (results come from `Evaluation.evaluate()`,
+  `EvaluationHandle`, or `ModelEvaluator.resume()`).
 
 
 ## [0.10.0] - 2026-06-21

--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ See [docs/design/dd-cdt-model.md](docs/design/dd-cdt-model.md) for the full
 reference: index types, `Model` API, `ModelVariant`, `Evaluation`, and the
 domain modeling pattern.
 
+### Top-level modules: `axes` and `graph`
+
+Besides the layer subpackages, `civic_digital_twins.dt_model` hosts two
+top-level modules with distinct, deliberate roles:
+
+- **`dt_model.axes`** is the *canonical home* of the cross-cutting axis
+  vocabulary: `Axis`, `AxisRole`, the role constants (`DOMAIN`, `PARAMETER`,
+  `ENSEMBLE`), the `TIME_AXIS` singleton, and axis set operations.  Axes are
+  shared by all three layers, so they live above them; every internal module
+  imports axis symbols from here.  User code can equivalently use the
+  top-level re-exports 
+  (`from civic_digital_twins.dt_model import Axis, TIME_AXIS`).
+- **`dt_model.graph`** is a *curated user façade* over the engine-owned
+  `engine.frontend.graph`: it re-exports only the node builders meant for
+  use in model definitions.  Internal code imports the engine module
+  directly — the façade is intentionally narrow and is not widened to serve
+  internal needs.
+
+A new top-level module should fit one of these two roles: canonical home for
+cross-cutting vocabulary, or curated façade over a layer-owned module.
+
 ### Usage patterns
 
 The `examples/` directory contains two illustrative examples, distinguished

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -1,15 +1,11 @@
 """Digital twin modeling and simulation library."""
 # SPDX-License-Identifier: Apache-2.0
 
+from .axes import DOMAIN, ENSEMBLE, PARAMETER, TIME_AXIS, Axis, AxisRole
 from .engine.frontend.graph import HasNode
 from .engine.numpybackend.executor import Functor, NumpyBackend
 from .model import (
-    DOMAIN,
-    ENSEMBLE,
-    PARAMETER,
     AbstractIndexNotInInputsWarning,
-    Axis,
-    AxisRole,
     CategoricalIndex,
     ConditionalCategoricalIndex,
     ConditionalDistributionIndex,
@@ -111,6 +107,7 @@ __all__ = [
     "RegionGuard",
     "ResumeState",
     "Scenario",
+    "TIME_AXIS",
     "TimeseriesIndex",
     "WeightedScenario",
     "sample_across",

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -30,6 +30,7 @@ from .model import (
 from .simulation import (
     AsyncEvaluationHandle,
     AxisEnsemble,
+    AxisLayout,
     BatchDrawable,
     CrossProductEnsemble,
     DistributionEnsemble,
@@ -62,6 +63,7 @@ __all__ = [
     "Axis",
     "AsyncEvaluationHandle",
     "AxisEnsemble",
+    "AxisLayout",
     "AxisRole",
     "BatchDrawable",
     "CategoricalIndex",

--- a/civic_digital_twins/dt_model/axes.py
+++ b/civic_digital_twins/dt_model/axes.py
@@ -1,8 +1,10 @@
-"""Axis identity: role constants and the Axis class.
+"""Axis identity: role constants, the Axis class, and axis set operations.
 
-This module is the canonical home for axis types shared between the model
-and engine layers.  Import from here (or from ``model.axis`` which re-exports
-everything) rather than from layer-specific modules.
+This module is the canonical home for the axis vocabulary shared by all
+layers (engine, model, simulation).  Always import axis types and utilities
+from here; user code can equivalently use the re-exports in the top-level
+``civic_digital_twins.dt_model`` package.  (See the README's "Conceptual
+Overview" for the module-role convention behind this layout.)
 """
 
 # SPDX-License-Identifier: Apache-2.0

--- a/civic_digital_twins/dt_model/axes.py
+++ b/civic_digital_twins/dt_model/axes.py
@@ -7,7 +7,18 @@ everything) rather than from layer-specific modules.
 
 # SPDX-License-Identifier: Apache-2.0
 
-__all__ = ["AxisRole", "DOMAIN", "PARAMETER", "ENSEMBLE", "Axis"]
+from collections.abc import Iterable
+
+__all__ = [
+    "AxisRole",
+    "DOMAIN",
+    "PARAMETER",
+    "ENSEMBLE",
+    "Axis",
+    "TIME_AXIS",
+    "filter_by_role",
+    "union_axes",
+]
 
 # Open string type alias — users can define additional roles as plain strings
 # following the UPPER_CASE convention.
@@ -62,3 +73,30 @@ class Axis:
     def __repr__(self) -> str:
         """Return a concise string representation."""
         return f"Axis({self.name!r}, role={self.role!r})"
+
+
+TIME_AXIS: Axis = Axis("time", DOMAIN)
+"""Singleton for the time DOMAIN axis carried by timeseries nodes.
+
+This is the canonical instance: every module that needs the time axis must
+import it from here rather than constructing ``Axis("time", DOMAIN)`` locally.
+(Value-based equality makes local copies *work*, but a single singleton keeps
+the definition in one place.)
+"""
+
+
+def union_axes(*seqs: tuple[Axis, ...]) -> tuple[Axis, ...]:
+    """Merge axis tuples, preserving first-seen order and deduplicating."""
+    seen: set[Axis] = set()
+    result: list[Axis] = []
+    for seq in seqs:
+        for ax in seq:
+            if ax not in seen:
+                seen.add(ax)
+                result.append(ax)
+    return tuple(result)
+
+
+def filter_by_role(axes: Iterable[Axis], role: AxisRole) -> tuple[Axis, ...]:
+    """Return the axes whose role equals *role*, preserving input order."""
+    return tuple(ax for ax in axes if ax.role == role)

--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -180,11 +180,8 @@ from typing import Protocol, runtime_checkable
 
 from numpy.typing import ArrayLike
 
-from ...axes import DOMAIN, Axis
+from ...axes import TIME_AXIS, Axis, union_axes
 from .. import atomic, compileflags
-
-_TIME_AXIS = Axis("time", DOMAIN)
-"""Singleton for the time domain axis used by timeseries nodes."""
 
 Scalar = bool | float | int | str
 """Type alias for supported scalar value types."""
@@ -273,18 +270,6 @@ _id_generator = atomic.Int()
 
 # In the rest of the file, `T` is used as a type parameter for `Node`,
 # while `C` is used as a type parameter for boolean conditions.
-
-
-def _union_axes(*seqs: tuple[Axis, ...]) -> tuple[Axis, ...]:
-    """Merge axis tuples, preserving first-seen order and deduplicating."""
-    seen: set[Axis] = set()
-    result: list[Axis] = []
-    for seq in seqs:
-        for ax in seq:
-            if ax not in seen:
-                seen.add(ax)
-                result.append(ax)
-    return tuple(result)
 
 
 def ensure_node[T](value: Node[T] | HasNode[T] | Scalar) -> Node[T]:
@@ -524,7 +509,7 @@ class timeseries_constant[T](Node[T]):
     @property
     def output_axes(self) -> tuple[Axis, ...]:
         """Return ``(Axis("time", DOMAIN),)`` — this node carries a time axis."""
-        return (_TIME_AXIS,)
+        return (TIME_AXIS,)
 
     def __repr__(self) -> str:
         """Return a round-trippable SSA representation of the node."""
@@ -544,7 +529,7 @@ class timeseries_placeholder[T](Node[T]):
     @property
     def output_axes(self) -> tuple[Axis, ...]:
         """Return ``(Axis("time", DOMAIN),)`` — this node carries a time axis."""
-        return (_TIME_AXIS,)
+        return (TIME_AXIS,)
 
     def __repr__(self) -> str:
         """Return a round-trippable SSA representation of the node."""
@@ -567,7 +552,7 @@ class BinaryOp[T](Node[T]):
     @property
     def output_axes(self) -> tuple[Axis, ...]:
         """Return the union of the left and right operand axes."""
-        return _union_axes(self.left.output_axes, self.right.output_axes)
+        return union_axes(self.left.output_axes, self.right.output_axes)
 
 
 class UnaryOp[T](Node[T]):
@@ -778,7 +763,7 @@ class where[C, T](Node[T]):
     @property
     def output_axes(self) -> tuple[Axis, ...]:
         """Return the union of condition, then, and otherwise axes."""
-        return _union_axes(self.condition.output_axes, self.then.output_axes, self.otherwise.output_axes)
+        return union_axes(self.condition.output_axes, self.then.output_axes, self.otherwise.output_axes)
 
     def __repr__(self) -> str:
         """Return a round-trippable SSA representation of the node."""
@@ -807,7 +792,7 @@ class MultiClauseOp[C, T](Node[T]):
     def output_axes(self) -> tuple[Axis, ...]:
         """Return the union of all clause condition, clause value, and default axes."""
         clause_seqs = [ax for cond, val in self.clauses for ax in (cond.output_axes, val.output_axes)]
-        return _union_axes(*clause_seqs, self.default_value.output_axes)
+        return union_axes(*clause_seqs, self.default_value.output_axes)
 
 
 class multi_clause_where[C, T](MultiClauseOp[C, T]):
@@ -1254,7 +1239,7 @@ class function_call[T](Node[T]):
     @property
     def output_axes(self) -> tuple[Axis, ...]:
         """Return the union of all input axes (conservative)."""
-        return _union_axes(*(a.output_axes for a in self.args), *(v.output_axes for v in self.kwargs.values()))
+        return union_axes(*(a.output_axes for a in self.args), *(v.output_axes for v in self.kwargs.values()))
 
     def __repr__(self) -> str:
         """Return a round-trippable SSA representation of the node."""

--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -995,7 +995,7 @@ class ProjectionOp[T](Node[T]):
 
     Args:
         node: Input tensor.
-        axis: The semantic :class:`~civic_digital_twins.dt_model.model.axis.Axis`
+        axis: The semantic :class:`~civic_digital_twins.dt_model.axes.Axis`
             along which to reduce (e.g. ``Axis("time", DOMAIN)``).
         name: Optional node name for debugging.
     """
@@ -1021,7 +1021,7 @@ class project_using_sum[T](ProjectionOp[T]):
 
     Args:
         node: Input tensor.
-        axis: Semantic :class:`~civic_digital_twins.dt_model.model.axis.Axis`
+        axis: Semantic :class:`~civic_digital_twins.dt_model.axes.Axis`
             along which to sum (e.g. ``Axis("time", DOMAIN)``).
     """
 

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -25,13 +25,10 @@ from typing import (
 
 import numpy as np
 
-from ...axes import DOMAIN, Axis
+from ...axes import TIME_AXIS
 from .. import compileflags
 from ..frontend import graph
 from . import numpy_ast
-
-_TIME_AXIS = Axis("time", DOMAIN)
-"""The only axis the numpybackend currently supports for ProjectionOp."""
 
 # Type aliases for operation function signatures
 type _BinaryOpFunc = Callable[[np.ndarray, np.ndarray], np.ndarray]
@@ -611,9 +608,9 @@ def _eval_projection_op(state: State, node: graph.Node) -> np.ndarray:
     so that a future second DOMAIN axis cannot silently produce wrong results.
     """
     node = cast(graph.ProjectionOp, node)
-    if node.axis != _TIME_AXIS:
+    if node.axis != TIME_AXIS:
         raise UnsupportedOperation(
-            f"executor: numpybackend only supports projection along {_TIME_AXIS!r}; got {node.axis!r}"
+            f"executor: numpybackend only supports projection along {TIME_AXIS!r}; got {node.axis!r}"
         )
     operand = state.get_node_value(node.node)
     if isinstance(node, graph.project_using_quantile):

--- a/civic_digital_twins/dt_model/engine/numpybackend/numpy_ast.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/numpy_ast.py
@@ -15,11 +15,8 @@ import ast
 
 import numpy as np
 
-from ...axes import DOMAIN, Axis
+from ...axes import TIME_AXIS
 from ..frontend import graph
-
-_TIME_AXIS = Axis("time", DOMAIN)
-"""The only axis the numpybackend currently supports for ProjectionOp."""
 
 
 class UnsupportedNodeArguments(Exception):
@@ -93,9 +90,9 @@ def _np_attr_name(name: str) -> ast.expr:
 
 
 def _axis_as_tuple(axis: graph.Axis) -> tuple[int, ...]:
-    if axis != _TIME_AXIS:
+    if axis != TIME_AXIS:
         raise UnsupportedNodeArguments(
-            f"numpy_ast: numpybackend only supports projection along {_TIME_AXIS!r}; got {axis!r}"
+            f"numpy_ast: numpybackend only supports projection along {TIME_AXIS!r}; got {axis!r}"
         )
     return (-1,)  # CDT convention: time axis always occupies the last numpy dimension
 

--- a/civic_digital_twins/dt_model/graph.py
+++ b/civic_digital_twins/dt_model/graph.py
@@ -9,7 +9,9 @@ intended for use in model definitions.  Import it as::
     smoothed = TimeseriesIndex("smoothed", graph.function_call("smooth", demand_ts))
 
 The raw engine path (``dt_model.engine.frontend.graph``) remains available
-for engine-level work (DAG construction, backends, debugging).
+for engine-level work (DAG construction, backends, debugging).  (See the
+README's "Conceptual Overview" for the module-role convention behind this
+layout.)
 """
 # SPDX-License-Identifier: Apache-2.0
 

--- a/civic_digital_twins/dt_model/model/__init__.py
+++ b/civic_digital_twins/dt_model/model/__init__.py
@@ -1,7 +1,7 @@
 """Model and index types for digital twin models."""
 # SPDX-License-Identifier: Apache-2.0
 
-from .axis import DOMAIN, ENSEMBLE, PARAMETER, Axis, AxisRole
+from ..axes import DOMAIN, ENSEMBLE, PARAMETER, Axis, AxisRole
 from .contracts import define, expose, functions, inputs, outputs
 from .index import (
     CategoricalIndex,

--- a/civic_digital_twins/dt_model/model/axis.py
+++ b/civic_digital_twins/dt_model/model/axis.py
@@ -1,7 +1,0 @@
-"""Axis identity: role constants and the Axis class."""
-
-# SPDX-License-Identifier: Apache-2.0
-
-from ..axes import DOMAIN, ENSEMBLE, PARAMETER, Axis, AxisRole
-
-__all__ = ["AxisRole", "DOMAIN", "PARAMETER", "ENSEMBLE", "Axis"]

--- a/civic_digital_twins/dt_model/model/index.py
+++ b/civic_digital_twins/dt_model/model/index.py
@@ -13,11 +13,8 @@ from typing import Any, Protocol, cast, runtime_checkable
 
 import numpy as np
 
+from ..axes import TIME_AXIS, Axis
 from ..engine.frontend import graph
-from .axis import DOMAIN, Axis
-
-_TIME_AXIS: Axis = Axis("time", DOMAIN)
-"""Default axis for time-indexed reduction operations."""
 
 
 @runtime_checkable
@@ -194,7 +191,7 @@ class GenericIndex(ABC):
     # Reduction operators
     # ------------------------------------------------------------------
 
-    def sum(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def sum(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that sums this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``, which sums across the
@@ -207,7 +204,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_sum(self.node, axis)
 
-    def mean(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def mean(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that averages this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -215,7 +212,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_mean(self.node, axis)
 
-    def min(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def min(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that computes the minimum of this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -223,7 +220,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_min(self.node, axis)
 
-    def max(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def max(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that computes the maximum of this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -231,7 +228,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_max(self.node, axis)
 
-    def std(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def std(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that computes the standard deviation of this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -239,7 +236,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_std(self.node, axis)
 
-    def var(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def var(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that computes the variance of this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -247,7 +244,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_var(self.node, axis)
 
-    def median(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def median(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that computes the median of this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -255,7 +252,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_median(self.node, axis)
 
-    def prod(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def prod(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that computes the product of this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -263,7 +260,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_prod(self.node, axis)
 
-    def any(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def any(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that tests if any elements of this index are True over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -271,7 +268,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_any(self.node, axis)
 
-    def all(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def all(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that tests if all elements of this index are True over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -279,7 +276,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_all(self.node, axis)
 
-    def count_nonzero(self, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def count_nonzero(self, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that counts non-zero elements of this index over the given axis.
 
         The default axis is ``Axis("time", DOMAIN)``; the reduced axis is
@@ -287,7 +284,7 @@ class GenericIndex(ABC):
         """
         return graph.project_using_count_nonzero(self.node, axis)
 
-    def quantile(self, q: float, axis: Axis = _TIME_AXIS) -> graph.Node:
+    def quantile(self, q: float, axis: Axis = TIME_AXIS) -> graph.Node:
         """Return a graph node that computes the quantile of this index over the given axis.
 
         Args:

--- a/civic_digital_twins/dt_model/simulation/__init__.py
+++ b/civic_digital_twins/dt_model/simulation/__init__.py
@@ -1,6 +1,7 @@
 """Scenario-based simulation and evaluation of digital twin models."""
 # SPDX-License-Identifier: Apache-2.0
 
+from .axis_layout import AxisLayout
 from .ensemble import (
     AxisEnsemble,
     BatchDrawable,
@@ -30,6 +31,7 @@ from .scenario import Scenario
 __all__ = [
     "AsyncEvaluationHandle",
     "AxisEnsemble",
+    "AxisLayout",
     "BatchDrawable",
     "CrossProductEnsemble",
     "DistributionEnsemble",

--- a/civic_digital_twins/dt_model/simulation/axis_layout.py
+++ b/civic_digital_twins/dt_model/simulation/axis_layout.py
@@ -1,0 +1,487 @@
+"""Axis layout management for evaluation results.
+
+An :class:`AxisLayout` maps each semantic :class:`~dt_model.axes.Axis` to its
+numpy dimension position and size in a result array.  It is the single owner
+of the layout logic previously spread across ``evaluation.py`` (construction,
+contraction, domain dropping), ``handle.py`` (merge signature validation,
+axis growth), and ``runner.py`` (serialization).
+
+Layout invariant
+----------------
+Result dimensions are ordered by role: all PARAMETER axes first, then all
+ENSEMBLE axes, then all DOMAIN axes.  The constructor enforces this grouping,
+turning what used to be scattered index arithmetic into a construction-time
+invariant.
+
+The class also provides *leading-array primitives* — pure shape arithmetic
+over the leading ``(*PARAMETER, *ENSEMBLE)`` dimensions of value arrays
+(prepend, broadcast, flatten, gather).  This module depends only on the axis
+vocabulary and numpy; the node-aware guarded-region operations built on top
+of these primitives live in :mod:`~simulation.region_execution`.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Container, Iterable, Mapping
+from typing import Any
+
+import numpy as np
+
+from ..axes import DOMAIN, ENSEMBLE, PARAMETER, Axis, AxisRole
+
+__all__ = ["AxisLayout"]
+
+_ROLE_RANK: dict[AxisRole, int] = {PARAMETER: 0, ENSEMBLE: 1, DOMAIN: 2}
+"""Canonical role ordering of result dimensions."""
+
+
+class AxisLayout:
+    """Immutable mapping from semantic axes to numpy dimension positions and sizes.
+
+    Positions are implicit: the *entries* iterable lists ``(axis, size)``
+    pairs in dimension order, so the axis at index ``i`` occupies numpy
+    dimension ``i``.
+
+    Parameters
+    ----------
+    entries:
+        ``(axis, size)`` pairs in dimension order.
+
+    Raises
+    ------
+    ValueError
+        If two axes share a name (names are globally unique within a
+        layout, across roles), if an axis has a role other than PARAMETER,
+        ENSEMBLE, or DOMAIN, if the roles are not grouped in canonical
+        order (PARAMETER, then ENSEMBLE, then DOMAIN), or if a size is not
+        a positive integer.
+    """
+
+    __slots__ = ("_axes", "_sizes", "_positions")
+
+    def __init__(self, entries: Iterable[tuple[Axis, int]]) -> None:
+        axes: list[Axis] = []
+        sizes: list[int] = []
+        for ax, size in entries:
+            axes.append(ax)
+            sizes.append(int(size))
+        names = [ax.name for ax in axes]
+        if len(set(names)) != len(names):
+            raise ValueError(f"AxisLayout: duplicate axis names in {names}.")
+        ranks: list[int] = []
+        for ax in axes:
+            rank = _ROLE_RANK.get(ax.role)
+            if rank is None:
+                raise ValueError(
+                    f"AxisLayout: unsupported role {ax.role!r} for axis {ax.name!r}; "
+                    f"expected one of {sorted(_ROLE_RANK)}."
+                )
+            ranks.append(rank)
+        if any(ranks[i] > ranks[i + 1] for i in range(len(ranks) - 1)):
+            raise ValueError(
+                "AxisLayout: axes must be grouped by role in canonical order "
+                f"(PARAMETER, ENSEMBLE, DOMAIN); got {[ax.role for ax in axes]}."
+            )
+        if any(size <= 0 for size in sizes):
+            raise ValueError(f"AxisLayout: sizes must be positive; got {sizes}.")
+        self._axes = tuple(axes)
+        self._sizes = tuple(sizes)
+        self._positions = {ax: i for i, ax in enumerate(axes)}
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        parameters: Iterable[tuple[Axis, int]] = (),
+        ensemble: Iterable[tuple[Axis, int]] = (),
+        domain: Iterable[tuple[Axis, int]] = (),
+    ) -> AxisLayout:
+        """Build a layout from role groups, enforcing the canonical ordering.
+
+        Parameters
+        ----------
+        parameters:
+            PARAMETER ``(axis, size)`` pairs (named axes before anonymous
+            ones, in caller order).
+        ensemble:
+            ENSEMBLE ``(axis, size)`` pairs.
+        domain:
+            DOMAIN ``(axis, size)`` pairs.
+        """
+        return cls((*parameters, *ensemble, *domain))
+
+    @classmethod
+    def from_positions(cls, positions: Mapping[Axis, int], sizes: Mapping[Axis, int]) -> AxisLayout:
+        """Build a layout from explicit position and size mappings.
+
+        Parameters
+        ----------
+        positions:
+            Maps each axis to its dimension position.  Positions must be
+            exactly ``0..n-1`` with no gaps.
+        sizes:
+            Maps each axis to its size.
+
+        Raises
+        ------
+        ValueError
+            If positions are not contiguous starting at zero.
+        KeyError
+            If an axis in *positions* is missing from *sizes*.
+        """
+        ordered = sorted(positions.items(), key=lambda item: item[1])
+        if [pos for _, pos in ordered] != list(range(len(ordered))):
+            raise ValueError(f"AxisLayout: positions must be contiguous 0..n-1; got {dict(positions)}.")
+        return cls((ax, sizes[ax]) for ax, _ in ordered)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> AxisLayout:
+        """Reconstruct a layout from the dict produced by :meth:`to_dict`.
+
+        The format matches the persisted :class:`~simulation.runner.ModelOutput`
+        payload: ``axis_layout`` is a list of ``[name, role, position]`` rows
+        and ``axis_sizes`` maps ``"name:role"`` keys to sizes.
+        """
+        positions = {Axis(row[0], row[1]): int(row[2]) for row in data["axis_layout"]}
+        sizes: dict[Axis, int] = {}
+        for key, size in data["axis_sizes"].items():
+            ax_name, ax_role = key.split(":", 1)
+            sizes[Axis(ax_name, ax_role)] = int(size)
+        return cls.from_positions(positions, sizes)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    @property
+    def axes(self) -> tuple[Axis, ...]:
+        """The axes in dimension order."""
+        return self._axes
+
+    @property
+    def entries(self) -> tuple[tuple[Axis, int], ...]:
+        """``(axis, size)`` pairs in dimension order."""
+        return tuple(zip(self._axes, self._sizes))
+
+    def __len__(self) -> int:
+        """Return the number of dimensions."""
+        return len(self._axes)
+
+    def __contains__(self, axis: Axis) -> bool:
+        """Return True when *axis* (by value equality) is in the layout."""
+        return axis in self._positions
+
+    def position_of(self, axis: Axis) -> int:
+        """Return the dimension position of *axis* (KeyError if absent)."""
+        return self._positions[axis]
+
+    def size_of(self, axis: Axis) -> int:
+        """Return the size of *axis* (KeyError if absent)."""
+        return self._sizes[self._positions[axis]]
+
+    def find_axis(self, name: str, role: AxisRole | None = None) -> Axis | None:
+        """Return the axis named *name* (optionally matching *role*), or None."""
+        for ax in self._axes:
+            if ax.name == name and (role is None or ax.role == role):
+                return ax
+        return None
+
+    def axes_by_role(self, role: AxisRole) -> tuple[tuple[Axis, int], ...]:
+        """Return ``(axis, position)`` pairs with the given role, in position order."""
+        return tuple((ax, pos) for pos, ax in enumerate(self._axes) if ax.role == role)
+
+    @property
+    def positions(self) -> dict[Axis, int]:
+        """A fresh ``{axis: position}`` dict (dimension order preserved)."""
+        return dict(self._positions)
+
+    @property
+    def sizes(self) -> dict[Axis, int]:
+        """A fresh ``{axis: size}`` dict (dimension order preserved)."""
+        return {ax: size for ax, size in zip(self._axes, self._sizes)}
+
+    # ------------------------------------------------------------------
+    # Derived shapes
+    # ------------------------------------------------------------------
+
+    @property
+    def n_params(self) -> int:
+        """Number of PARAMETER dimensions."""
+        return sum(1 for ax in self._axes if ax.role == PARAMETER)
+
+    @property
+    def n_ensemble(self) -> int:
+        """Number of ENSEMBLE dimensions."""
+        return sum(1 for ax in self._axes if ax.role == ENSEMBLE)
+
+    @property
+    def n_domain(self) -> int:
+        """Number of DOMAIN dimensions."""
+        return sum(1 for ax in self._axes if ax.role == DOMAIN)
+
+    @property
+    def n_leading(self) -> int:
+        """Number of leading (PARAMETER + ENSEMBLE) dimensions."""
+        return self.n_params + self.n_ensemble
+
+    @property
+    def full_shape(self) -> tuple[int, ...]:
+        """Shape of a fully-broadcast result array in dimension order."""
+        return self._sizes
+
+    @property
+    def leading_axes(self) -> tuple[Axis, ...]:
+        """The PARAMETER and ENSEMBLE axes, in dimension order."""
+        return self._axes[: self.n_leading]
+
+    @property
+    def leading_shape(self) -> tuple[int, ...]:
+        """Sizes of the leading (PARAMETER + ENSEMBLE) dimensions."""
+        return self._sizes[: self.n_leading]
+
+    @property
+    def leading_size(self) -> int:
+        """Total number of leading-axis coordinates (1 when there are none)."""
+        shape = self.leading_shape
+        return int(np.prod(shape, dtype=np.int64)) if shape else 1
+
+    def compatible_with(self, shape: tuple[int, ...]) -> bool:
+        """Return True when *shape* is broadcast-compatible with this layout.
+
+        A compatible shape has exactly one dimension per layout axis, each
+        either 1 (the value does not vary along that axis) or the axis size.
+        """
+        if len(shape) != len(self._axes):
+            return False
+        return all(dim in {1, size} for dim, size in zip(shape, self._sizes))
+
+    # ------------------------------------------------------------------
+    # Leading-array primitives
+    #
+    # Pure shape arithmetic over arrays whose first n_leading dimensions
+    # map onto the leading (PARAMETER + ENSEMBLE) axes.  Trailing (DOMAIN)
+    # dimensions are always preserved untouched.
+    # ------------------------------------------------------------------
+
+    def spans_leading(self, shape: tuple[int, ...]) -> bool:
+        """Return True when *shape* has explicit leading dimensions.
+
+        The shape must have at least ``n_leading`` dimensions and each of
+        the first ``n_leading`` must be 1 or the corresponding axis size.
+        """
+        leading_shape = self.leading_shape
+        return len(shape) >= self.n_leading and all(shape[i] in {1, leading_shape[i]} for i in range(self.n_leading))
+
+    def prepend_leading(self, arr: np.ndarray) -> np.ndarray:
+        """Return *arr* with ``n_leading`` singleton dimensions prepended."""
+        return arr.reshape((1,) * self.n_leading + arr.shape)
+
+    def broadcast_leading(self, arr: np.ndarray) -> np.ndarray:
+        """Broadcast the first ``n_leading`` dims of *arr* to the leading shape.
+
+        Trailing dimensions are preserved untouched.
+
+        Raises
+        ------
+        ValueError
+            If *arr* does not span the leading layout (:meth:`spans_leading`).
+        """
+        if not self.spans_leading(arr.shape):
+            raise ValueError(
+                f"broadcast_leading: shape {arr.shape} does not span the "
+                f"leading layout {self.leading_shape} (each leading dim must "
+                f"be 1 or the axis size)."
+            )
+        return np.broadcast_to(arr, self.leading_shape + arr.shape[self.n_leading :])
+
+    def flatten_leading(self, arr: np.ndarray) -> np.ndarray:
+        """Reshape *arr* to ``(leading_size, *trailing)``.
+
+        Raises
+        ------
+        ValueError
+            If the leading dimensions of *arr* are not exactly the leading
+            shape (broadcast first with :meth:`broadcast_leading` when
+            needed).  A plain reshape could silently scramble coordinates
+            whenever the element counts happen to match, so the precondition
+            is checked explicitly.
+        """
+        if arr.shape[: self.n_leading] != self.leading_shape:
+            raise ValueError(
+                f"flatten_leading: shape {arr.shape} does not start with the "
+                f"full leading shape {self.leading_shape}; broadcast_leading first."
+            )
+        return arr.reshape((self.leading_size,) + arr.shape[self.n_leading :])
+
+    def unflatten_leading(self, arr: np.ndarray) -> np.ndarray:
+        """Inverse of :meth:`flatten_leading`: restore the leading dimensions.
+
+        Raises
+        ------
+        ValueError
+            If the first dimension of *arr* is not ``leading_size``.
+        """
+        if arr.ndim < 1 or arr.shape[0] != self.leading_size:
+            raise ValueError(
+                f"unflatten_leading: shape {arr.shape} does not start with leading_size {self.leading_size}."
+            )
+        return arr.reshape(self.leading_shape + arr.shape[1:])
+
+    def take_leading(self, arr: np.ndarray, flat_idx: np.ndarray) -> np.ndarray:
+        """Gather flattened leading coordinates of *arr* into a new first axis.
+
+        Equivalent to indexing rows of :meth:`flatten_leading` with
+        *flat_idx*; trailing dimensions are preserved.
+        """
+        return np.take(self.flatten_leading(arr), flat_idx, axis=0)
+
+    # ------------------------------------------------------------------
+    # Signatures (merge compatibility)
+    # ------------------------------------------------------------------
+
+    def role_signature(self, role: AxisRole, *, exclude_name: str | None = None) -> frozenset[tuple[str, int, int]]:
+        """Return a ``{(name, position, size)}`` signature of the axes with *role*.
+
+        Parameters
+        ----------
+        role:
+            The role to include.
+        exclude_name:
+            Optional axis name to leave out (e.g. the axis being grown by a
+            merge, whose size is allowed to differ).
+        """
+        return frozenset(
+            (ax.name, pos, self._sizes[pos])
+            for pos, ax in enumerate(self._axes)
+            if ax.role == role and ax.name != exclude_name
+        )
+
+    def parameter_signature(self) -> frozenset[tuple[str, AxisRole, int, int]]:
+        """Return a ``{(name, role, position, size)}`` signature of all non-ENSEMBLE axes.
+
+        Includes DOMAIN axes so that two layouts only compare equal when
+        their PARAMETER grids *and* domain dimensions match.
+        """
+        return frozenset(
+            (ax.name, ax.role, pos, self._sizes[pos]) for pos, ax in enumerate(self._axes) if ax.role != ENSEMBLE
+        )
+
+    # ------------------------------------------------------------------
+    # Transformations
+    # ------------------------------------------------------------------
+
+    def with_grown_axis(self, name: str, new_size: int) -> AxisLayout:
+        """Return a copy with the axis named *name* resized to *new_size*.
+
+        This is the single primitive behind ENSEMBLE and PARAMETER merge
+        growth (KeyError if no axis has that name).
+        """
+        ax = self.find_axis(name)
+        if ax is None:
+            raise KeyError(f"AxisLayout: no axis named {name!r}.")
+        return AxisLayout((a, new_size if a == ax else size) for a, size in self.entries)
+
+    def with_axis_appended(self, axis: Axis, size: int) -> AxisLayout:
+        """Return a copy with *axis* appended as the last dimension.
+
+        Used to register the DOMAIN time axis once its length is known
+        (post-execution).  The canonical role ordering is re-validated.
+        """
+        return AxisLayout((*self.entries, (axis, size)))
+
+    # ------------------------------------------------------------------
+    # Array operations
+    # ------------------------------------------------------------------
+
+    def contract_ensemble(self, arr: np.ndarray, weights: Mapping[Axis, np.ndarray]) -> np.ndarray:
+        """Contract all ENSEMBLE dimensions of *arr* and return the ``(*P, *D)`` array.
+
+        For each ENSEMBLE axis (in descending position order so earlier
+        squeezes do not shift later positions): if the dimension has size 1
+        the singleton is squeezed away directly; otherwise a weighted average
+        is taken using ``weights[axis]``.
+
+        Raises
+        ------
+        ValueError
+            If *arr* is not compatible with this layout (one dimension per
+            axis, each 1 or the axis size) — averaging positionally over a
+            mismatched array would contract the wrong dimension.
+        """
+        if not self.compatible_with(arr.shape):
+            raise ValueError(f"contract_ensemble: shape {arr.shape} is incompatible with layout {self!r}.")
+        for ax, pos in sorted(self.axes_by_role(ENSEMBLE), key=lambda t: t[1], reverse=True):
+            arr = arr.squeeze(axis=pos) if arr.shape[pos] == 1 else np.average(arr, weights=weights[ax], axis=pos)
+        return arr
+
+    def drop_stray_domain(self, arr: np.ndarray, carried_axes: Container[Axis]) -> np.ndarray:
+        """Drop the DOMAIN dimensions of *arr* that are not in *carried_axes*.
+
+        *arr* must already be ENSEMBLE-contracted (shape ``(*P, *D)``).  The
+        result carries exactly the PARAMETER dimensions plus the DOMAIN
+        dimensions listed in *carried_axes*.
+
+        Raises
+        ------
+        ValueError
+            If *arr* is not ENSEMBLE-contracted (its rank must be
+            ``n_params + n_domain`` — on a full-layout array the positional
+            arithmetic would treat ENSEMBLE dimensions as DOMAIN ones), or
+            if a non-carried DOMAIN dimension has size greater than 1: the
+            value varies along an axis its node does not declare in
+            ``output_axes``, so the declared and actual axes disagree.
+            Dropping data or silently returning an undeclared dimension
+            would both be wrong; the inconsistency is reported instead.
+        """
+        n_params = self.n_params
+        if arr.ndim != n_params + self.n_domain:
+            raise ValueError(
+                f"drop_stray_domain: shape {arr.shape} is not ENSEMBLE-contracted "
+                f"(expected {n_params + self.n_domain} dims: {n_params} PARAMETER + "
+                f"{self.n_domain} DOMAIN)."
+            )
+        stray: list[int] = []
+        for i, (ax, _) in enumerate(self.axes_by_role(DOMAIN)):
+            if ax in carried_axes:
+                continue
+            dim = n_params + i
+            if arr.shape[dim] != 1:
+                raise ValueError(
+                    f"drop_stray_domain: DOMAIN axis {ax.name!r} is not carried by the "
+                    f"node's output_axes, but the value varies along it "
+                    f"(size {arr.shape[dim]}); declared and actual axes disagree."
+                )
+            stray.append(dim)
+        return np.squeeze(arr, axis=tuple(stray)) if stray else arr
+
+    # ------------------------------------------------------------------
+    # Serialization and dunder support
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the JSON-friendly dict format used by :meth:`from_dict`."""
+        return {
+            "axis_layout": [[ax.name, ax.role, pos] for pos, ax in enumerate(self._axes)],
+            "axis_sizes": {f"{ax.name}:{ax.role}": size for ax, size in zip(self._axes, self._sizes)},
+        }
+
+    def __eq__(self, other: object) -> bool:
+        """Return True when both layouts have equal entries in the same order."""
+        if isinstance(other, AxisLayout):
+            return self.entries == other.entries
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        """Hash based on the ordered entries."""
+        return hash(self.entries)
+
+    def __repr__(self) -> str:
+        """Return a concise string representation."""
+        inner = ", ".join(f"{ax!r}: {size}" for ax, size in self.entries)
+        return f"AxisLayout({inner})"

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -19,8 +19,21 @@ from ..model.index import (
     GenericIndex,
     Index,
 )
+from .axis_layout import AxisLayout
 from .plan import EvaluationPlan
 from .scenario import Scenario
+
+
+def _grown_axes(axes: tuple[Axis, ...], sizes: tuple[int, ...], axis_name: str, new_size: int) -> tuple[Axis, ...]:
+    """Return *axes* with the named axis regenerated at *new_size* (position preserved).
+
+    Thin wrapper around :meth:`~simulation.axis_layout.AxisLayout.with_grown_axis`
+    so growing a :class:`FrozenEnsemble` axis goes through the same primitive
+    as the merge functions in ``handle.py``, rather than hand-rolling a fresh
+    ``Axis(name, ENSEMBLE)``.
+    """
+    return AxisLayout.build(ensemble=list(zip(axes, sizes))).with_grown_axis(axis_name, new_size).axes
+
 
 WeightedScenario = tuple[float, dict[GenericIndex, Any]]
 """A weighted scenario maps each abstract index to a concrete value.
@@ -208,9 +221,9 @@ class FrozenEnsemble:
             idx: np.concatenate([self._cached_assignments[idx], other._cached_assignments[idx]])
             for idx in self._cached_assignments
         }
-        new_ax = Axis(self._axes[0].name, ENSEMBLE)
+        new_axes = _grown_axes(self._axes, (S1,), self._axes[0].name, S1 + S2)
         return FrozenEnsemble(
-            (new_ax,),
+            new_axes,
             (merged_weights,),
             merged_assignments,
         )
@@ -235,8 +248,8 @@ class FrozenEnsemble:
         S2 = other._weights[0].size
         alpha = S1 / (S1 + S2)
         merged_weights = np.concatenate([self._weights[ax_idx] * alpha, other._weights[0] * (1.0 - alpha)])
-        new_ax = Axis(axis_name, ENSEMBLE)
-        new_axes = tuple(new_ax if i == ax_idx else ax for i, ax in enumerate(self._axes))
+        sizes = tuple(w.size for w in self._weights)
+        new_axes = _grown_axes(self._axes, sizes, axis_name, S1 + S2)
         new_weights = tuple(merged_weights if i == ax_idx else w for i, w in enumerate(self._weights))
         M = len(self._axes)
         merged_assignments: dict[GenericIndex, np.ndarray] = {}
@@ -268,8 +281,8 @@ class FrozenEnsemble:
         """
         ax_idx = next(i for i, ax in enumerate(self._axes) if ax.name == axis_name)
         S2 = other._weights[0].size
-        new_ax = Axis(axis_name, ENSEMBLE)
-        new_axes = tuple(new_ax if i == ax_idx else ax for i, ax in enumerate(self._axes))
+        sizes = tuple(w.size for w in self._weights)
+        new_axes = _grown_axes(self._axes, sizes, axis_name, S2)
         new_weights = tuple(other._weights[0] if i == ax_idx else w for i, w in enumerate(self._weights))
         M = len(self._axes)
         merged_assignments: dict[GenericIndex, np.ndarray] = {}

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -10,7 +10,7 @@ from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
-from ..model.axis import ENSEMBLE, Axis
+from ..axes import ENSEMBLE, Axis
 from ..model.index import (
     CategoricalIndex,
     ConditionalCategoricalIndex,

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -34,16 +34,11 @@ class EvaluationResult:
         The executor state after evaluation.
     axis_layout:
         The :class:`~simulation.axis_layout.AxisLayout` of result arrays.
-        A ``{Axis: position}`` dict (with sizes in *axis_sizes*) is also
-        accepted transitionally and converted internally.
     parameter_arrays:
         Anonymous PARAMETER-axis arrays from ``parameters=`` (array-valued
         entries only; callable-backed indexes are not included).  Used by
         :meth:`parameter_values_for`.  Empty dict when no anonymous PARAMETER
         axes.
-    axis_sizes:
-        Maps each :class:`~dt_model.axes.Axis` to its size.  Only used (and
-        required) with the transitional dict form of *axis_layout*.
     factorized_weights:
         Per-ENSEMBLE-axis weight vectors.
     named_axis_values:
@@ -54,19 +49,13 @@ class EvaluationResult:
     def __init__(
         self,
         state: executor.State,
-        axis_layout: AxisLayout | dict[Axis, int],
+        axis_layout: AxisLayout,
         parameter_arrays: dict[GenericIndex, np.ndarray],
-        axis_sizes: dict[Axis, int] | None = None,
         factorized_weights: dict[Axis, np.ndarray] | None = None,
         named_axis_values: dict[str, np.ndarray] | None = None,
     ) -> None:
         self._state = state
-        if isinstance(axis_layout, AxisLayout):
-            self._layout = axis_layout
-        else:
-            # Transitional dict form (handle.py, runner.py); to be removed
-            # once all constructors pass an AxisLayout.
-            self._layout = AxisLayout.from_positions(axis_layout, axis_sizes or {})
+        self._layout = axis_layout
         self._parameter_arrays = parameter_arrays
         self._factorized_weights: dict[Axis, np.ndarray] = factorized_weights or {}
         self._named_axis_values: dict[str, np.ndarray] = named_axis_values or {}
@@ -79,20 +68,6 @@ class EvaluationResult:
     def layout(self) -> AxisLayout:
         """The :class:`~simulation.axis_layout.AxisLayout` of result arrays."""
         return self._layout
-
-    # Transitional views, kept only for one lingering test assertion
-    # (test_evaluation_handle.py); to be deleted at step 12 together with the
-    # dict-accepting constructor form, once that assertion is migrated.
-    # _axis_layout has no readers left (handle.py and runner.py are fully
-    # migrated onto .layout) — excluded from coverage until its step-12 removal.
-
-    @property
-    def _axis_layout(self) -> dict[Axis, int]:  # pragma: no cover
-        return self._layout.positions
-
-    @property
-    def _axis_sizes(self) -> dict[Axis, int]:
-        return self._layout.sizes
 
     @property
     def weights(self) -> np.ndarray:

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import numpy as np
 
+from ..axes import DOMAIN, ENSEMBLE, PARAMETER, Axis
 from ..engine.frontend import graph, linearize
 from ..engine.numpybackend import executor
-from ..model.axis import DOMAIN, ENSEMBLE, PARAMETER, Axis
 from ..model.index import GenericIndex
 from ..model.model import Model
 from ..model.model_variant import ModelVariant
@@ -31,7 +31,7 @@ class EvaluationResult:
     state:
         The executor state after evaluation.
     axis_layout:
-        Maps each :class:`~dt_model.model.axis.Axis` to its numpy dimension
+        Maps each :class:`~dt_model.axes.Axis` to its numpy dimension
         position in result arrays.
     parameter_arrays:
         Anonymous PARAMETER-axis arrays from ``parameters=`` (array-valued
@@ -39,7 +39,7 @@ class EvaluationResult:
         :meth:`parameter_values_for`.  Empty dict when no anonymous PARAMETER
         axes.
     axis_sizes:
-        Maps each :class:`~dt_model.model.axis.Axis` to its size.
+        Maps each :class:`~dt_model.axes.Axis` to its size.
     factorized_weights:
         Per-ENSEMBLE-axis weight vectors.
     named_axis_values:

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -7,14 +7,16 @@ from typing import Any
 
 import numpy as np
 
-from ..axes import DOMAIN, ENSEMBLE, PARAMETER, Axis
+from ..axes import PARAMETER, TIME_AXIS, Axis
 from ..engine.frontend import graph, linearize
 from ..engine.numpybackend import executor
 from ..model.index import GenericIndex
 from ..model.model import Model
 from ..model.model_variant import ModelVariant
+from .axis_layout import AxisLayout
 from .ensemble import AxisEnsemble
 from .plan import EvaluationPlan, Region, RegionGuard
+from .region_execution import RegionArrayOps
 from .scenario import Scenario
 
 __all__ = ["EvaluationResult", "Evaluation"]
@@ -31,15 +33,17 @@ class EvaluationResult:
     state:
         The executor state after evaluation.
     axis_layout:
-        Maps each :class:`~dt_model.axes.Axis` to its numpy dimension
-        position in result arrays.
+        The :class:`~simulation.axis_layout.AxisLayout` of result arrays.
+        A ``{Axis: position}`` dict (with sizes in *axis_sizes*) is also
+        accepted transitionally and converted internally.
     parameter_arrays:
         Anonymous PARAMETER-axis arrays from ``parameters=`` (array-valued
         entries only; callable-backed indexes are not included).  Used by
         :meth:`parameter_values_for`.  Empty dict when no anonymous PARAMETER
         axes.
     axis_sizes:
-        Maps each :class:`~dt_model.axes.Axis` to its size.
+        Maps each :class:`~dt_model.axes.Axis` to its size.  Only used (and
+        required) with the transitional dict form of *axis_layout*.
     factorized_weights:
         Per-ENSEMBLE-axis weight vectors.
     named_axis_values:
@@ -50,22 +54,42 @@ class EvaluationResult:
     def __init__(
         self,
         state: executor.State,
-        axis_layout: dict[Axis, int],
+        axis_layout: AxisLayout | dict[Axis, int],
         parameter_arrays: dict[GenericIndex, np.ndarray],
         axis_sizes: dict[Axis, int] | None = None,
         factorized_weights: dict[Axis, np.ndarray] | None = None,
         named_axis_values: dict[str, np.ndarray] | None = None,
     ) -> None:
         self._state = state
-        self._axis_layout = axis_layout
+        if isinstance(axis_layout, AxisLayout):
+            self._layout = axis_layout
+        else:
+            # Transitional dict form (handle.py, runner.py); to be removed
+            # once all constructors pass an AxisLayout.
+            self._layout = AxisLayout.from_positions(axis_layout, axis_sizes or {})
         self._parameter_arrays = parameter_arrays
-        self._axis_sizes: dict[Axis, int] = axis_sizes or {}
         self._factorized_weights: dict[Axis, np.ndarray] = factorized_weights or {}
         self._named_axis_values: dict[str, np.ndarray] = named_axis_values or {}
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+
+    @property
+    def layout(self) -> AxisLayout:
+        """The :class:`~simulation.axis_layout.AxisLayout` of result arrays."""
+        return self._layout
+
+    # Transitional views over the layout, kept while handle.py and runner.py
+    # still consume the dict form; to be removed at the end of the refactor.
+
+    @property
+    def _axis_layout(self) -> dict[Axis, int]:
+        return self._layout.positions
+
+    @property
+    def _axis_sizes(self) -> dict[Axis, int]:
+        return self._layout.sizes
 
     @property
     def weights(self) -> np.ndarray:
@@ -110,13 +134,7 @@ class EvaluationResult:
     @property
     def full_shape(self) -> tuple[int, ...]:
         """Shape of a fully-broadcast result array in axis-layout order."""
-        n_dims = len(self._axis_layout)
-        if n_dims == 0:
-            return ()
-        shape: list[int] = [0] * n_dims
-        for ax, pos in self._axis_layout.items():
-            shape[pos] = self._axis_sizes[ax]
-        return tuple(shape)
+        return self._layout.full_shape
 
     def __getitem__(self, index: GenericIndex) -> np.ndarray:
         """Return the result array for *index*."""
@@ -125,24 +143,13 @@ class EvaluationResult:
     def _contract_ensemble(self, index: GenericIndex) -> np.ndarray:
         """Contract all ENSEMBLE axes and return the ``(*P, *D)`` array.
 
-        For each ENSEMBLE axis (in descending position order so earlier
-        squeezes do not shift later positions): if the axis size is 1 the
-        singleton is squeezed away directly; otherwise a weighted average is
-        taken.  The result shape is ``(*PARAMETER, *DOMAIN)`` — all DOMAIN
-        dimensions are preserved regardless of size.
+        Delegates to :meth:`~simulation.axis_layout.AxisLayout.contract_ensemble`
+        with this result's factorized weights.  The result shape is
+        ``(*PARAMETER, *DOMAIN)`` — all DOMAIN dimensions are preserved
+        regardless of size.
         """
         arr = np.asarray(self._state.values[index.node])
-        for ax, pos in sorted(
-            ((a, p) for a, p in self._axis_layout.items() if a.role == ENSEMBLE),
-            key=lambda t: t[1],
-            reverse=True,
-        ):
-            arr = (
-                arr.squeeze(axis=pos)
-                if arr.shape[pos] == 1
-                else np.average(arr, weights=self._factorized_weights[ax], axis=pos)
-            )
-        return arr
+        return self._layout.contract_ensemble(arr, self._factorized_weights)
 
     def expected_value(self, index: GenericIndex) -> np.ndarray:
         """Return the typed result for *index* after contracting ENSEMBLE axes.
@@ -162,19 +169,7 @@ class EvaluationResult:
         you need the full ``(*PARAMETER, *DOMAIN)`` shape.
         """
         arr = self._contract_ensemble(index)
-        n_params = sum(1 for ax in self._axis_layout if ax.role == PARAMETER)
-        domain_axes = sorted(
-            [(ax, pos) for ax, pos in self._axis_layout.items() if ax.role == DOMAIN],
-            key=lambda t: t[1],
-        )
-        stray = tuple(
-            n_params + i
-            for i, (ax, _) in enumerate(domain_axes)
-            if ax not in index.output_axes and arr.shape[n_params + i] == 1
-        )
-        if stray:
-            arr = np.squeeze(arr, axis=stray)
-        return arr
+        return self._layout.drop_stray_domain(arr, index.output_axes)
 
 
 class Evaluation:
@@ -573,8 +568,8 @@ class Evaluation:
         k = len(parameter_axes)  # named PARAMETER axes
         m = len(array_params)  # anonymous PARAMETER axes
         n_params = k + m
-        axis_layout: dict[Axis, int] = {}
-        axis_sizes: dict[Axis, int] = {}
+        param_axis_entries: list[tuple[Axis, int]] = []  # named axes first, then anonymous
+        ens_axis_entries: list[tuple[Axis, int]] = []
         factorized_weights: dict[Axis, np.ndarray] = {}
         c_subs: dict[graph.Node, np.ndarray] = {}
         param_nodes: list[graph.Node] = []  # anonymous array param nodes
@@ -584,9 +579,7 @@ class Evaluation:
         # Build broadcast-ready shaped arrays (singleton at every position except own).
         named_shaped: dict[str, np.ndarray] = {}
         for i, (name, arr) in enumerate(parameter_axes.items()):
-            ax = Axis(name, PARAMETER)
-            axis_layout[ax] = i
-            axis_sizes[ax] = arr.size
+            param_axis_entries.append((Axis(name, PARAMETER), arr.size))
             shape = [1] * k
             shape[i] = arr.size
             named_shaped[name] = arr.reshape(shape)
@@ -622,9 +615,7 @@ class Evaluation:
 
         # Anonymous array PARAMETER axes — positions k..k+m-1.
         for j, (idx, arr) in enumerate(array_params.items()):
-            ax = Axis(getattr(idx, "name", f"param_{k + j}"), PARAMETER)
-            axis_layout[ax] = k + j
-            axis_sizes[ax] = arr.size
+            param_axis_entries.append((Axis(getattr(idx, "name", f"param_{k + j}"), PARAMETER), arr.size))
             shape = [1] * n_params
             shape[k + j] = arr.size
             c_subs[idx.node] = arr.reshape(shape)
@@ -636,9 +627,8 @@ class Evaluation:
         if ensemble is not None:
             ens_assignments = ensemble.assignments()
             n_ensemble = len(ensemble.ensemble_axes)
-            for j, (ax, w) in enumerate(zip(ensemble.ensemble_axes, ensemble.ensemble_weights)):
-                axis_layout[ax] = n_params + j
-                axis_sizes[ax] = w.size
+            for ax, w in zip(ensemble.ensemble_axes, ensemble.ensemble_weights):
+                ens_axis_entries.append((ax, w.size))
                 factorized_weights[ax] = w
             for idx, batched in ens_assignments.items():
                 # Prepend n_params PARAMETER singletons so ENSEMBLE arrays
@@ -675,119 +665,15 @@ class Evaluation:
         if backend is not executor.NumpyBackend:
             raise NotImplementedError(f"Backend {backend!r} is not supported; only NumpyBackend is available.")
 
-        n_full = n_params + n_ensemble
-        n_total = n_full + extra_ts
-
-        # Guarded regions operate over the full leading evaluation layout:
-        # (*PARAMETER, *ENSEMBLE).  The helpers below gather/scatter arbitrary
-        # leading-axis coordinates, so selectors may vary along PARAMETER axes
-        # and ensembles may span multiple ENSEMBLE axes.
-        leading_axes = tuple(ax for ax, pos in sorted(axis_layout.items(), key=lambda item: item[1]) if pos < n_full)
-        leading_shape = tuple(axis_sizes[ax] for ax in leading_axes)
-        n_leading = int(np.prod(leading_shape, dtype=np.int64)) if leading_shape else 1
-
-        def _has_domain_axis(node: graph.Node) -> bool:
-            return any(ax.role == DOMAIN for ax in node.output_axes)
-
-        def _normalise_leading(node: graph.Node, value: Any) -> np.ndarray:
-            """Return *value* with explicit leading singleton axes when needed."""
-            arr = np.asarray(value)
-            if n_full == 0 or isinstance(node, graph.variant_selector):
-                return arr
-            has_domain = _has_domain_axis(node)
-            # A raw DOMAIN-only value, e.g. a timeseries constant with shape (T,),
-            # has no explicit PARAMETER/ENSEMBLE dimensions yet.  Prepend them
-            # even when T accidentally equals a leading-axis size.
-            if has_domain and arr.ndim == len(node.output_axes):
-                return arr.reshape((1,) * n_full + arr.shape)
-            if arr.ndim >= n_full and all(arr.shape[i] in {1, leading_shape[i]} for i in range(n_full)):
-                return arr
-            return arr.reshape((1,) * n_full + arr.shape)
-
-        def _broadcast_to_leading(node: graph.Node, value: Any) -> np.ndarray:
-            """Broadcast *value* to ``leading_shape + trailing_shape``."""
-            arr = _normalise_leading(node, value)
-            if n_full == 0 or isinstance(node, graph.variant_selector):
-                return arr
-            target = tuple(leading_shape[i] if arr.shape[i] == 1 else arr.shape[i] for i in range(n_full))
-            return np.broadcast_to(arr, target + arr.shape[n_full:])
-
-        def _leading_mask(selector_node: graph.Node, selector_value: Any, branch_key: str) -> np.ndarray:
-            """Return a boolean mask over the full ``(*PARAMETER, *ENSEMBLE)`` layout."""
-            sel = _broadcast_to_leading(selector_node, selector_value)
-            if n_full == 0:
-                mask = np.asarray(sel == branch_key)
-                if mask.shape != ():
-                    if any(dim > 1 for dim in mask.shape):
-                        raise NotImplementedError(
-                            "Regional execution does not support selectors with non-singleton DOMAIN axes."
-                        )
-                    # Defensive normalisation: a selector that evaluates to a
-                    # singleton (1,) array (rather than a 0-d scalar) under
-                    # n_full==0 with no timeseries does not arise from any
-                    # supported index/selector construction — scalar selectors
-                    # already yield mask.shape == ().  Reachable only by wrapping
-                    # a scalar in a 1-element array via a custom function_call.
-                    mask = mask.reshape(())  # pragma: no cover
-                return mask
-            trailing = sel.shape[n_full:]
-            if trailing:
-                if any(dim > 1 for dim in trailing):
-                    raise NotImplementedError(
-                        "Regional execution does not support selectors with non-singleton DOMAIN axes."
-                    )
-                sel = sel.reshape(sel.shape[:n_full])
-            return np.broadcast_to(sel == branch_key, leading_shape)
-
-        def _gather_leading(node: graph.Node, value: Any, flat_idx: np.ndarray) -> np.ndarray:
-            """Gather selected leading-axis coordinates into a branch-local first axis."""
-            if n_full == 0 or isinstance(node, graph.variant_selector):
-                return np.asarray(value)
-            arr = _broadcast_to_leading(node, value)
-            flat = arr.reshape((n_leading,) + arr.shape[n_full:])
-            return np.take(flat, flat_idx, axis=0)
-
-        def _branch_fill_value(dtype: np.dtype) -> tuple[np.dtype, Any]:
-            """Return an output dtype and inactive-branch fill value for *dtype*."""
-            if dtype.kind in {"f", "c"}:
-                return dtype, np.nan
-            if dtype.kind == "b":
-                return dtype, False
-            if dtype.kind in {"i", "u"}:
-                return dtype, 0
-            return np.dtype(object), None
-
-        def _scatter_leading(node: graph.Node, value: Any, flat_idx: np.ndarray) -> np.ndarray:
-            """Scatter a branch-local value back into the full leading layout."""
-            arr = np.asarray(value)
-            if n_full == 0 or isinstance(node, graph.variant_selector):
-                return arr
-            k = int(flat_idx.size)
-            if arr.ndim == 0:
-                arr = np.broadcast_to(arr, (k,)).copy()
-            elif arr.shape[0] == 1 and k != 1:  # pragma: no cover
-                arr = np.broadcast_to(arr, (k,) + arr.shape[1:]).copy()
-            elif arr.shape[0] != k:  # pragma: no cover
-                # DOMAIN-only values produced inside the branch (shape (T,)) are
-                # invariant across selected leading coordinates.
-                if _has_domain_axis(node):
-                    arr = np.broadcast_to(arr, (k,) + arr.shape).copy()
-                else:
-                    raise ValueError(
-                        f"Regional scatter for node {getattr(node, 'name', repr(node))!r}: "
-                        f"branch result first dimension {arr.shape[0]} does not match selected size {k}."
-                    )
-            if extra_ts and not _has_domain_axis(node) and arr.ndim == 1:
-                arr = arr.reshape(arr.shape + (1,))
-            out_dtype, fill_value = _branch_fill_value(arr.dtype)
-            full_flat = np.full((n_leading,) + arr.shape[1:], fill_value, dtype=out_dtype)
-            full_flat[flat_idx] = arr.astype(out_dtype, copy=False)
-            return full_flat.reshape(leading_shape + arr.shape[1:])
-
-        def _empty_branch_value() -> np.ndarray:
-            """Create a broadcast-compatible inactive value for an unselected branch."""
-            trailing = (1,) if extra_ts else ()
-            return np.full(leading_shape + trailing, np.nan, dtype=float)
+        # Leading evaluation layout: (*PARAMETER, *ENSEMBLE).  The canonical
+        # role ordering is enforced by the AxisLayout constructor; the DOMAIN
+        # time axis is appended after execution, once T is known.  Guarded
+        # regions gather/scatter arbitrary leading-axis coordinates via
+        # RegionArrayOps, so selectors may vary along PARAMETER axes and
+        # ensembles may span multiple ENSEMBLE axes.
+        leading_layout = AxisLayout.build(parameters=param_axis_entries, ensemble=ens_axis_entries)
+        n_total = leading_layout.n_leading + extra_ts
+        region_ops = RegionArrayOps(leading_layout, has_timeseries=_has_timeseries)
 
         # Coverage validation (D_valid): every abstract index must have a value source.
         # We check only abstract indexes (value=None or Distribution-backed) — NOT
@@ -830,10 +716,11 @@ class Evaluation:
                 # guard's selector matches its branch key (AND of all masks).
                 # For single-level plans region.guards has one element; for
                 # nested variants it has one entry per nesting level.
-                mask = np.ones(leading_shape, dtype=bool)
+                mask = np.ones(leading_layout.leading_shape, dtype=bool)
                 for guard in region.guards:
                     sel_val = state.values[guard.selector_node]
-                    mask = mask & np.asarray(_leading_mask(guard.selector_node, sel_val, guard.branch_key))
+                    guard_mask = region_ops.selector_mask(guard.selector_node, sel_val, guard.branch_key)
+                    mask = mask & np.asarray(guard_mask)
                 flat_mask = np.asarray(mask).reshape(-1)
                 branch_idx = np.flatnonzero(flat_mask)
 
@@ -843,7 +730,7 @@ class Evaluation:
                     # arrays so merge-region np.select can still reference them.
                     for node in region.nodes:
                         if node not in state.values:
-                            state.values[node] = _empty_branch_value()
+                            state.values[node] = region_ops.empty_branch_value()
                             substituted_nodes.add(node)  # prevent spurious shape-norm
                     continue
 
@@ -851,7 +738,7 @@ class Evaluation:
                 # value to the matching leading coordinates.  Constants and
                 # structural variant_selector sentinels are carried unchanged.
                 branch_values: dict[graph.Node, np.ndarray] = {
-                    node: _gather_leading(node, value, branch_idx) for node, value in state.values.items()
+                    node: region_ops.gather(node, value, branch_idx) for node, value in state.values.items()
                 }
 
                 branch_state = executor.State(
@@ -866,7 +753,7 @@ class Evaluation:
                 for node in region.nodes:
                     if node not in branch_state.values or node in state.values:
                         continue
-                    state.values[node] = _scatter_leading(node, branch_state.values[node], branch_idx)
+                    state.values[node] = region_ops.scatter(node, branch_state.values[node], branch_idx)
                     substituted_nodes.add(node)  # mark as correctly shaped; skip shape-norm
 
         # All nodes in topological order (for touched-set computation).
@@ -909,11 +796,12 @@ class Evaluation:
                 n_inject = n_total - arr.ndim
                 state.values[node] = arr.reshape((1,) * n_inject + arr.shape)
 
-        # DOMAIN axis tracking: register Axis("time", DOMAIN) in axis_layout
-        # so that every result dimension is named.  T is read post-execution
-        # because abstract TimeseriesIndex nodes are filled at evaluate time.
+        # DOMAIN axis tracking: append TIME_AXIS to the layout so that every
+        # result dimension is named.  T is read post-execution because
+        # abstract TimeseriesIndex nodes are filled at evaluate time.
         # Assumption: T is uniform across all PARAMETER configurations (T is a
         # structural property of the model, not a function of parameter values).
+        result_layout = leading_layout
         if _has_timeseries:
             ts_nodes = [
                 n
@@ -931,9 +819,7 @@ class Evaluation:
                         f"expected T={T}. T must be constant across all PARAMETER "
                         f"configurations (it is a structural model property)."
                     )
-            time_axis = Axis("time", DOMAIN)
-            axis_layout[time_axis] = n_full
-            axis_sizes[time_axis] = T
+            result_layout = leading_layout.with_axis_appended(TIME_AXIS, T)
         if __debug__:
             for node in actual_nodes:
                 assert node in state.values, (
@@ -944,18 +830,16 @@ class Evaluation:
                 assert arr.ndim == n_total, (
                     f"Post-norm: node {getattr(node, 'name', repr(node))!r} ndim={arr.ndim}, expected {n_total}"
                 )
-                for ax, pos in axis_layout.items():
-                    assert arr.shape[pos] in {1, axis_sizes[ax]}, (
-                        f"Post-norm: node {getattr(node, 'name', repr(node))!r} "
-                        f"axis {ax.name!r} at pos {pos}: shape[{pos}]={arr.shape[pos]}, "
-                        f"expected 1 or {axis_sizes[ax]}"
-                    )
+                assert result_layout.compatible_with(arr.shape), (
+                    f"Post-norm: node {getattr(node, 'name', repr(node))!r} "
+                    f"shape {arr.shape} is incompatible with layout {result_layout!r} "
+                    f"(each dim must be 1 or the axis size)"
+                )
 
         return EvaluationResult(
             state,
-            axis_layout,
+            result_layout,
             array_params,
-            axis_sizes=axis_sizes,
             factorized_weights=factorized_weights,
             named_axis_values=parameter_axes if parameter_axes else None,
         )

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -106,6 +106,15 @@ class EvaluationResult:
         return joint
 
     @property
+    def factorized_weights(self) -> dict[Axis, np.ndarray]:
+        """Per-ENSEMBLE-axis weight vectors, keyed by axis.
+
+        The joint scenario weight array (outer product of these vectors) is
+        available via :attr:`weights`.
+        """
+        return self._factorized_weights
+
+    @property
     def parameter_values(self) -> dict[GenericIndex, np.ndarray]:
         """Parameter value arrays, keyed by the index passed in ``parameters=``."""
         return self._parameter_arrays

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -80,11 +80,14 @@ class EvaluationResult:
         """The :class:`~simulation.axis_layout.AxisLayout` of result arrays."""
         return self._layout
 
-    # Transitional views over the layout, kept while handle.py and runner.py
-    # still consume the dict form; to be removed at the end of the refactor.
+    # Transitional views, kept only for one lingering test assertion
+    # (test_evaluation_handle.py); to be deleted at step 12 together with the
+    # dict-accepting constructor form, once that assertion is migrated.
+    # _axis_layout has no readers left (handle.py and runner.py are fully
+    # migrated onto .layout) — excluded from coverage until its step-12 removal.
 
     @property
-    def _axis_layout(self) -> dict[Axis, int]:
+    def _axis_layout(self) -> dict[Axis, int]:  # pragma: no cover
         return self._layout.positions
 
     @property

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -24,9 +24,9 @@ from typing import Any
 
 import numpy as np
 
+from ..axes import ENSEMBLE, PARAMETER, Axis
 from ..engine.frontend import graph
 from ..engine.numpybackend import executor
-from ..model.axis import ENSEMBLE, PARAMETER, Axis
 from ..model.index import GenericIndex
 from .ensemble import BatchDrawable, DistributionEnsemble, FrozenEnsemble
 from .evaluation import Evaluation, EvaluationResult

--- a/civic_digital_twins/dt_model/simulation/handle.py
+++ b/civic_digital_twins/dt_model/simulation/handle.py
@@ -103,8 +103,8 @@ def _merge_results(
         axes differ, or if the PARAMETER axis layouts are incompatible.
     """
     # --- Collect ENSEMBLE axes ---
-    ens_1 = [(ax, pos) for ax, pos in r1._axis_layout.items() if ax.role == ENSEMBLE]
-    ens_2 = [(ax, pos) for ax, pos in r2._axis_layout.items() if ax.role == ENSEMBLE]
+    ens_1 = r1.layout.axes_by_role(ENSEMBLE)
+    ens_2 = r2.layout.axes_by_role(ENSEMBLE)
 
     if not ens_1 or not ens_2:
         raise ValueError(
@@ -127,34 +127,30 @@ def _merge_results(
                 f"_merge_results: both results have multiple ENSEMBLE axes {names}; "
                 "specify merge_axis_name= to indicate which axis to grow."
             )
-        grow_entry_1 = next(((ax, pos) for ax, pos in ens_1 if ax.name == merge_axis_name), None)
-        grow_entry_2 = next(((ax, pos) for ax, pos in ens_2 if ax.name == merge_axis_name), None)
-        if grow_entry_1 is None:
+        grow_ax_1 = r1.layout.find_axis(merge_axis_name, ENSEMBLE)
+        grow_ax_2 = r2.layout.find_axis(merge_axis_name, ENSEMBLE)
+        if grow_ax_1 is None:
             raise ValueError(f"_merge_results: no ENSEMBLE axis named {merge_axis_name!r} in r1.")
-        if grow_entry_2 is None:
+        if grow_ax_2 is None:
             raise ValueError(f"_merge_results: no ENSEMBLE axis named {merge_axis_name!r} in r2.")
-        grow_ax_1, ens_pos = grow_entry_1
-        grow_ax_2, ens_pos2 = grow_entry_2
+        ens_pos = r1.layout.position_of(grow_ax_1)
+        ens_pos2 = r2.layout.position_of(grow_ax_2)
         if ens_pos != ens_pos2:
             raise ValueError(
                 f"Growing ENSEMBLE axis {merge_axis_name!r} is at dim {ens_pos} in r1 but dim {ens_pos2} in r2."
             )
 
         # Validate the fixed ENSEMBLE axes match by name, position, and size.
-        def _fixed_ens_sig(axes: list[tuple[Axis, int]], sizes: dict[Axis, int]) -> frozenset[tuple[str, int, int]]:
-            return frozenset((ax.name, pos, sizes[ax]) for ax, pos in axes if ax.name != merge_axis_name)
-
-        if _fixed_ens_sig(ens_1, r1._axis_sizes) != _fixed_ens_sig(ens_2, r2._axis_sizes):
+        fixed_1 = r1.layout.role_signature(ENSEMBLE, exclude_name=merge_axis_name)
+        fixed_2 = r2.layout.role_signature(ENSEMBLE, exclude_name=merge_axis_name)
+        if fixed_1 != fixed_2:
             raise ValueError("_merge_results: fixed ENSEMBLE axis layouts differ between r1 and r2.")
 
-    S1: int = r1._axis_sizes[grow_ax_1]
-    S2: int = r2._axis_sizes[grow_ax_2]
+    S1: int = r1.layout.size_of(grow_ax_1)
+    S2: int = r2.layout.size_of(grow_ax_2)
 
     # --- Validate that PARAMETER axes are compatible ---
-    def _param_sig(layout: dict[Axis, int], sizes: dict[Axis, int]) -> frozenset[tuple[str, object, int, int]]:
-        return frozenset((ax.name, ax.role, pos, sizes[ax]) for ax, pos in layout.items() if ax.role != ENSEMBLE)
-
-    if _param_sig(r1._axis_layout, r1._axis_sizes) != _param_sig(r2._axis_layout, r2._axis_sizes):
+    if r1.layout.parameter_signature() != r2.layout.parameter_signature():
         raise ValueError(
             "_merge_results requires both results to have identical PARAMETER axis layouts. "
             "Ensure both were built from the same plan with the same 'parameters=' dict."
@@ -190,40 +186,28 @@ def _merge_results(
             merged_values[node] = np.concatenate([v1, v2], axis=ens_pos)
 
     # --- Build merged axis metadata ---
-    # Fresh Axis object for the grown dimension (identity-based keys; old object
-    # would carry a stale size and must not be reused).
-    merged_grow_ax = Axis(grow_ax_1.name, ENSEMBLE)
-    merged_axis_layout: dict[Axis, int] = {
-        **{ax: pos for ax, pos in r1._axis_layout.items() if ax is not grow_ax_1},
-        merged_grow_ax: ens_pos,
-    }
-    merged_axis_sizes: dict[Axis, int] = {
-        **{ax: sz for ax, sz in r1._axis_sizes.items() if ax is not grow_ax_1},
-        merged_grow_ax: S1 + S2,
-    }
+    merged_layout = r1.layout.with_grown_axis(grow_ax_1.name, S1 + S2)
 
     # Size-proportional mixture for the growing axis; fixed ENSEMBLE axes
-    # keep their factorised weights from r1 unchanged.
-    w1 = r1._factorized_weights[grow_ax_1]
-    w2 = r2._factorized_weights[grow_ax_2]
+    # keep their factorised weights from r1 unchanged.  (Axis equality is
+    # value-based, so the grown dimension keeps grow_ax_1 as its key.)
+    w1 = r1.factorized_weights[grow_ax_1]
+    w2 = r2.factorized_weights[grow_ax_2]
     alpha = S1 / (S1 + S2)
-    merged_factorized_weights: dict[Axis, np.ndarray] = {
-        **{ax: w for ax, w in r1._factorized_weights.items() if ax is not grow_ax_1},
-        merged_grow_ax: np.concatenate([w1 * alpha, w2 * (1.0 - alpha)]),
-    }
+    merged_factorized_weights: dict[Axis, np.ndarray] = dict(r1.factorized_weights)
+    merged_factorized_weights[grow_ax_1] = np.concatenate([w1 * alpha, w2 * (1.0 - alpha)])
 
     merged_state = executor.State(merged_values)
     # named_axis_values is taken from r1 unchanged.  This is sound because the
-    # _param_sig check above already proved r1 and r2 share identical PARAMETER
-    # axes (name, role, position, size); and _merge_results only ever grows an
-    # ENSEMBLE axis, never a PARAMETER axis.
+    # parameter-signature check above already proved r1 and r2 share identical
+    # PARAMETER axes (name, role, position, size); and _merge_results only ever
+    # grows an ENSEMBLE axis, never a PARAMETER axis.
     return EvaluationResult(
         merged_state,
-        merged_axis_layout,
-        r1._parameter_arrays,
-        axis_sizes=merged_axis_sizes,
+        merged_layout,
+        r1.parameter_values,
         factorized_weights=merged_factorized_weights,
-        named_axis_values=r1._named_axis_values or None,
+        named_axis_values=r1.named_axis_values or None,
     )
 
 
@@ -267,8 +251,8 @@ def _merge_results_param_extend(
     param_name: str = getattr(param_idx, "name", repr(param_idx))
 
     # --- Validate ENSEMBLE axes ---
-    ens_1 = [(ax, pos) for ax, pos in r1._axis_layout.items() if ax.role == ENSEMBLE]
-    ens_2 = [(ax, pos) for ax, pos in r2._axis_layout.items() if ax.role == ENSEMBLE]
+    ens_1 = r1.layout.axes_by_role(ENSEMBLE)
+    ens_2 = r2.layout.axes_by_role(ENSEMBLE)
     if len(ens_1) != 1 or len(ens_2) != 1:
         raise ValueError(
             "_merge_results_param_extend requires exactly one ENSEMBLE axis in each result; "
@@ -278,8 +262,8 @@ def _merge_results_param_extend(
     _, ens_pos2 = ens_2[0]
     if ens_pos != ens_pos2:
         raise ValueError(f"ENSEMBLE axis position mismatch: r1 at dim {ens_pos}, r2 at dim {ens_pos2}.")
-    S = r1._axis_sizes[ax_ens]
-    S2_check = r2._axis_sizes[ens_2[0][0]]
+    S = r1.layout.size_of(ax_ens)
+    S2_check = r2.layout.size_of(ens_2[0][0])
     if S != S2_check:
         raise ValueError(
             f"_merge_results_param_extend requires identical ENSEMBLE sizes; got {S} vs {S2_check}. "
@@ -287,33 +271,24 @@ def _merge_results_param_extend(
         )
 
     # --- Locate the growing PARAMETER axis in r1 ---
-    grow_ax_1: Axis | None = next(
-        (ax for ax, _ in r1._axis_layout.items() if ax.role == PARAMETER and ax.name == param_name),
-        None,
-    )
+    grow_ax_1 = r1.layout.find_axis(param_name, PARAMETER)
     if grow_ax_1 is None:
         raise ValueError(
             f"_merge_results_param_extend: no PARAMETER axis named {param_name!r} in r1. "
             "extra_parameters must contain indexes already present in the initial parameters= dict."
         )
-    param_pos = r1._axis_layout[grow_ax_1]
-    P1 = r1._axis_sizes[grow_ax_1]
+    param_pos = r1.layout.position_of(grow_ax_1)
+    P1 = r1.layout.size_of(grow_ax_1)
 
-    grow_ax_2: Axis | None = next(
-        (ax for ax, _ in r2._axis_layout.items() if ax.role == PARAMETER and ax.name == param_name),
-        None,
-    )
+    grow_ax_2 = r2.layout.find_axis(param_name, PARAMETER)
     if grow_ax_2 is None:
         raise ValueError(f"_merge_results_param_extend: no PARAMETER axis named {param_name!r} in r2.")
-    P2 = r2._axis_sizes[grow_ax_2]
+    P2 = r2.layout.size_of(grow_ax_2)
 
     # --- Validate fixed PARAMETER axes ---
-    def _fixed_sig(layout: dict[Axis, int], sizes: dict[Axis, int]) -> frozenset[tuple[str, int, int]]:
-        return frozenset(
-            (ax.name, pos, sizes[ax]) for ax, pos in layout.items() if ax.role == PARAMETER and ax.name != param_name
-        )
-
-    if _fixed_sig(r1._axis_layout, r1._axis_sizes) != _fixed_sig(r2._axis_layout, r2._axis_sizes):
+    fixed_1 = r1.layout.role_signature(PARAMETER, exclude_name=param_name)
+    fixed_2 = r2.layout.role_signature(PARAMETER, exclude_name=param_name)
+    if fixed_1 != fixed_2:
         raise ValueError("_merge_results_param_extend: fixed PARAMETER axis layouts differ between r1 and r2.")
 
     # --- Concatenate node arrays along the growing PARAMETER axis ---
@@ -337,41 +312,30 @@ def _merge_results_param_extend(
             merged_values[node] = np.concatenate([v1, v2], axis=param_pos)
 
     # --- Build merged axis metadata ---
-    # Fresh Axis identity for the grown dimension (old object would carry stale size).
-    merged_grow_ax = Axis(param_name, PARAMETER)
-    merged_axis_layout: dict[Axis, int] = {}
-    merged_axis_sizes: dict[Axis, int] = {}
-    for ax, pos in r1._axis_layout.items():
-        if ax is grow_ax_1:
-            merged_axis_layout[merged_grow_ax] = pos
-            merged_axis_sizes[merged_grow_ax] = P1 + P2
-        else:
-            merged_axis_layout[ax] = pos
-            merged_axis_sizes[ax] = r1._axis_sizes[ax]
+    merged_layout = r1.layout.with_grown_axis(param_name, P1 + P2)
 
     # Factorised weights: ENSEMBLE axis unchanged.
-    merged_factorized_weights: dict[Axis, np.ndarray] = dict(r1._factorized_weights)
+    merged_factorized_weights: dict[Axis, np.ndarray] = dict(r1.factorized_weights)
 
     # Concatenate the growing parameter's value array.
-    merged_parameter_arrays: dict[GenericIndex, np.ndarray] = dict(r1._parameter_arrays)
-    if param_idx not in r1._parameter_arrays or param_idx not in r2._parameter_arrays:  # pragma: no cover
+    merged_parameter_arrays: dict[GenericIndex, np.ndarray] = dict(r1.parameter_values)
+    if param_idx not in r1.parameter_values or param_idx not in r2.parameter_values:  # pragma: no cover
         raise ValueError(  # pragma: no cover
             f"_merge_results_param_extend: parameter index {param_name!r} is not tracked in "
             "parameter_arrays.  PARAMETER axis extension requires indexes supplied via "
             "parameters=, not parameter_axes=."
         )
     merged_parameter_arrays[param_idx] = np.concatenate(
-        [r1._parameter_arrays[param_idx], r2._parameter_arrays[param_idx]]
+        [r1.parameter_values[param_idx], r2.parameter_values[param_idx]]
     )
 
     merged_state = executor.State(merged_values)
     return EvaluationResult(
         merged_state,
-        merged_axis_layout,
+        merged_layout,
         merged_parameter_arrays,
-        axis_sizes=merged_axis_sizes,
         factorized_weights=merged_factorized_weights,
-        named_axis_values=r1._named_axis_values or None,
+        named_axis_values=r1.named_axis_values or None,
     )
 
 
@@ -391,12 +355,8 @@ def _frozen_ensemble_from_result(
     snapshot is available (e.g. on handles produced by
     :meth:`~simulation.runner.ModelEvaluator.resume`).
     """
-    ens_entries = sorted(
-        ((ax, pos) for ax, pos in result._axis_layout.items() if ax.role == ENSEMBLE),
-        key=lambda t: t[1],
-    )
-    axes = tuple(ax for ax, _ in ens_entries)
-    weights = tuple(result._factorized_weights[ax] for ax in axes)
+    axes = tuple(ax for ax, _ in result.layout.axes_by_role(ENSEMBLE))
+    weights = tuple(result.factorized_weights[ax] for ax in axes)
     n_ens_dims = len(axes)
 
     excluded_ids = frozenset(id(idx) for idx in parameters)

--- a/civic_digital_twins/dt_model/simulation/region_execution.py
+++ b/civic_digital_twins/dt_model/simulation/region_execution.py
@@ -1,0 +1,164 @@
+"""Guarded-region array operations over the leading evaluation layout.
+
+Regional plan execution evaluates guarded regions only at the leading-axis
+coordinates (``(*PARAMETER, *ENSEMBLE)``) selected by their guards.  This
+module owns the node-aware array operations that support it: masking
+coordinates by selector value, gathering already-known values into a
+branch-local state, scattering branch results back into the full layout, and
+the fill policy for inactive coordinates.
+
+The pure shape arithmetic lives in the leading-array primitives of
+:class:`~simulation.axis_layout.AxisLayout`; this module adds the
+region-execution semantics on top: ``variant_selector`` sentinels pass
+through untouched, DOMAIN-carrying nodes get broadcast treatment based on
+their declared ``output_axes``, and scalar values are padded with a trailing
+singleton when the evaluation carries timeseries.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from ..axes import DOMAIN
+from ..engine.frontend import graph
+from .axis_layout import AxisLayout
+
+__all__ = ["RegionArrayOps"]
+
+
+def _has_domain_axis(node: graph.Node) -> bool:
+    """Return True when the node's output carries a DOMAIN axis."""
+    return any(ax.role == DOMAIN for ax in node.output_axes)
+
+
+def _branch_fill_value(dtype: np.dtype) -> tuple[np.dtype, Any]:
+    """Return an output dtype and inactive-branch fill value for *dtype*."""
+    if dtype.kind in {"f", "c"}:
+        return dtype, np.nan
+    if dtype.kind == "b":
+        return dtype, False
+    if dtype.kind in {"i", "u"}:
+        return dtype, 0
+    return np.dtype(object), None
+
+
+@dataclass(frozen=True)
+class RegionArrayOps:
+    """Node-aware mask/gather/scatter operations for guarded-region execution.
+
+    Bound to one execution context: the leading (PARAMETER + ENSEMBLE)
+    layout and whether the evaluation carries a trailing timeseries
+    dimension.
+
+    Parameters
+    ----------
+    layout:
+        The leading evaluation layout (no DOMAIN axes yet — the time axis
+        is appended to the result layout only after execution).
+    has_timeseries:
+        Whether scalar (non-DOMAIN) values must be padded with a trailing
+        singleton so they broadcast against timeseries ``(T,)`` values.
+    """
+
+    layout: AxisLayout
+    has_timeseries: bool
+
+    def _align_to_leading(self, node: graph.Node, value: Any) -> np.ndarray:
+        """Return *value* normalised and broadcast over the leading layout.
+
+        Values without explicit leading dimensions gain them first: a raw
+        DOMAIN-only value (e.g. a timeseries constant with shape ``(T,)``)
+        is recognised by its node's ``output_axes`` and prepended even when
+        ``T`` accidentally equals a leading-axis size.
+        """
+        arr = np.asarray(value)
+        if self.layout.n_leading == 0 or isinstance(node, graph.variant_selector):
+            return arr
+        if _has_domain_axis(node) and arr.ndim == len(node.output_axes):
+            arr = self.layout.prepend_leading(arr)
+        elif not self.layout.spans_leading(arr.shape):
+            arr = self.layout.prepend_leading(arr)
+        return self.layout.broadcast_leading(arr)
+
+    def selector_mask(self, node: graph.Node, value: Any, branch_key: str) -> np.ndarray:
+        """Return a boolean mask over the leading layout where *value* equals *branch_key*.
+
+        Raises
+        ------
+        NotImplementedError
+            If the selector value varies along a DOMAIN axis (non-singleton
+            trailing dimensions).
+        """
+        sel = self._align_to_leading(node, value)
+        n = self.layout.n_leading
+        if n == 0:
+            mask = np.asarray(sel == branch_key)
+            if mask.shape != ():
+                if any(dim > 1 for dim in mask.shape):
+                    raise NotImplementedError(
+                        "Regional execution does not support selectors with non-singleton DOMAIN axes."
+                    )
+                mask = mask.reshape(())
+            return mask
+        trailing = sel.shape[n:]
+        if trailing:
+            if any(dim > 1 for dim in trailing):
+                raise NotImplementedError(
+                    "Regional execution does not support selectors with non-singleton DOMAIN axes."
+                )
+            sel = sel.reshape(sel.shape[:n])
+        return np.broadcast_to(sel == branch_key, self.layout.leading_shape)
+
+    def gather(self, node: graph.Node, value: Any, flat_idx: np.ndarray) -> np.ndarray:
+        """Gather selected leading-axis coordinates into a branch-local first axis."""
+        if self.layout.n_leading == 0 or isinstance(node, graph.variant_selector):
+            return np.asarray(value)
+        return self.layout.take_leading(self._align_to_leading(node, value), flat_idx)
+
+    def scatter(self, node: graph.Node, value: Any, flat_idx: np.ndarray) -> np.ndarray:
+        """Scatter a branch-local value back into the full leading layout.
+
+        Inactive coordinates are filled with a branch-neutral placeholder
+        chosen by dtype (NaN for floats, False for booleans, 0 for integers,
+        None for object arrays).
+
+        Raises
+        ------
+        ValueError
+            If a non-DOMAIN value's first dimension does not enumerate the
+            selected coordinates.
+        """
+        arr = np.asarray(value)
+        if self.layout.n_leading == 0 or isinstance(node, graph.variant_selector):
+            return arr
+        k = int(flat_idx.size)
+        if arr.ndim == 0:
+            arr = np.broadcast_to(arr, (k,)).copy()
+        elif arr.shape[0] == 1 and k != 1:
+            arr = np.broadcast_to(arr, (k,) + arr.shape[1:]).copy()
+        elif arr.shape[0] != k:
+            # DOMAIN-only values produced inside the branch (shape (T,)) are
+            # invariant across selected leading coordinates.
+            if _has_domain_axis(node):
+                arr = np.broadcast_to(arr, (k,) + arr.shape).copy()
+            else:
+                raise ValueError(
+                    f"Regional scatter for node {getattr(node, 'name', repr(node))!r}: "
+                    f"branch result first dimension {arr.shape[0]} does not match selected size {k}."
+                )
+        if self.has_timeseries and not _has_domain_axis(node) and arr.ndim == 1:
+            arr = arr.reshape(arr.shape + (1,))
+        out_dtype, fill_value = _branch_fill_value(arr.dtype)
+        full_flat = np.full((self.layout.leading_size,) + arr.shape[1:], fill_value, dtype=out_dtype)
+        full_flat[flat_idx] = arr.astype(out_dtype, copy=False)
+        return self.layout.unflatten_leading(full_flat)
+
+    def empty_branch_value(self) -> np.ndarray:
+        """Create a broadcast-compatible inactive value for an unselected branch."""
+        trailing = (1,) if self.has_timeseries else ()
+        return np.full(self.layout.leading_shape + trailing, np.nan, dtype=float)

--- a/civic_digital_twins/dt_model/simulation/runner.py
+++ b/civic_digital_twins/dt_model/simulation/runner.py
@@ -47,6 +47,7 @@ from ..engine.numpybackend.executor import Functor, NumpyBackend, State
 from ..model.index import GenericIndex
 from ..model.model import Model
 from ..model.model_variant import ModelVariant
+from .axis_layout import AxisLayout
 from .ensemble import DistributionEnsemble
 from .evaluation import Evaluation, EvaluationResult
 from .handle import AsyncEvaluationHandle, EvaluationHandle
@@ -290,27 +291,17 @@ def _encode_result(result: EvaluationResult, indexes: Iterable[GenericIndex]) ->
         except KeyError:
             pass  # index not computed in this evaluation
 
-    axis_layout = [
-        [ax.name, ax.role, pos]
-        for ax, pos in result._axis_layout.items()  # type: ignore[attr-defined]
-    ]
-    factorized_weights = {
-        ax.name: _encode_array(w)
-        for ax, w in result._factorized_weights.items()  # type: ignore[attr-defined]
-    }
+    factorized_weights = {ax.name: _encode_array(w) for ax, w in result.factorized_weights.items()}
     parameter_arrays = {idx.name: _encode_array(arr) for idx, arr in result.parameter_values.items()}
     named_axis_values = {name: _encode_array(arr) for name, arr in result.named_axis_values.items()}
-    axis_sizes = {
-        f"{ax.name}:{ax.role}": size
-        for ax, size in result._axis_sizes.items()  # type: ignore[attr-defined]
-    }
+    layout_dict = result.layout.to_dict()
     return {
         "nodes": nodes,
-        "axis_layout": axis_layout,
+        "axis_layout": layout_dict["axis_layout"],
         "factorized_weights": factorized_weights,
         "parameter_arrays": parameter_arrays,
         "named_axis_values": named_axis_values,
-        "axis_sizes": axis_sizes,
+        "axis_sizes": layout_dict["axis_sizes"],
     }
 
 
@@ -339,12 +330,6 @@ def _decode_result(data: dict[str, Any], indexes: Iterable[GenericIndex]) -> Eva
         model, so the result is valid for the current session.
     """
     idx_by_name: dict[str, GenericIndex] = {idx.name: idx for idx in indexes}
-    # factorized_weights is serialised keyed by axis name alone (it only ever holds
-    # ENSEMBLE axes), so we recover each axis's role via this name->role lookup.
-    # This is unambiguous because axis names are globally unique within an
-    # EvaluationResult (see Axis docstring): no two axes — across PARAMETER,
-    # ENSEMBLE, or DOMAIN — share a name, so the lookup cannot collide on role.
-    axis_role: dict[str, str] = {row[0]: row[1] for row in data["axis_layout"]}
 
     state_values: dict = {}
     for name, encoded in data["nodes"].items():
@@ -352,10 +337,17 @@ def _decode_result(data: dict[str, Any], indexes: Iterable[GenericIndex]) -> Eva
             state_values[idx_by_name[name].node] = _decode_array(encoded)
     state = State(values=state_values)
 
-    axis_layout: dict[Axis, int] = {Axis(row[0], row[1]): int(row[2]) for row in data["axis_layout"]}
-    factorized_weights: dict[Axis, np.ndarray] = {
-        Axis(name, axis_role[name]): _decode_array(encoded) for name, encoded in data["factorized_weights"].items()
-    }
+    layout = AxisLayout.from_dict(data)
+    # factorized_weights is serialised keyed by axis name alone (it only ever holds
+    # ENSEMBLE axes); recover each axis (and its role) from the reconstructed
+    # layout.  This is unambiguous because axis names are globally unique within
+    # an EvaluationResult (see Axis docstring): no two axes — across PARAMETER,
+    # ENSEMBLE, or DOMAIN — share a name, so the lookup cannot collide on role.
+    factorized_weights: dict[Axis, np.ndarray] = {}
+    for name, encoded in data["factorized_weights"].items():
+        ax = layout.find_axis(name)
+        assert ax is not None, f"_decode_result: factorized_weights axis {name!r} not found in axis_layout."
+        factorized_weights[ax] = _decode_array(encoded)
     parameter_arrays: dict[GenericIndex, np.ndarray] = {
         idx_by_name[name]: _decode_array(encoded)
         for name, encoded in data["parameter_arrays"].items()
@@ -364,16 +356,11 @@ def _decode_result(data: dict[str, Any], indexes: Iterable[GenericIndex]) -> Eva
     named_axis_values: dict[str, np.ndarray] = {
         name: _decode_array(encoded) for name, encoded in data["named_axis_values"].items()
     }
-    axis_sizes: dict[Axis, int] = {}
-    for key, size in data["axis_sizes"].items():
-        ax_name, ax_role = key.split(":", 1)
-        axis_sizes[Axis(ax_name, ax_role)] = int(size)
 
     return EvaluationResult(
         state=state,
-        axis_layout=axis_layout,
+        axis_layout=layout,
         parameter_arrays=parameter_arrays,
-        axis_sizes=axis_sizes,
         factorized_weights=factorized_weights,
         named_axis_values=named_axis_values,
     )

--- a/civic_digital_twins/dt_model/simulation/runner.py
+++ b/civic_digital_twins/dt_model/simulation/runner.py
@@ -42,8 +42,8 @@ from typing import Any, Generic, Self, TypeVar
 
 import numpy as np
 
+from ..axes import Axis
 from ..engine.numpybackend.executor import Functor, NumpyBackend, State
-from ..model.axis import Axis
 from ..model.index import GenericIndex
 from ..model.model import Model
 from ..model.model_variant import ModelVariant

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -704,8 +704,10 @@ grid.
 | `result[idx]` | Raw array for `idx` in canonical `(*PARAMETER, *ENSEMBLE)` shape prefix. |
 | `result.expected_value(idx)` | Contract all ENSEMBLE axes using factorized weights; result shape is `(*PARAMETER, *DOMAIN)`. |
 | `result.weights` | Joint weight array (outer product of per-axis weights). |
+| `result.factorized_weights` | Per-ENSEMBLE-axis weight vectors, keyed by `Axis` (`result.weights` is their outer product). |
 | `result.parameter_values` | The `parameters=` dict passed to `evaluate`. |
 | `result.full_shape` | `(*PARAMETER, *ENSEMBLE)` sizes in axis-layout order. |
+| `result.layout` | The `AxisLayout` mapping each `Axis` to its numpy dimension position and size. |
 
 ### End-to-End Example
 
@@ -940,6 +942,13 @@ evaluated.
 ENSEMBLE `Axis` objects, per-axis weight vectors, and a batched
 `assignments()` mapping.  `DistributionEnsemble` and `PartitionedEnsemble`
 implement this protocol.
+
+**AxisLayout**: maps each semantic `Axis` to its numpy dimension position
+and size in a result array, enforcing the canonical
+`(*PARAMETER, *ENSEMBLE, *DOMAIN)` dimension ordering.  Exposed as
+`EvaluationResult.layout`; the single source of truth for axis layout
+consumed by `Evaluation`, `EvaluationHandle`'s merge logic, and
+`ModelEvaluator` resume serialization.
 
 **Ensemble**: a structural `Protocol` for iterables that yield
 `WeightedScenario` tuples.  Used as a common type for ensemble

--- a/tests/dt_model/model/test_functions.py
+++ b/tests/dt_model/model/test_functions.py
@@ -585,7 +585,7 @@ def test_iter_node_deps_exclusive_multi_clause_where_and_variant_selector():
 
 def test_iter_node_deps_projection_op():
     """function_call reachable through a ProjectionOp (project_using_sum) is claimed."""
-    from civic_digital_twins.dt_model.model.axis import DOMAIN, Axis
+    from civic_digital_twins.dt_model.axes import DOMAIN, Axis
 
     p = graph.placeholder("inp", default_value=1.0)
     fc = graph.function_call("solve", p)

--- a/tests/dt_model/simulation/test_acceptance_typed_axes.py
+++ b/tests/dt_model/simulation/test_acceptance_typed_axes.py
@@ -193,7 +193,7 @@ def test_scalar_ensemble_broadcasts_with_timeseries():
 
 def test_index_sum_axis_minus1_over_timeseries_with_ensemble():
     """Index.sum() over time axis on timeseries+ensemble: time reduced, shape (*ENSEMBLE, 1)."""
-    from civic_digital_twins.dt_model.model.axis import DOMAIN, Axis
+    from civic_digital_twins.dt_model.axes import DOMAIN, Axis
 
     T = 6
     S = 4

--- a/tests/dt_model/simulation/test_axis_layout.py
+++ b/tests/dt_model/simulation/test_axis_layout.py
@@ -1,0 +1,319 @@
+"""Tests for simulation/axis_layout.py: AxisLayout and its leading-array primitives."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from civic_digital_twins.dt_model.axes import DOMAIN, ENSEMBLE, PARAMETER, TIME_AXIS, Axis
+from civic_digital_twins.dt_model.simulation.axis_layout import AxisLayout
+
+P1 = Axis("p1", PARAMETER)
+P2 = Axis("p2", PARAMETER)
+E1 = Axis("e1", ENSEMBLE)
+E2 = Axis("e2", ENSEMBLE)
+
+
+class TestConstruction:
+    """AxisLayout construction and validation."""
+
+    def test_entries_positions_sizes(self):
+        """Entries preserve order; positions are implicit indices."""
+        layout = AxisLayout([(P1, 2), (E1, 3), (TIME_AXIS, 5)])
+        assert layout.entries == ((P1, 2), (E1, 3), (TIME_AXIS, 5))
+        assert layout.axes == (P1, E1, TIME_AXIS)
+        assert len(layout) == 3
+        assert layout.positions == {P1: 0, E1: 1, TIME_AXIS: 2}
+        assert layout.sizes == {P1: 2, E1: 3, TIME_AXIS: 5}
+
+    def test_empty(self):
+        """An empty layout is valid (deterministic scalar evaluation)."""
+        layout = AxisLayout([])
+        assert layout.entries == ()
+        assert layout.full_shape == ()
+        assert layout.leading_size == 1
+
+    def test_duplicate_names_rejected(self):
+        """Axis names are globally unique within a layout, across roles."""
+        with pytest.raises(ValueError, match="duplicate axis names"):
+            AxisLayout([(Axis("x", PARAMETER), 2), (Axis("x", ENSEMBLE), 3)])
+
+    def test_unknown_role_rejected(self):
+        """Only PARAMETER, ENSEMBLE, and DOMAIN roles are supported."""
+        with pytest.raises(ValueError, match="unsupported role"):
+            AxisLayout([(Axis("x", "SPATIAL"), 2)])
+
+    def test_role_ordering_enforced(self):
+        """Axes must be grouped PARAMETER, then ENSEMBLE, then DOMAIN."""
+        with pytest.raises(ValueError, match="canonical order"):
+            AxisLayout([(E1, 3), (P1, 2)])
+        with pytest.raises(ValueError, match="canonical order"):
+            AxisLayout([(TIME_AXIS, 5), (E1, 3)])
+
+    def test_nonpositive_size_rejected(self):
+        """Sizes must be positive integers."""
+        with pytest.raises(ValueError, match="positive"):
+            AxisLayout([(P1, 0)])
+
+    def test_build_groups(self):
+        """build() concatenates the role groups in canonical order."""
+        layout = AxisLayout.build(parameters=[(P1, 2), (P2, 4)], ensemble=[(E1, 3)], domain=[(TIME_AXIS, 5)])
+        assert layout == AxisLayout([(P1, 2), (P2, 4), (E1, 3), (TIME_AXIS, 5)])
+
+    def test_from_positions(self):
+        """from_positions() orders entries by position."""
+        layout = AxisLayout.from_positions({E1: 1, P1: 0}, {P1: 2, E1: 3})
+        assert layout.entries == ((P1, 2), (E1, 3))
+
+    def test_from_positions_noncontiguous_rejected(self):
+        """Positions must be exactly 0..n-1."""
+        with pytest.raises(ValueError, match="contiguous"):
+            AxisLayout.from_positions({P1: 0, E1: 2}, {P1: 2, E1: 3})
+
+
+class TestQueries:
+    """Lookup and role-query methods."""
+
+    def test_contains_and_lookup(self):
+        """position_of/size_of work by value equality; KeyError when absent."""
+        layout = AxisLayout([(P1, 2), (E1, 3)])
+        assert Axis("p1", PARAMETER) in layout
+        assert TIME_AXIS not in layout
+        assert layout.position_of(Axis("e1", ENSEMBLE)) == 1
+        assert layout.size_of(Axis("e1", ENSEMBLE)) == 3
+        with pytest.raises(KeyError):
+            layout.position_of(TIME_AXIS)
+
+    def test_find_axis(self):
+        """find_axis matches by name, optionally constrained by role."""
+        layout = AxisLayout([(P1, 2), (E1, 3)])
+        assert layout.find_axis("e1") is layout.axes[1]
+        assert layout.find_axis("e1", ENSEMBLE) is layout.axes[1]
+        assert layout.find_axis("e1", PARAMETER) is None
+        assert layout.find_axis("missing") is None
+
+    def test_axes_by_role(self):
+        """axes_by_role returns (axis, position) pairs in position order."""
+        layout = AxisLayout([(P1, 2), (P2, 4), (E1, 3), (TIME_AXIS, 5)])
+        assert layout.axes_by_role(PARAMETER) == ((P1, 0), (P2, 1))
+        assert layout.axes_by_role(ENSEMBLE) == ((E1, 2),)
+        assert layout.axes_by_role(DOMAIN) == ((TIME_AXIS, 3),)
+
+
+class TestDerivedShapes:
+    """Counts, shapes, and compatibility checks."""
+
+    def test_counts_and_shapes(self):
+        """Role counts and derived shapes reflect the layout."""
+        layout = AxisLayout([(P1, 2), (P2, 4), (E1, 3), (TIME_AXIS, 5)])
+        assert (layout.n_params, layout.n_ensemble, layout.n_domain) == (2, 1, 1)
+        assert layout.n_leading == 3
+        assert layout.full_shape == (2, 4, 3, 5)
+        assert layout.leading_axes == (P1, P2, E1)
+        assert layout.leading_shape == (2, 4, 3)
+        assert layout.leading_size == 24
+
+    def test_compatible_with(self):
+        """Shapes must have one dim per axis, each 1 or the axis size."""
+        layout = AxisLayout([(P1, 2), (E1, 3)])
+        assert layout.compatible_with((2, 3))
+        assert layout.compatible_with((1, 3))
+        assert not layout.compatible_with((2,))
+        assert not layout.compatible_with((2, 4))
+
+
+class TestSignatures:
+    """Merge-compatibility signatures."""
+
+    def test_role_signature(self):
+        """role_signature yields (name, position, size) triples, with exclusion."""
+        layout = AxisLayout([(P1, 2), (E1, 3), (E2, 4)])
+        assert layout.role_signature(ENSEMBLE) == frozenset({("e1", 1, 3), ("e2", 2, 4)})
+        assert layout.role_signature(ENSEMBLE, exclude_name="e1") == frozenset({("e2", 2, 4)})
+
+    def test_parameter_signature_includes_domain(self):
+        """parameter_signature covers all non-ENSEMBLE axes with their role."""
+        layout = AxisLayout([(P1, 2), (E1, 3), (TIME_AXIS, 5)])
+        assert layout.parameter_signature() == frozenset(
+            {("p1", PARAMETER, 0, 2), ("time", DOMAIN, 2, 5)},
+        )
+
+
+class TestTransformations:
+    """with_grown_axis and with_axis_appended."""
+
+    def test_with_grown_axis(self):
+        """Growing an axis changes only its size."""
+        layout = AxisLayout([(P1, 2), (E1, 3)])
+        grown = layout.with_grown_axis("e1", 8)
+        assert grown.entries == ((P1, 2), (E1, 8))
+        assert layout.entries == ((P1, 2), (E1, 3))  # immutable
+
+    def test_with_grown_axis_missing(self):
+        """Growing an unknown axis raises KeyError."""
+        with pytest.raises(KeyError, match="missing"):
+            AxisLayout([(P1, 2)]).with_grown_axis("missing", 8)
+
+    def test_with_axis_appended(self):
+        """Appending registers the DOMAIN time axis as the last dimension."""
+        layout = AxisLayout([(P1, 2), (E1, 3)]).with_axis_appended(TIME_AXIS, 5)
+        assert layout.entries == ((P1, 2), (E1, 3), (TIME_AXIS, 5))
+
+    def test_with_axis_appended_revalidates_order(self):
+        """Appending re-checks the canonical role ordering."""
+        with pytest.raises(ValueError, match="canonical order"):
+            AxisLayout([(E1, 3)]).with_axis_appended(P1, 2)
+
+
+class TestArrayOperations:
+    """contract_ensemble and drop_stray_domain."""
+
+    def test_contract_ensemble_weighted_average(self):
+        """A non-singleton ENSEMBLE dim is contracted by weighted average."""
+        layout = AxisLayout([(P1, 2), (E1, 3)])
+        arr = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        out = layout.contract_ensemble(arr, {E1: np.array([1.0, 1.0, 2.0])})
+        assert out.shape == (2,)
+        np.testing.assert_allclose(out, [(1 + 2 + 6) / 4, (4 + 5 + 12) / 4])
+
+    def test_contract_ensemble_singleton_squeeze(self):
+        """A singleton ENSEMBLE dim is squeezed without consulting weights."""
+        layout = AxisLayout([(P1, 2), (E1, 3)])
+        arr = np.ones((2, 1))
+        out = layout.contract_ensemble(arr, {})
+        assert out.shape == (2,)
+
+    def test_contract_ensemble_incompatible_shape_rejected(self):
+        """A rank or size mismatch is reported instead of contracting a wrong dim."""
+        layout = AxisLayout([(P1, 2), (E1, 3)])
+        with pytest.raises(ValueError, match="incompatible with layout"):
+            layout.contract_ensemble(np.ones((2,)), {})
+
+    def test_contract_ensemble_multiple_axes(self):
+        """Multiple ENSEMBLE dims contract in descending position order."""
+        layout = AxisLayout([(E1, 2), (E2, 3)])
+        arr = np.arange(6.0).reshape(2, 3)
+        out = layout.contract_ensemble(arr, {E1: np.ones(2), E2: np.ones(3)})
+        assert out.shape == ()
+        np.testing.assert_allclose(out, arr.mean())
+
+    def test_drop_stray_domain(self):
+        """Size-1 DOMAIN dims not carried by the index are squeezed away."""
+        layout = AxisLayout([(P1, 2), (TIME_AXIS, 5)])
+        arr = np.ones((2, 1))
+        assert layout.drop_stray_domain(arr, ()).shape == (2,)
+
+    def test_drop_stray_domain_keeps_carried(self):
+        """DOMAIN dims carried by the index are preserved at any size."""
+        layout = AxisLayout([(P1, 2), (TIME_AXIS, 5)])
+        assert layout.drop_stray_domain(np.ones((2, 1)), (TIME_AXIS,)).shape == (2, 1)
+        assert layout.drop_stray_domain(np.ones((2, 5)), (TIME_AXIS,)).shape == (2, 5)
+
+    def test_drop_stray_domain_requires_contracted_array(self):
+        """A full-layout (non-contracted) array is rejected up front."""
+        layout = AxisLayout([(P1, 2), (E1, 3), (TIME_AXIS, 5)])
+        with pytest.raises(ValueError, match="not ENSEMBLE-contracted"):
+            layout.drop_stray_domain(np.ones((2, 3, 5)), ())
+
+    def test_drop_stray_domain_undeclared_variation_rejected(self):
+        """A non-carried DOMAIN dim of size > 1 is a contract violation."""
+        layout = AxisLayout([(P1, 2), (TIME_AXIS, 5)])
+        with pytest.raises(ValueError, match="declared and actual axes disagree"):
+            layout.drop_stray_domain(np.ones((2, 5)), ())
+
+
+class TestSerialization:
+    """to_dict/from_dict round-trip in the runner persistence format."""
+
+    def test_to_dict_format(self):
+        """to_dict emits [name, role, pos] rows and 'name:role' size keys."""
+        layout = AxisLayout([(P1, 2), (E1, 3)])
+        assert layout.to_dict() == {
+            "axis_layout": [["p1", PARAMETER, 0], ["e1", ENSEMBLE, 1]],
+            "axis_sizes": {f"p1:{PARAMETER}": 2, f"e1:{ENSEMBLE}": 3},
+        }
+
+    def test_round_trip(self):
+        """from_dict(to_dict()) reproduces the layout."""
+        layout = AxisLayout([(P1, 2), (E1, 3), (TIME_AXIS, 5)])
+        assert AxisLayout.from_dict(layout.to_dict()) == layout
+
+
+class TestDunder:
+    """Equality, hashing, and repr."""
+
+    def test_eq_and_hash(self):
+        """Layouts compare by ordered entries; unequal sizes differ."""
+        a = AxisLayout([(P1, 2), (E1, 3)])
+        b = AxisLayout([(Axis("p1", PARAMETER), 2), (Axis("e1", ENSEMBLE), 3)])
+        assert a == b
+        assert hash(a) == hash(b)
+        assert a != AxisLayout([(P1, 2), (E1, 4)])
+        assert a != "not a layout"
+
+    def test_repr(self):
+        """The repr lists entries in order."""
+        assert "Axis('p1'" in repr(AxisLayout([(P1, 2)]))
+
+
+class TestLeadingPrimitives:
+    """Pure leading-array shape arithmetic."""
+
+    LEAD = AxisLayout([(P1, 2), (E1, 3)])
+
+    def test_spans_leading(self):
+        """A spanning shape has >= n_leading dims, each 1 or the axis size."""
+        assert self.LEAD.spans_leading((2, 3))
+        assert self.LEAD.spans_leading((1, 3))
+        assert self.LEAD.spans_leading((2, 3, 7))  # trailing dims allowed
+        assert not self.LEAD.spans_leading((2,))  # too few dims
+        assert not self.LEAD.spans_leading((4, 3))  # wrong size
+
+    def test_prepend_leading(self):
+        """prepend_leading adds one singleton per leading axis."""
+        assert self.LEAD.prepend_leading(np.ones((7,))).shape == (1, 1, 7)
+        assert self.LEAD.prepend_leading(np.asarray(5.0)).shape == (1, 1)
+
+    def test_broadcast_leading(self):
+        """Singleton leading dims expand to the layout; trailing dims survive."""
+        out = self.LEAD.broadcast_leading(np.ones((1, 3, 4)))
+        assert out.shape == (2, 3, 4)
+
+    def test_broadcast_leading_requires_spanning_shape(self):
+        """A shape that does not span the leading layout is rejected."""
+        with pytest.raises(ValueError, match="does not span the"):
+            self.LEAD.broadcast_leading(np.ones((4, 3)))
+        with pytest.raises(ValueError, match="does not span the"):
+            self.LEAD.broadcast_leading(np.ones((3,)))
+
+    def test_flatten_unflatten_roundtrip(self):
+        """unflatten_leading inverts flatten_leading."""
+        arr = np.arange(24.0).reshape(2, 3, 4)
+        flat = self.LEAD.flatten_leading(arr)
+        assert flat.shape == (6, 4)
+        np.testing.assert_array_equal(self.LEAD.unflatten_leading(flat), arr)
+
+    def test_flatten_leading_requires_full_leading_dims(self):
+        """A shape whose element count merely coincides is rejected, not scrambled."""
+        with pytest.raises(ValueError, match="does not start with the"):
+            self.LEAD.flatten_leading(np.ones((3, 2)))  # transposed leading dims
+
+    def test_unflatten_leading_requires_leading_size(self):
+        """The first dimension must be exactly leading_size."""
+        with pytest.raises(ValueError, match="does not start with"):
+            self.LEAD.unflatten_leading(np.ones((5,)))
+        with pytest.raises(ValueError, match="does not start with"):
+            self.LEAD.unflatten_leading(np.asarray(1.0))
+
+    def test_take_leading(self):
+        """take_leading gathers rows of the flattened leading layout."""
+        arr = np.arange(6.0).reshape(2, 3)
+        np.testing.assert_array_equal(self.LEAD.take_leading(arr, np.array([0, 4])), [0.0, 4.0])
+
+    def test_empty_layout(self):
+        """With no leading axes the primitives degenerate gracefully."""
+        empty = AxisLayout([])
+        assert empty.spans_leading(())
+        arr = np.float64(7.0)
+        assert empty.prepend_leading(np.asarray(arr)).shape == ()
+        assert empty.flatten_leading(np.asarray(arr)).shape == (1,)

--- a/tests/dt_model/simulation/test_cross_product_ensemble.py
+++ b/tests/dt_model/simulation/test_cross_product_ensemble.py
@@ -277,7 +277,7 @@ def test_cpe_implements_axis_ensemble_protocol():
 
 def test_cpe_single_ensemble_axis():
     """CrossProductEnsemble reports exactly one ENSEMBLE axis."""
-    from civic_digital_twins.dt_model.model.axis import ENSEMBLE  # noqa: PLC0415
+    from civic_digital_twins.dt_model.axes import ENSEMBLE  # noqa: PLC0415
 
     season = CategoricalIndex("season", {"summer": 0.5, "winter": 0.5})
     model = _simple_model(season)

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -753,3 +753,23 @@ def test_evaluation_result_full_shape_with_axes():
     ens = DistributionEnsemble(scenario, 7)
     result = ev.evaluate(ensemble=ens)
     assert result.full_shape == (7,)
+
+
+def test_evaluation_result_layout_property():
+    """EvaluationResult.layout exposes the AxisLayout of result arrays."""
+    from scipy import stats  # noqa: PLC0415
+
+    from civic_digital_twins.dt_model.axes import ENSEMBLE  # noqa: PLC0415
+    from civic_digital_twins.dt_model.model.index import DistributionIndex  # noqa: PLC0415
+    from civic_digital_twins.dt_model.simulation.axis_layout import AxisLayout  # noqa: PLC0415
+    from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble  # noqa: PLC0415
+
+    I_x = DistributionIndex("x", stats.norm, {"loc": 0.0, "scale": 1.0})
+    I_result = Index("result", I_x.node * 2.0)
+    model = _make_model(I_x, I_result)
+    scenario = Scenario(model)
+    ev = Evaluation(scenario)
+    result = ev.evaluate(ensemble=DistributionEnsemble(scenario, 7))
+    assert isinstance(result.layout, AxisLayout)
+    assert result.layout.full_shape == (7,)
+    assert [ax.role for ax in result.layout.axes] == [ENSEMBLE]

--- a/tests/dt_model/simulation/test_evaluation.py
+++ b/tests/dt_model/simulation/test_evaluation.py
@@ -103,7 +103,7 @@ def test_axes_two_axes_result_shape():
 
 def test_axes_non_axis_abstract_has_shape_1_1_s():
     """A non-axis abstract index has shape (1, …, 1, S)."""
-    from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
+    from civic_digital_twins.dt_model.axes import ENSEMBLE, Axis
     from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble
 
     I_x = Index("x", None)
@@ -158,7 +158,7 @@ def test_axes_two_axes_additive_formula():
 
 def test_axes_non_axis_factor_marginalised_correctly():
     """Weighted marginalisation over a non-axis index gives the correct mean."""
-    from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
+    from civic_digital_twins.dt_model.axes import ENSEMBLE, Axis
     from civic_digital_twins.dt_model.simulation.ensemble import FrozenEnsemble
 
     I_x = Index("x", None)

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -898,7 +898,6 @@ def test_merge_results_param_extend_param_axis_missing_in_r2() -> None:
 
 def test_merge_results_param_extend_ensemble_pos_mismatch_raises() -> None:
     """_merge_results_param_extend raises ValueError when ENSEMBLE axis positions differ."""
-    from civic_digital_twins.dt_model.axes import PARAMETER  # noqa: PLC0415
     from civic_digital_twins.dt_model.engine.numpybackend import executor as _ex  # noqa: PLC0415
     from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
 
@@ -907,18 +906,20 @@ def test_merge_results_param_extend_ensemble_pos_mismatch_raises() -> None:
     r1 = handle.result
     # r1: PARAMETER(speed) at dim 0, ENSEMBLE at dim 1 → ens_pos=1
 
-    # Build r2 with ENSEMBLE at dim 0 (position mismatch vs r1's dim 1).
-    ax_param = Axis("speed", PARAMETER)
+    # Build r2 with ENSEMBLE at dim 0.  Under the canonical role ordering
+    # (PARAMETER before ENSEMBLE, enforced by AxisLayout) a position mismatch
+    # arises from a differing PARAMETER count: r2 has no PARAMETER axis, so
+    # its single ENSEMBLE axis sits at dim 0 versus r1's dim 1.
     ax_ens = Axis("_ensemble", ENSEMBLE)
     values: dict = {}
     for idx in plan.nodes_of_interest:
-        values[idx.node] = np.zeros((5, 2))  # shape (5_ens, 2_param)
+        values[idx.node] = np.zeros((5,))  # shape (5_ens,)
     r2 = EvaluationResult(
         _ex.State(values),
-        {ax_ens: 0, ax_param: 1},  # ENSEMBLE at dim 0, PARAMETER at dim 1
+        {ax_ens: 0},  # ENSEMBLE at dim 0 (r1 has it at dim 1)
         {},
-        axis_sizes={ax_ens: 5, ax_param: 2},
-        factorized_weights={ax_ens: np.full(5, 0.2), ax_param: np.full(2, 0.5)},
+        axis_sizes={ax_ens: 5},
+        factorized_weights={ax_ens: np.full(5, 0.2)},
     )
     with pytest.raises(ValueError, match="ENSEMBLE axis position mismatch"):
         _merge_results_param_extend(r1, r2, plan, speed)

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -12,6 +12,7 @@ from civic_digital_twins.dt_model.axes import ENSEMBLE, Axis
 from civic_digital_twins.dt_model.engine.numpybackend import executor as _executor
 from civic_digital_twins.dt_model.model.index import DistributionIndex, GenericIndex, Index
 from civic_digital_twins.dt_model.model.model import Model
+from civic_digital_twins.dt_model.simulation.axis_layout import AxisLayout
 from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
 from civic_digital_twins.dt_model.simulation.evaluation import Evaluation, EvaluationResult
 from civic_digital_twins.dt_model.simulation.handle import EvaluationHandle, _merge_results
@@ -165,7 +166,7 @@ def test_merge_preserves_nonuniform_weights() -> None:
     def _make(ax, sz, w):
         values = {idx.node: np.zeros(sz) for idx in plan.nodes_of_interest}
         state = _executor.State(values)
-        return EvaluationResult(state, {ax: 0}, {}, axis_sizes={ax: sz}, factorized_weights={ax: w})
+        return EvaluationResult(state, AxisLayout([(ax, sz)]), {}, factorized_weights={ax: w})
 
     r1 = _make(ax1, S1, w1)
     r2 = _make(ax2, S2, w2)
@@ -500,15 +501,14 @@ def _make_fake_result(
     ens_sizes: tuple[int, ...],
 ) -> EvaluationResult:
     """Build a minimal EvaluationResult with the given ENSEMBLE axes (no real evaluation)."""
-    axis_layout: dict[Axis, int] = {ax: i for i, ax in enumerate(ens_axes)}
-    axis_sizes: dict[Axis, int] = dict(zip(ens_axes, ens_sizes))
+    layout = AxisLayout.build(ensemble=list(zip(ens_axes, ens_sizes)))
     factorized_weights: dict[Axis, np.ndarray] = {ax: np.full(sz, 1.0 / sz) for ax, sz in zip(ens_axes, ens_sizes)}
     # Populate values for every node of interest with a zero array of the right shape.
     values: dict = {}
     for idx in plan.nodes_of_interest:
         values[idx.node] = np.zeros(ens_sizes)
     state = _executor.State(values)
-    return EvaluationResult(state, axis_layout, {}, axis_sizes=axis_sizes, factorized_weights=factorized_weights)
+    return EvaluationResult(state, layout, {}, factorized_weights=factorized_weights)
 
 
 def test_merge_results_multi_axis_no_name_raises() -> None:
@@ -534,10 +534,10 @@ def test_merge_results_multi_axis_concat() -> None:
     r2 = _make_fake_result(plan, (Axis("ens1", ENSEMBLE), Axis("ens2", ENSEMBLE)), (4, 3))
     merged = _merge_results(r1, r2, plan, merge_axis_name="ens1")
 
-    merged_ens1 = next(ax for ax in merged._axis_sizes if ax.name == "ens1")
-    merged_ens2 = next(ax for ax in merged._axis_sizes if ax.name == "ens2")
-    assert merged._axis_sizes[merged_ens1] == 6
-    assert merged._axis_sizes[merged_ens2] == 3
+    merged_ens1 = next(ax for ax in merged.layout.axes if ax.name == "ens1")
+    merged_ens2 = next(ax for ax in merged.layout.axes if ax.name == "ens2")
+    assert merged.layout.size_of(merged_ens1) == 6
+    assert merged.layout.size_of(merged_ens2) == 3
 
     for noi in plan.nodes_of_interest:
         assert np.asarray(merged._state.values[noi.node]).shape == (6, 3)
@@ -845,16 +845,14 @@ def test_merge_results_growing_axis_at_different_position_raises() -> None:
 
     r1 = EvaluationResult(
         _ex.State(values_r1),
-        {ax_e1_r1: 0, ax_e2_r1: 1},
+        AxisLayout.build(ensemble=[(ax_e1_r1, 2), (ax_e2_r1, 3)]),
         {},
-        axis_sizes={ax_e1_r1: 2, ax_e2_r1: 3},
         factorized_weights={ax_e1_r1: np.full(2, 0.5), ax_e2_r1: np.full(3, 1 / 3)},
     )
     r2 = EvaluationResult(
         _ex.State(values_r2),
-        {ax_e2_r2: 0, ax_e1_r2: 1},
+        AxisLayout.build(ensemble=[(ax_e2_r2, 3), (ax_e1_r2, 2)]),
         {},
-        axis_sizes={ax_e2_r2: 3, ax_e1_r2: 2},
         factorized_weights={ax_e2_r2: np.full(3, 1 / 3), ax_e1_r2: np.full(2, 0.5)},
     )
     # ens1 is at dim 0 in r1 but dim 1 in r2.
@@ -886,9 +884,8 @@ def test_merge_results_param_extend_param_axis_missing_in_r2() -> None:
         values[idx.node] = np.zeros((2, 5))
     r2 = EvaluationResult(
         _ex.State(values),
-        {ax_fake_param: 0, ax_ens: 1},  # ENSEMBLE at dim 1, matching r1
+        AxisLayout.build(parameters=[(ax_fake_param, 2)], ensemble=[(ax_ens, 5)]),  # ENSEMBLE at dim 1, matching r1
         {},
-        axis_sizes={ax_fake_param: 2, ax_ens: 5},
         factorized_weights={ax_fake_param: np.full(2, 0.5), ax_ens: np.full(5, 0.2)},
     )
     # r2 has no PARAMETER axis named "speed" → raises
@@ -916,9 +913,8 @@ def test_merge_results_param_extend_ensemble_pos_mismatch_raises() -> None:
         values[idx.node] = np.zeros((5,))  # shape (5_ens,)
     r2 = EvaluationResult(
         _ex.State(values),
-        {ax_ens: 0},  # ENSEMBLE at dim 0 (r1 has it at dim 1)
+        AxisLayout.build(ensemble=[(ax_ens, 5)]),  # ENSEMBLE at dim 0 (r1 has it at dim 1)
         {},
-        axis_sizes={ax_ens: 5},
         factorized_weights={ax_ens: np.full(5, 0.2)},
     )
     with pytest.raises(ValueError, match="ENSEMBLE axis position mismatch"):

--- a/tests/dt_model/simulation/test_evaluation_handle.py
+++ b/tests/dt_model/simulation/test_evaluation_handle.py
@@ -8,8 +8,8 @@ import pytest
 from scipy import stats
 
 from civic_digital_twins.dt_model import define, inputs, outputs
+from civic_digital_twins.dt_model.axes import ENSEMBLE, Axis
 from civic_digital_twins.dt_model.engine.numpybackend import executor as _executor
-from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
 from civic_digital_twins.dt_model.model.index import DistributionIndex, GenericIndex, Index
 from civic_digital_twins.dt_model.model.model import Model
 from civic_digital_twins.dt_model.simulation.ensemble import DistributionEnsemble
@@ -869,8 +869,8 @@ def test_merge_results_growing_axis_at_different_position_raises() -> None:
 
 def test_merge_results_param_extend_param_axis_missing_in_r2() -> None:
     """_merge_results_param_extend raises ValueError when r2 lacks the growing PARAMETER axis."""
+    from civic_digital_twins.dt_model.axes import PARAMETER  # noqa: PLC0415
     from civic_digital_twins.dt_model.engine.numpybackend import executor as _ex  # noqa: PLC0415
-    from civic_digital_twins.dt_model.model.axis import PARAMETER  # noqa: PLC0415
     from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
 
     speed, model, ev, handle = _make_param_handle(np.array([1.0, 2.0]), ensemble_size=5)
@@ -898,8 +898,8 @@ def test_merge_results_param_extend_param_axis_missing_in_r2() -> None:
 
 def test_merge_results_param_extend_ensemble_pos_mismatch_raises() -> None:
     """_merge_results_param_extend raises ValueError when ENSEMBLE axis positions differ."""
+    from civic_digital_twins.dt_model.axes import PARAMETER  # noqa: PLC0415
     from civic_digital_twins.dt_model.engine.numpybackend import executor as _ex  # noqa: PLC0415
-    from civic_digital_twins.dt_model.model.axis import PARAMETER  # noqa: PLC0415
     from civic_digital_twins.dt_model.simulation.handle import _merge_results_param_extend  # noqa: PLC0415
 
     speed, model, ev, handle = _make_param_handle(np.array([1.0, 2.0]), ensemble_size=5)

--- a/tests/dt_model/simulation/test_evaluation_regional.py
+++ b/tests/dt_model/simulation/test_evaluation_regional.py
@@ -9,8 +9,8 @@ from scipy import stats
 
 from civic_digital_twins.dt_model import define, inputs, outputs
 from civic_digital_twins.dt_model import graph as _graph
+from civic_digital_twins.dt_model.axes import ENSEMBLE, Axis
 from civic_digital_twins.dt_model.engine.numpybackend.executor import NumpyBackend
-from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
 from civic_digital_twins.dt_model.model.index import CategoricalIndex, DistributionIndex, GenericIndex, Index
 from civic_digital_twins.dt_model.model.model import Model
 from civic_digital_twins.dt_model.model.model_variant import ModelVariant

--- a/tests/dt_model/simulation/test_partitioned_ensemble.py
+++ b/tests/dt_model/simulation/test_partitioned_ensemble.py
@@ -7,7 +7,7 @@ import pytest
 from scipy import stats
 
 from civic_digital_twins.dt_model import define, inputs, outputs
-from civic_digital_twins.dt_model.model.axis import ENSEMBLE, Axis
+from civic_digital_twins.dt_model.axes import ENSEMBLE, Axis
 from civic_digital_twins.dt_model.model.index import CategoricalIndex, DistributionIndex, GenericIndex, Index
 from civic_digital_twins.dt_model.model.model import Model
 from civic_digital_twins.dt_model.simulation.ensemble import EnsembleAxisSpec, PartitionedEnsemble

--- a/tests/dt_model/simulation/test_region_execution.py
+++ b/tests/dt_model/simulation/test_region_execution.py
@@ -1,0 +1,162 @@
+"""Tests for simulation/region_execution.py: RegionArrayOps."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from civic_digital_twins.dt_model.axes import ENSEMBLE, PARAMETER, Axis
+from civic_digital_twins.dt_model.engine.frontend import graph
+from civic_digital_twins.dt_model.simulation.axis_layout import AxisLayout
+from civic_digital_twins.dt_model.simulation.region_execution import RegionArrayOps
+
+P1 = Axis("p1", PARAMETER)
+E1 = Axis("e1", ENSEMBLE)
+
+LEAD = RegionArrayOps(AxisLayout([(P1, 2), (E1, 3)]), has_timeseries=False)
+LEAD_TS = RegionArrayOps(AxisLayout([(P1, 2), (E1, 3)]), has_timeseries=True)
+SCALAR = RegionArrayOps(AxisLayout([]), has_timeseries=False)
+
+
+def _selector() -> graph.Node:
+    """Build a minimal variant_selector sentinel node."""
+    return graph.variant_selector(graph.placeholder("sel"), {"a": []}, [])
+
+
+class TestSelectorMask:
+    """selector_mask over the leading layout."""
+
+    def test_scalar_layout_scalar_selector(self):
+        """With no leading axes a scalar selector yields a 0-d mask."""
+        mask = SCALAR.selector_mask(graph.constant("a"), np.asarray("a"), "a")
+        assert mask.shape == () and bool(mask)
+
+    def test_scalar_layout_singleton_selector_normalised(self):
+        """A (1,) selector under an empty layout is normalised to 0-d."""
+        mask = SCALAR.selector_mask(graph.constant("a"), np.asarray(["a"]), "b")
+        assert mask.shape == () and not bool(mask)
+
+    def test_scalar_layout_wide_selector_rejected(self):
+        """A multi-coordinate selector under an empty layout is unsupported."""
+        with pytest.raises(NotImplementedError, match="non-singleton DOMAIN"):
+            SCALAR.selector_mask(graph.constant("a"), np.asarray(["a", "b"]), "a")
+
+    def test_mask_broadcasts_over_leading(self):
+        """The mask spans the full leading shape."""
+        sel = np.array([["a"], ["b"]], dtype=object)  # (P, 1)
+        mask = LEAD.selector_mask(graph.constant("x"), sel, "a")
+        assert mask.shape == (2, 3)
+        assert mask[0].all() and not mask[1].any()
+
+    def test_trailing_singleton_squeezed(self):
+        """A trailing singleton (timeseries) dim on the selector is dropped."""
+        node = graph.timeseries_constant([1.0])
+        sel = np.full((2, 3, 1), "a", dtype=object)
+        mask = LEAD.selector_mask(node, sel, "a")
+        assert mask.shape == (2, 3) and mask.all()
+
+    def test_trailing_wide_rejected(self):
+        """A selector varying along a DOMAIN axis is unsupported."""
+        node = graph.timeseries_constant([1.0, 2.0])
+        sel = np.full((2, 3, 2), "a", dtype=object)
+        with pytest.raises(NotImplementedError, match="non-singleton DOMAIN"):
+            LEAD.selector_mask(node, sel, "a")
+
+
+class TestGather:
+    """gather into a branch-local first axis."""
+
+    def test_passthrough(self):
+        """Empty layouts and selector sentinels bypass the gather."""
+        assert SCALAR.gather(graph.constant(1.0), 7.0, np.array([0])).shape == ()
+        assert LEAD.gather(_selector(), np.array(["a"]), np.array([0])).shape == (1,)
+
+    def test_gather_selects_flat_coordinates(self):
+        """Gather flattens the leading layout and takes the given rows."""
+        arr = np.arange(6.0).reshape(2, 3)
+        np.testing.assert_array_equal(LEAD.gather(graph.constant(1.0), arr, np.array([0, 4])), [0.0, 4.0])
+
+    def test_gather_aligns_scalar_value(self):
+        """A 0-d value gains leading dims and is broadcast before the gather."""
+        out = LEAD.gather(graph.constant(1.0), 5.0, np.array([1, 2]))
+        np.testing.assert_array_equal(out, [5.0, 5.0])
+
+    def test_gather_aligns_domain_only_value(self):
+        """A raw (T,) timeseries value is recognised via output_axes and aligned."""
+        node = graph.timeseries_constant([1.0, 2.0, 3.0])
+        out = LEAD.gather(node, np.array([1.0, 2.0, 3.0]), np.array([0, 5]))
+        assert out.shape == (2, 3)
+        np.testing.assert_array_equal(out[1], [1.0, 2.0, 3.0])
+
+    def test_gather_aligns_incompatible_dims(self):
+        """Dims matching neither 1 nor the axis size trigger a leading prepend."""
+        out = LEAD.gather(graph.constant(1.0), np.ones((4, 7)), np.array([0, 3]))
+        assert out.shape == (2, 4, 7)
+
+
+class TestScatter:
+    """scatter branch-local values back into the full leading layout."""
+
+    def test_passthrough(self):
+        """Empty layouts and selector sentinels bypass the scatter."""
+        assert SCALAR.scatter(graph.constant(1.0), 7.0, np.array([0])).shape == ()
+        assert LEAD.scatter(_selector(), np.array(["a"]), np.array([0])).shape == (1,)
+
+    def test_scatter_roundtrip_with_nan_fill(self):
+        """Scattered floats land at their coordinates; the rest is NaN."""
+        idx = np.array([0, 4])
+        out = LEAD.scatter(graph.constant(1.0), np.array([1.0, 2.0]), idx)
+        assert out.shape == (2, 3)
+        flat = out.reshape(-1)
+        np.testing.assert_array_equal(flat[idx], [1.0, 2.0])
+        assert np.isnan(np.delete(flat, idx)).all()
+
+    def test_scatter_fill_by_dtype(self):
+        """Booleans fill with False, integers with 0, objects with None."""
+        idx = np.array([1])
+        out_b = LEAD.scatter(graph.constant(True), np.array([True]), idx)
+        assert out_b.dtype.kind == "b" and out_b.reshape(-1)[1] and not out_b.reshape(-1)[0]
+        out_i = LEAD.scatter(graph.constant(1), np.array([9]), idx)
+        assert out_i.dtype.kind == "i" and out_i.reshape(-1)[0] == 0
+        out_o = LEAD.scatter(graph.constant("x"), np.array(["v"], dtype=object), idx)
+        assert out_o.dtype == object and out_o.reshape(-1)[0] is None
+
+    def test_scatter_broadcasts_scalar(self):
+        """A 0-d branch value is broadcast across the selected coordinates."""
+        out = LEAD.scatter(graph.constant(1.0), np.float64(9.0), np.array([1, 2]))
+        assert (out.reshape(-1)[[1, 2]] == 9.0).all()
+
+    def test_scatter_broadcasts_singleton_first_dim(self):
+        """A (1, ...) branch value is broadcast across k selected coordinates."""
+        out = LEAD.scatter(graph.constant(1.0), np.array([5.0]), np.array([0, 3]))
+        assert (out.reshape(-1)[[0, 3]] == 5.0).all()
+
+    def test_scatter_broadcasts_domain_only_value(self):
+        """A (T,) value from a DOMAIN node is repeated per coordinate."""
+        node = graph.timeseries_constant([1.0, 2.0, 3.0])
+        out = LEAD_TS.scatter(node, np.array([1.0, 2.0, 3.0]), np.array([0, 5]))
+        assert out.shape == (2, 3, 3)
+        np.testing.assert_array_equal(out.reshape(-1, 3)[5], [1.0, 2.0, 3.0])
+
+    def test_scatter_size_mismatch_rejected(self):
+        """A non-DOMAIN value with a wrong first dimension is an error."""
+        with pytest.raises(ValueError, match="does not match selected size"):
+            LEAD.scatter(graph.constant(1.0), np.ones(3), np.array([0, 1]))
+
+    def test_scatter_pads_scalar_values_with_timeseries(self):
+        """With timeseries, per-coordinate scalars gain a trailing singleton."""
+        out = LEAD_TS.scatter(graph.constant(1.0), np.array([1.0, 2.0]), np.array([0, 1]))
+        assert out.shape == (2, 3, 1)
+
+
+class TestEmptyBranchValue:
+    """empty_branch_value placeholders."""
+
+    def test_shape_without_timeseries(self):
+        """The placeholder spans the leading shape."""
+        out = LEAD.empty_branch_value()
+        assert out.shape == (2, 3) and np.isnan(out).all()
+
+    def test_shape_with_timeseries(self):
+        """With timeseries a trailing singleton is appended."""
+        assert LEAD_TS.empty_branch_value().shape == (2, 3, 1)

--- a/tests/dt_model/symbols/test_index_reduction_methods.py
+++ b/tests/dt_model/symbols/test_index_reduction_methods.py
@@ -72,7 +72,7 @@ class TestIndexReductionMethodCreation:
     @pytest.mark.parametrize("method,operator_class,name", INDEX_REDUCTION_METHODS)
     def test_method_has_correct_axis(self, method, operator_class, name):
         """Test that reduction method creates operator with the default time axis."""
-        from civic_digital_twins.dt_model.model.axis import DOMAIN, Axis
+        from civic_digital_twins.dt_model.axes import DOMAIN, Axis
 
         idx = Index("test_index", 5.0)
         result = method(idx)

--- a/tests/dt_model/test_axes.py
+++ b/tests/dt_model/test_axes.py
@@ -74,3 +74,14 @@ class TestFilterByRole:
         """Any iterable of axes is accepted, not just tuples."""
         p = Axis("p", PARAMETER)
         assert filter_by_role(iter([p, TIME_AXIS]), DOMAIN) == (TIME_AXIS,)
+
+
+class TestTopLevelExports:
+    """Axis vocabulary re-exported by the top-level package."""
+
+    def test_time_axis_reexported(self):
+        """TIME_AXIS is importable from civic_digital_twins.dt_model."""
+        import civic_digital_twins.dt_model as dt
+
+        assert dt.TIME_AXIS is TIME_AXIS
+        assert dt.Axis is Axis

--- a/tests/dt_model/test_axes.py
+++ b/tests/dt_model/test_axes.py
@@ -1,0 +1,76 @@
+"""Tests for the axis utilities in dt_model.axes."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from civic_digital_twins.dt_model.axes import (
+    DOMAIN,
+    ENSEMBLE,
+    PARAMETER,
+    TIME_AXIS,
+    Axis,
+    filter_by_role,
+    union_axes,
+)
+
+
+class TestTimeAxisSingleton:
+    """The canonical TIME_AXIS singleton."""
+
+    def test_identity(self):
+        """TIME_AXIS is the time DOMAIN axis."""
+        assert TIME_AXIS.name == "time"
+        assert TIME_AXIS.role == DOMAIN
+
+    def test_value_equality_with_local_construction(self):
+        """TIME_AXIS compares and hashes equal to a locally constructed copy."""
+        assert TIME_AXIS == Axis("time", DOMAIN)
+        assert hash(TIME_AXIS) == hash(Axis("time", DOMAIN))
+
+
+class TestUnionAxes:
+    """union_axes() merge semantics."""
+
+    def test_empty(self):
+        """No input tuples (or empty ones) yield an empty tuple."""
+        assert union_axes() == ()
+        assert union_axes((), ()) == ()
+
+    def test_preserves_first_seen_order(self):
+        """Axes appear in first-seen order across input tuples."""
+        a = Axis("a", PARAMETER)
+        b = Axis("b", ENSEMBLE)
+        c = Axis("c", DOMAIN)
+        assert union_axes((a, b), (c, a)) == (a, b, c)
+
+    def test_deduplicates_by_value(self):
+        """Two distinct objects with equal (name, role) count as one axis."""
+        a1 = Axis("a", PARAMETER)
+        a2 = Axis("a", PARAMETER)
+        assert union_axes((a1,), (a2,)) == (a1,)
+
+    def test_same_name_different_role_are_distinct(self):
+        """Axes sharing a name but not a role are kept separate."""
+        ad = Axis("x", DOMAIN)
+        ap = Axis("x", PARAMETER)
+        assert union_axes((ad,), (ap,)) == (ad, ap)
+
+
+class TestFilterByRole:
+    """filter_by_role() selection semantics."""
+
+    def test_filters_and_preserves_order(self):
+        """Only axes with the requested role survive, in input order."""
+        p1 = Axis("p1", PARAMETER)
+        e1 = Axis("e1", ENSEMBLE)
+        p2 = Axis("p2", PARAMETER)
+        assert filter_by_role((p1, e1, p2), PARAMETER) == (p1, p2)
+        assert filter_by_role((p1, e1, p2), ENSEMBLE) == (e1,)
+
+    def test_no_match(self):
+        """An empty tuple is returned when no axis has the role."""
+        assert filter_by_role((Axis("p", PARAMETER),), DOMAIN) == ()
+
+    def test_accepts_any_iterable(self):
+        """Any iterable of axes is accepted, not just tuples."""
+        p = Axis("p", PARAMETER)
+        assert filter_by_role(iter([p, TIME_AXIS]), DOMAIN) == (TIME_AXIS,)


### PR DESCRIPTION
## Summary

- `AxisLayout` (`simulation/axis_layout.py`) — new class centralizing the
  axis-to-numpy-dimension mapping that was previously duplicated across
  `evaluation.py`, `handle.py`, and `runner.py`: canonical
  PARAMETER→ENSEMBLE→DOMAIN ordering enforced at construction, role queries,
  merge-signature comparison, `with_grown_axis()`, and dict serialization.
  Exposed publicly as `EvaluationResult.layout` (plus a new
  `.factorized_weights` accessor). Exported from `civic_digital_twins.dt_model`.
- `RegionArrayOps` (`simulation/region_execution.py`) — the guarded-region
  mask/gather/scatter closures that lived inline in `_execute_plan` are now
  a small, independently-tested class built on `AxisLayout`'s pure
  leading-array primitives (`spans_leading`, `broadcast_leading`,
  `flatten_leading`, `take_leading`, …).
- `TIME_AXIS` singleton in `dt_model.axes`, replacing five independent
  `Axis("time", DOMAIN)` constructions across the engine, model, and
  simulation layers. Exported from `civic_digital_twins.dt_model`.
- `union_axes()` / `filter_by_role()` — axis-tuple set operations moved from
  `engine.frontend.graph` into `dt_model.axes`, the canonical home for the
  axis vocabulary shared by all three layers.
- `handle.py`'s `_merge_results`/`_merge_results_param_extend` and
  `ensemble.py`'s `FrozenEnsemble.concat`/`concat_along`/`with_replaced_axis`
  now grow axes through one shared primitive (`AxisLayout.with_grown_axis`),
  replacing three independent hand-rolled rebuilds and their stale
  identity-based idioms. `runner.py`'s resume serialization goes through
  `AxisLayout.to_dict()`/`from_dict()`, removing the `# type: ignore[attr-defined]`
  markers that private cross-module access required.
- **Breaking:** `civic_digital_twins.dt_model.model.axis` removed outright
  (no external consumers — the top-level `civic_digital_twins.dt_model`
  re-exports were already the stable path). `EvaluationResult`'s transitional
  dict-accepting constructor form is also gone; `axis_layout=` now requires
  an `AxisLayout`. See CHANGELOG `[Unreleased]` for the full list and
  replacements.

## Test plan

- [x] `uv run pytest` — 1010 passed, 100% coverage
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest tests/test_doc_sync.py` — 7/7 (doc↔script alignment)
- [x] All `examples/doc/*.py` scripts run clean
- [x] `CHANGELOG.md` `[Unreleased]` updated, breaking changes marked