### PR TITLE
refactor(model)!: make Index/TimeseriesIndex/DistributionIndex.value private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `union_axes()` and `filter_by_role()` in `civic_digital_twins.dt_model.axes`
   — axis-tuple set operations, consolidating a duplicate `_union_axes()` that
   previously lived in `engine.frontend.graph`.
+- `Index.is_abstract` / `TimeseriesIndex.is_abstract` — read-only property
+  replacing ad-hoc `value is None` checks; `DistributionIndex` overrides it
+  to always return `True`. `Model.abstract_indexes()` now delegates to it.
+- `Index.concrete_default` / `TimeseriesIndex.concrete_default` — read-only
+  property returning the concrete scalar/array default, or `None` when the
+  index is a bare placeholder or formula-backed. Replaces `Scenario`'s direct
+  use of `.value` when seeding the executor state.
+- `DistributionIndex.frozen_distribution` — the frozen distribution instance,
+  replacing `DistributionIndex.value` (see below).
 
 ### Changed
 
@@ -95,6 +104,13 @@ Removed without a prior deprecation cycle:
   to code constructing `EvaluationResult` directly, which is not the
   documented flow (results come from `Evaluation.evaluate()`,
   `EvaluationHandle`, or `ModelEvaluator.resume()`).
+- **Breaking:** `Index.value` / `TimeseriesIndex.value` / `DistributionIndex.value`
+  — the raw scalar/node/`None`/`Distribution` union getter is gone. Its
+  ambiguity invited pattern-matching on the runtime type inside `compute()`
+  bodies instead of building a graph formula (found in the wild: an index
+  silently degrading to an unresolved placeholder whenever its input hadn't
+  concretely resolved yet). Use `is_abstract`, `concrete_default`, or
+  `DistributionIndex.frozen_distribution` instead (see above).
 
 
 ## [0.10.0] - 2026-06-21

--- a/civic_digital_twins/dt_model/model/index.py
+++ b/civic_digital_twins/dt_model/model/index.py
@@ -359,8 +359,9 @@ class Index(GenericIndex):
         """Whether this index requires an external value before evaluation."""
         return self._value is None
 
+    @property
     def concrete_default(self) -> graph.Scalar | None:
-        """Return this index's concrete scalar default, or ``None`` if unset or formula-backed.
+        """The index's concrete scalar default, or ``None`` if unset or formula-backed.
 
         Used by :class:`~simulation.scenario.Scenario` to seed the executor
         state with each index's default before overrides are applied. Most
@@ -459,8 +460,9 @@ class TimeseriesIndex(GenericIndex):
         """Whether this index requires an external value before evaluation."""
         return self._value is None
 
+    @property
     def concrete_default(self) -> np.ndarray | None:
-        """Return this index's concrete array default, or ``None`` if unset or formula-backed.
+        """The index's concrete array default, or ``None`` if unset or formula-backed.
 
         Used by :class:`~simulation.scenario.Scenario` to seed the executor
         state with each index's default before overrides are applied. Most

--- a/civic_digital_twins/dt_model/model/index.py
+++ b/civic_digital_twins/dt_model/model/index.py
@@ -350,14 +350,24 @@ class Index(GenericIndex):
         return self._name
 
     @property
-    def value(self) -> graph.Scalar | graph.Node | None:
-        """The default scalar / formula node, or ``None`` for a bare placeholder."""
-        return self._value
-
-    @property
     def node(self) -> graph.Node:
         """The underlying computation graph node."""
         return self._node
+
+    @property
+    def is_abstract(self) -> bool:
+        """Whether this index requires an external value before evaluation."""
+        return self._value is None
+
+    def concrete_default(self) -> graph.Scalar | None:
+        """Return this index's concrete scalar default, or ``None`` if unset or formula-backed.
+
+        Used by :class:`~simulation.scenario.Scenario` to seed the executor
+        state with each index's default before overrides are applied. Most
+        model-authoring code should not need this — read values through the
+        computation graph (``.node``) instead.
+        """
+        return None if isinstance(self._value, graph.Node) else self._value
 
     def __repr__(self) -> str:
         """Return a string representation of the index."""
@@ -440,14 +450,24 @@ class TimeseriesIndex(GenericIndex):
         return self._name
 
     @property
-    def value(self) -> np.ndarray | graph.Node | None:
-        """The default array / formula node, or ``None`` for a bare placeholder."""
-        return self._value
-
-    @property
     def node(self) -> graph.Node:
         """The underlying computation graph node."""
         return self._node
+
+    @property
+    def is_abstract(self) -> bool:
+        """Whether this index requires an external value before evaluation."""
+        return self._value is None
+
+    def concrete_default(self) -> np.ndarray | None:
+        """Return this index's concrete array default, or ``None`` if unset or formula-backed.
+
+        Used by :class:`~simulation.scenario.Scenario` to seed the executor
+        state with each index's default before overrides are applied. Most
+        model-authoring code should not need this — read values through the
+        computation graph (``.node``) instead.
+        """
+        return None if isinstance(self._value, graph.Node) else self._value
 
     def __repr__(self) -> str:
         """Return a string representation of the timeseries index."""
@@ -476,8 +496,8 @@ class ConstTimeseriesIndex(TimeseriesIndex):
     --------
     >>> import numpy as np
     >>> ts = ConstTimeseriesIndex("demand", np.array([10.0, 20.0, 30.0]))
-    >>> ts.value
-    array([10., 20., 30.])
+    >>> ts
+    const_timeseries_idx([10.0, 20.0, 30.0])
     """
 
     def __init__(self, name: str, value: np.ndarray) -> None:
@@ -541,9 +561,14 @@ class DistributionIndex(Index):
         return dict(self._params)
 
     @property
-    def value(self) -> Distribution:  # type: ignore[override]
-        """The frozen distribution instance."""
+    def frozen_distribution(self) -> Distribution:
+        """The frozen distribution instance sampled by the ensemble."""
         return self._frozen
+
+    @property
+    def is_abstract(self) -> bool:
+        """Always ``True``: a distribution-backed index is always sampled by the ensemble."""
+        return True
 
     def sample(self, rng: np.random.Generator | None = None, size: int = 1) -> np.ndarray:
         """Draw ``size`` samples from the frozen distribution.

--- a/civic_digital_twins/dt_model/model/model.py
+++ b/civic_digital_twins/dt_model/model/model.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from ..engine.frontend import graph
 from ..engine.numpybackend.executor import Functor
-from .index import DistributionIndex, GenericIndex, Index, TimeseriesIndex
+from .index import GenericIndex, Index, TimeseriesIndex
 
 
 class ModelContractWarning(UserWarning):
@@ -615,9 +615,9 @@ class Model:
     def abstract_indexes(self) -> list[GenericIndex]:
         """Return indexes that require external values before evaluation.
 
-        An index is abstract when its ``value`` is ``None`` (explicit
-        placeholder) or a :class:`~.index.Distribution` (needs sampling).
-        Constant and formula-based indexes are concrete and are not returned.
+        Delegates to each index's own :attr:`~.index.Index.is_abstract` /
+        :attr:`~.index.TimeseriesIndex.is_abstract` classification. Constant
+        and formula-based indexes are concrete and are not returned.
 
         Returns
         -------
@@ -631,15 +631,7 @@ class Model:
         as an input (e.g. a distribution-backed behavioural parameter sampled
         internally by the ensemble).
         """
-        result = []
-        for index in self.indexes:
-            if isinstance(index, Index):
-                if index.value is None or isinstance(index, DistributionIndex):
-                    result.append(index)
-            elif isinstance(index, TimeseriesIndex):
-                if index.value is None:
-                    result.append(index)
-        return result
+        return [index for index in self.indexes if isinstance(index, (Index, TimeseriesIndex)) and index.is_abstract]
 
     def is_instantiated(self) -> bool:
         """Return ``True`` when all indexes have concrete, evaluable values.

--- a/civic_digital_twins/dt_model/simulation/ensemble.py
+++ b/civic_digital_twins/dt_model/simulation/ensemble.py
@@ -15,7 +15,7 @@ from ..model.index import (
     CategoricalIndex,
     ConditionalCategoricalIndex,
     ConditionalDistributionIndex,
-    Distribution,
+    DistributionIndex,
     GenericIndex,
     Index,
 )
@@ -1067,7 +1067,7 @@ class CrossProductEnsemble:
                 cats_unordered.append(idx)
             elif isinstance(idx, ConditionalDistributionIndex):
                 dists_unordered.append(idx)
-            elif isinstance(idx, Index) and isinstance(idx.value, Distribution):
+            elif isinstance(idx, DistributionIndex):
                 dists_unordered.append(idx)
             # else: plain placeholder Index — skip silently
 

--- a/civic_digital_twins/dt_model/simulation/scenario.py
+++ b/civic_digital_twins/dt_model/simulation/scenario.py
@@ -320,9 +320,9 @@ class Scenario:
     def effective_distribution(self, idx: GenericIndex) -> Distribution | None:
         """Return the effective :class:`~model.index.Distribution` for *idx*.
 
-        Checks ``overrides`` first; falls back to ``idx.value`` if that is a
-        :class:`~model.index.Distribution`.  Returns ``None`` when no
-        distribution is configured.
+        Checks ``overrides`` first; falls back to *idx*'s own frozen
+        distribution if it is a :class:`~model.index.DistributionIndex`.
+        Returns ``None`` when no distribution is configured.
 
         Parameters
         ----------
@@ -339,7 +339,7 @@ class Scenario:
         if val is not None:
             return val if isinstance(val, Distribution) else None
         if isinstance(idx, DistributionIndex):
-            return idx.value
+            return idx.frozen_distribution
         return None
 
     def effective_outcomes(self, idx: CategoricalIndex | ConditionalCategoricalIndex) -> dict[str, float] | None:
@@ -444,7 +444,7 @@ class Scenario:
             # Determine the effective value: override takes precedence.
             val: DomainValue | graph.Node | None = self._overrides.get(idx)
             if val is None and isinstance(idx, (Index, TimeseriesIndex)):
-                val = idx.value  # type: ignore[assignment]  # Scalar ⊄ DomainValue
+                val = idx.concrete_default()  # type: ignore[assignment]  # Scalar ⊄ DomainValue
 
             if val is None or isinstance(val, (Distribution, dict, graph.Node)):
                 continue  # no concrete value or formula node; ensemble's responsibility

--- a/civic_digital_twins/dt_model/simulation/scenario.py
+++ b/civic_digital_twins/dt_model/simulation/scenario.py
@@ -444,7 +444,7 @@ class Scenario:
             # Determine the effective value: override takes precedence.
             val: DomainValue | graph.Node | None = self._overrides.get(idx)
             if val is None and isinstance(idx, (Index, TimeseriesIndex)):
-                val = idx.concrete_default()  # type: ignore[assignment]  # Scalar ⊄ DomainValue
+                val = idx.concrete_default  # type: ignore[assignment]  # Scalar ⊄ DomainValue
 
             if val is None or isinstance(val, (Distribution, dict, graph.Node)):
                 continue  # no concrete value or formula node; ensemble's responsibility

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -860,13 +860,13 @@ Multiplying the per-constraint probabilities gives the joint
 *sustainability field* over the grid:
 
 ```python
-from civic_digital_twins.dt_model import Distribution
+from civic_digital_twins.dt_model import DistributionIndex
 
 field = np.ones((tt.size, ee.size))
 for c in model.constraints:
     usage = np.broadcast_to(result[c.usage], result.full_shape)
-    if isinstance(c.capacity.value, Distribution):
-        mask = 1.0 - c.capacity.value.cdf(usage)        # P(usage ≤ capacity)
+    if isinstance(c.capacity, DistributionIndex):
+        mask = 1.0 - c.capacity.frozen_distribution.cdf(usage)  # P(usage ≤ capacity)
     else:
         cap = np.broadcast_to(result[c.capacity], result.full_shape)
         mask = (usage <= cap).astype(float)

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -164,7 +164,7 @@ def load_dist(weather):
 
 pv_load = ConditionalDistributionIndex("load", [cv_weather], load_dist)
 
-assert pv_load.value is None  # abstract — resolved per-scenario by the ensemble
+assert pv_load.is_abstract  # abstract — resolved per-scenario by the ensemble
 ```
 
 The factory receives string values for `CategoricalIndex` parents and float values
@@ -211,7 +211,7 @@ def weekend_probs(season):
 
 cv_weekend = ConditionalCategoricalIndex("weekend", [cv_season], ["yes", "no"], weekend_probs)
 
-assert cv_weekend.value is None  # abstract
+assert cv_weekend.is_abstract  # abstract
 ```
 
 Like `CategoricalIndex`, `cv_weekend == "yes"` returns a `graph.equal` node usable
@@ -263,9 +263,9 @@ done by constructing `Index` and `TimeseriesIndex` objects beforehand.
 The model merely collects them so that `Evaluation` and ensemble classes
 can inspect which indexes are abstract.
 
-`abstract_indexes()` returns indexes whose `value` is `None` or a
-`Distribution`.  All other indexes (constants and formulas) are concrete
-and are not returned.
+`abstract_indexes()` returns indexes whose `is_abstract` property is `True`
+(a bare placeholder, or a `DistributionIndex`).  All other indexes (constants
+and formulas) are concrete and are not returned.
 
 ### Recommended API: `@define` + `compute()`
 

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -38,10 +38,10 @@ def _demo_00_index_modes() -> None:
     # Explicit placeholder (resolved by the caller)
     demand = Index("demand", None)
 
-    assert cap_dist.value is not None
-    assert mu.value is not None
-    assert cap.value == 500.0
-    assert demand.value is None
+    assert cap_dist.frozen_distribution is not None
+    assert mu.frozen_distribution is not None
+    assert cap.concrete_default == 500.0
+    assert demand.is_abstract
     _ = load
 
 
@@ -56,7 +56,7 @@ def _demo_01_categorical_index() -> None:
 
     mode = CategoricalIndex("mode", {"bike": 0.3, "train": 0.7})
 
-    assert mode.value is None
+    assert mode.is_abstract
     assert mode.support == ["bike", "train"]
 
 
@@ -76,7 +76,7 @@ def _demo_03_conditional_categorical_index() -> None:
 
     cv_weekend = ConditionalCategoricalIndex("weekend", [cv_season], ["yes", "no"], weekend_probs)
 
-    assert cv_weekend.value is None  # abstract
+    assert cv_weekend.is_abstract  # abstract
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +99,7 @@ def _demo_04_conditional_distribution_index() -> None:
 
     pv_load = ConditionalDistributionIndex("load", [cv_weather], load_dist)
 
-    assert pv_load.value is None  # abstract — resolved per-scenario by the ensemble
+    assert pv_load.is_abstract  # abstract — resolved per-scenario by the ensemble
 
 
 # ---------------------------------------------------------------------------
@@ -119,8 +119,8 @@ def _demo_02_timeseries_index() -> None:
     # Placeholder (externally supplied)
     demand_ts = TimeseriesIndex("demand_ts")
 
-    assert flow.value is not None
-    assert demand_ts.value is None
+    assert flow.concrete_default is not None
+    assert demand_ts.is_abstract
 
 
 # ---------------------------------------------------------------------------

--- a/examples/doc/doc_model.py
+++ b/examples/doc/doc_model.py
@@ -340,7 +340,7 @@ def _demo_18_19_overtourism() -> None:
         ConditionalDistributionIndex,
         ConstIndex,
         CrossProductEnsemble,
-        Distribution,
+        DistributionIndex,
         Evaluation,
         GenericIndex,
         Index,
@@ -422,8 +422,8 @@ def _demo_18_19_overtourism() -> None:
     field = np.ones((tt.size, ee.size))
     for c in model.constraints:
         usage = np.broadcast_to(result[c.usage], result.full_shape)
-        if isinstance(c.capacity.value, Distribution):
-            mask = 1.0 - c.capacity.value.cdf(usage)
+        if isinstance(c.capacity, DistributionIndex):
+            mask = 1.0 - c.capacity.frozen_distribution.cdf(usage)
         else:
             cap = np.broadcast_to(result[c.capacity], result.full_shape)
             mask = (usage <= cap).astype(float)

--- a/examples/doc/doc_modularity.py
+++ b/examples/doc/doc_modularity.py
@@ -478,7 +478,7 @@ peak_factor = Index(
     graph.piecewise((1.8, mode == "bike"), (1.0, True)),  # default: non-bike
 )
 
-assert peak_factor.value is not None
+assert not peak_factor.is_abstract
 
 
 # ---------------------------------------------------------------------------
@@ -500,7 +500,7 @@ def _demo_15_piecewise_categorical() -> None:
         ),
     )
 
-    assert peak_factor.value is not None
+    assert not peak_factor.is_abstract
 
 
 # ---------------------------------------------------------------------------

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -19,7 +19,6 @@ from civic_digital_twins.dt_model import (  # noqa: E402
     CategoricalIndex,
     ConditionalDistributionIndex,
     CrossProductEnsemble,
-    Distribution,
     DistributionIndex,
     DomainValue,
     Evaluation,
@@ -194,9 +193,9 @@ field = np.ones(visitors_axis.size)
 for c in model.constraints:
     usage = np.broadcast_to(result[c.usage], result.full_shape)  # (201, 6)
 
-    if isinstance(c.capacity.value, Distribution):
+    if isinstance(c.capacity, DistributionIndex):
         # Probabilistic capacity: probability that usage ≤ capacity
-        mask = 1.0 - c.capacity.value.cdf(usage)
+        mask = 1.0 - c.capacity.frozen_distribution.cdf(usage)
     else:
         cap = np.broadcast_to(result[c.capacity], result.full_shape)
         mask = (usage <= cap).astype(float)

--- a/examples/doc/doc_overtourism_getting_started.py
+++ b/examples/doc/doc_overtourism_getting_started.py
@@ -46,8 +46,8 @@ CV_weather = CategoricalIndex(
     {"good": 1 / 3, "unsettled": 1 / 3, "bad": 1 / 3},
 )
 
-assert CV_season.value is None  # placeholder
-assert CV_weather.value is None
+assert CV_season.is_abstract  # placeholder
+assert CV_weather.is_abstract
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +75,7 @@ PV_visitors = ConditionalDistributionIndex(
     visitors_distribution,
 )
 
-assert PV_visitors.value is None  # placeholder (axis in grid evaluation)
+assert PV_visitors.is_abstract  # placeholder (axis in grid evaluation)
 
 
 # ---------------------------------------------------------------------------

--- a/examples/overtourism_molveno/molveno_model.py
+++ b/examples/overtourism_molveno/molveno_model.py
@@ -94,7 +94,6 @@ from civic_digital_twins.dt_model import (
     outputs,
     sample_across,
 )
-from civic_digital_twins.dt_model.model.index import Distribution
 from civic_digital_twins.dt_model.simulation.handle import _get_default_executor
 from civic_digital_twins.dt_model.simulation.runner import (
     EvaluationConfig,
@@ -782,8 +781,8 @@ def compute_sustainability_field(
     field_elements: dict = {}
     for c in model.constraints:
         usage = np.broadcast_to(result[c.usage], result.full_shape)
-        if isinstance(c.capacity.value, Distribution):
-            mask = (1.0 - c.capacity.value.cdf(usage)).astype(float)
+        if isinstance(c.capacity, DistributionIndex):
+            mask = (1.0 - c.capacity.frozen_distribution.cdf(usage)).astype(float)
         else:
             cap = np.broadcast_to(result[c.capacity], result.full_shape)
             mask = (usage <= cap).astype(float)

--- a/examples/overtourism_molveno/overtourism-getting-started.md
+++ b/examples/overtourism_molveno/overtourism-getting-started.md
@@ -237,16 +237,16 @@ The sustainability field measures what fraction of the weighted scenario
 population considers each visitor count sustainable:
 
 ```python
-from civic_digital_twins.dt_model import Distribution
+from civic_digital_twins.dt_model import DistributionIndex
 
 field = np.ones(visitors_axis.size)
 
 for c in model.constraints:
     usage = np.broadcast_to(result[c.usage], result.full_shape)  # (201, 6)
 
-    if isinstance(c.capacity.value, Distribution):
+    if isinstance(c.capacity, DistributionIndex):
         # Probabilistic capacity: probability that usage ≤ capacity
-        mask = 1.0 - c.capacity.value.cdf(usage)
+        mask = 1.0 - c.capacity.frozen_distribution.cdf(usage)
     else:
         cap = np.broadcast_to(result[c.capacity], result.full_shape)
         mask = (usage <= cap).astype(float)

--- a/tests/dt_model/examples/test_overtourism_molveno.py
+++ b/tests/dt_model/examples/test_overtourism_molveno.py
@@ -19,7 +19,7 @@ from civic_digital_twins.dt_model import (
     ModelContractWarning,
     Scenario,
 )
-from civic_digital_twins.dt_model.model.index import Distribution, DistributionIndex, GenericIndex, Index
+from civic_digital_twins.dt_model.model.index import DistributionIndex, GenericIndex, Index
 
 model = MolvenoModel(inputs=MolvenoModel.default_inputs())
 _pvs = [model.inputs.pv_tourists, model.inputs.pv_excursionists]
@@ -46,8 +46,8 @@ def compute_field(model, ensemble, tt, ee):
     for c in model.constraints:
         # Broadcast to full shape in case the formula doesn't depend on all axes.
         usage = np.broadcast_to(result[c.usage], result.full_shape)
-        if isinstance(c.capacity.value, Distribution):
-            mask = (1.0 - c.capacity.value.cdf(usage)).astype(float)
+        if isinstance(c.capacity, DistributionIndex):
+            mask = (1.0 - c.capacity.frozen_distribution.cdf(usage)).astype(float)
         else:
             cap = np.broadcast_to(result[c.capacity], result.full_shape)
             mask = (usage <= cap).astype(float)

--- a/tests/dt_model/model/test_categorical_index.py
+++ b/tests/dt_model/model/test_categorical_index.py
@@ -17,7 +17,7 @@ def test_construction_basic():
     """CategoricalIndex constructs with valid outcomes."""
     ci = CategoricalIndex("mode", {"bike": 0.3, "train": 0.7})
     assert ci.name == "mode"
-    assert ci.value is None  # always abstract
+    assert ci.is_abstract  # always abstract
 
 
 def test_node_is_placeholder():
@@ -43,7 +43,7 @@ def test_outcomes_returns_copy():
 def test_is_abstract():
     """CategoricalIndex is treated as abstract (value is None)."""
     ci = CategoricalIndex("mode", {"a": 1.0})
-    assert ci.value is None
+    assert ci.is_abstract
 
 
 def test_repr():

--- a/tests/dt_model/model/test_conditional_indexes.py
+++ b/tests/dt_model/model/test_conditional_indexes.py
@@ -50,7 +50,7 @@ def test_ccat_construction_basic():
         factory=_weather_given_season,
     )
     assert ccat.name == "weather_cond"
-    assert ccat.value is None
+    assert ccat.is_abstract
     assert ccat.support == ["sunny", "rainy"]
     assert ccat.parents == [_season]
 
@@ -205,7 +205,7 @@ def test_cdist_construction_basic():
     """ConditionalDistributionIndex constructs with valid arguments."""
     cdist = ConditionalDistributionIndex("temp", parents=[_weather], factory=_dist_given_weather)
     assert cdist.name == "temp"
-    assert cdist.value is None
+    assert cdist.is_abstract
     assert cdist.parents == [_weather]
 
 

--- a/tests/dt_model/model/test_model_variant.py
+++ b/tests/dt_model/model/test_model_variant.py
@@ -125,14 +125,14 @@ def test_static_selector_bike_outputs():
     """Active variant's outputs are accessible through ModelVariant."""
     mv = ModelVariant("Transport", _make_variants(), selector="bike")
     # BikeModel sets emissions=0.0
-    assert mv.outputs.emissions.concrete_default() == 0.0
+    assert mv.outputs.emissions.concrete_default == 0.0
 
 
 def test_static_selector_train_outputs():
     """Static 'train' selector delegates to TrainModel."""
     mv = ModelVariant("Transport", _make_variants(), selector="train")
     # TrainModel sets emissions=50.0
-    assert mv.outputs.emissions.concrete_default() == 50.0
+    assert mv.outputs.emissions.concrete_default == 50.0
 
 
 def test_static_selector_unknown_key_raises():
@@ -424,7 +424,7 @@ def test_expose_proxy_field_accessible_on_active_variant():
     }
     mv = ModelVariant("ExposeGroup", variants, selector="a")
     # The expose.ratio of variant "a" should be accessible.
-    assert mv.expose.ratio.concrete_default() == 1.0
+    assert mv.expose.ratio.concrete_default == 1.0
 
 
 def test_expose_indexes_not_in_inactive_variant():

--- a/tests/dt_model/model/test_model_variant.py
+++ b/tests/dt_model/model/test_model_variant.py
@@ -4,10 +4,12 @@
 
 import pytest
 
-from civic_digital_twins.dt_model import define, expose, inputs, outputs
+from civic_digital_twins.dt_model import NumpyBackend, define, expose, inputs, outputs
 from civic_digital_twins.dt_model.model.index import Index
 from civic_digital_twins.dt_model.model.model import Model
 from civic_digital_twins.dt_model.model.model_variant import ModelVariant
+from civic_digital_twins.dt_model.simulation.evaluation import Evaluation
+from civic_digital_twins.dt_model.simulation.scenario import Scenario
 
 # ---------------------------------------------------------------------------
 # Shared fixtures — two concrete Model subclasses with the same I/O contract
@@ -29,8 +31,7 @@ class _BikeModel(Model):
 
     def compute(self, inputs: Inputs) -> Outputs:
         """Compute throughput/emissions for the bike variant."""
-        cap_val = inputs.capacity.value
-        throughput = Index("throughput", float(cap_val) * 1.0 if isinstance(cap_val, (int, float)) else None)
+        throughput = Index("throughput", inputs.capacity * 1.0)
         emissions = Index("emissions", 0.0)
         return _BikeModel.Outputs(throughput=throughput, emissions=emissions)
 
@@ -50,8 +51,7 @@ class _TrainModel(Model):
 
     def compute(self, inputs: Inputs) -> Outputs:
         """Compute throughput/emissions for the train variant."""
-        cap_val = inputs.capacity.value
-        throughput = Index("throughput", float(cap_val) * 10.0 if isinstance(cap_val, (int, float)) else None)
+        throughput = Index("throughput", inputs.capacity * 10.0)
         emissions = Index("emissions", 50.0)
         return _TrainModel.Outputs(throughput=throughput, emissions=emissions)
 
@@ -125,14 +125,14 @@ def test_static_selector_bike_outputs():
     """Active variant's outputs are accessible through ModelVariant."""
     mv = ModelVariant("Transport", _make_variants(), selector="bike")
     # BikeModel sets emissions=0.0
-    assert mv.outputs.emissions.value == 0.0
+    assert mv.outputs.emissions.concrete_default() == 0.0
 
 
 def test_static_selector_train_outputs():
     """Static 'train' selector delegates to TrainModel."""
     mv = ModelVariant("Transport", _make_variants(), selector="train")
     # TrainModel sets emissions=50.0
-    assert mv.outputs.emissions.value == 50.0
+    assert mv.outputs.emissions.concrete_default() == 50.0
 
 
 def test_static_selector_unknown_key_raises():
@@ -170,7 +170,8 @@ def test_outputs_proxy_delegates_to_active_variant():
     variants = _make_variants()
     mv = ModelVariant("Transport", variants, selector="train")
     # TrainModel throughput = capacity * 10 = 500 * 10 = 5000
-    assert mv.outputs.throughput.value == 5000.0
+    result = Evaluation(Scenario(mv)).evaluate(backend=NumpyBackend)
+    assert float(result[mv.outputs.throughput]) == pytest.approx(5000.0)
 
 
 def test_expose_proxy_delegates_to_active_variant():
@@ -401,8 +402,7 @@ class _ExposeModel(Model, legacy=True):
         Outputs = _ExposeModel.Outputs
         Expose = _ExposeModel.Expose
 
-        cap_val = capacity.value
-        throughput = Index("throughput", float(cap_val) if isinstance(cap_val, (int, float)) else None)
+        throughput = Index("throughput", capacity * 1.0)
         emissions = Index("emissions", 0.0)
         ratio = Index("ratio_" + label, 1.0)
 
@@ -424,7 +424,7 @@ def test_expose_proxy_field_accessible_on_active_variant():
     }
     mv = ModelVariant("ExposeGroup", variants, selector="a")
     # The expose.ratio of variant "a" should be accessible.
-    assert mv.expose.ratio.value == 1.0
+    assert mv.expose.ratio.concrete_default() == 1.0
 
 
 def test_expose_indexes_not_in_inactive_variant():

--- a/tests/dt_model/model/test_model_variant_runtime.py
+++ b/tests/dt_model/model/test_model_variant_runtime.py
@@ -28,8 +28,7 @@ class _BikeModel(Model):
 
     def compute(self, inputs: Inputs) -> Outputs:
         """Compute throughput/emissions for the bike variant."""
-        cap_val = inputs.capacity.value
-        throughput = Index("throughput", float(cap_val) * 1.0 if isinstance(cap_val, (int, float)) else None)
+        throughput = Index("throughput", inputs.capacity * 1.0)
         emissions = Index("emissions", 0.0)
         return _BikeModel.Outputs(throughput=throughput, emissions=emissions)
 
@@ -47,8 +46,7 @@ class _TrainModel(Model):
 
     def compute(self, inputs: Inputs) -> Outputs:
         """Compute throughput/emissions for the train variant."""
-        cap_val = inputs.capacity.value
-        throughput = Index("throughput", float(cap_val) * 10.0 if isinstance(cap_val, (int, float)) else None)
+        throughput = Index("throughput", inputs.capacity * 10.0)
         emissions = Index("emissions", 50.0)
         return _TrainModel.Outputs(throughput=throughput, emissions=emissions)
 

--- a/tests/dt_model/symbols/test_index.py
+++ b/tests/dt_model/symbols/test_index.py
@@ -18,16 +18,18 @@ def test_timeseries_index_construction():
     idx = TimeseriesIndex("cap", values)
     assert idx.name == "cap"
     assert isinstance(idx.node, graph.timeseries_placeholder)
-    assert isinstance(idx.concrete_default(), np.ndarray)
-    assert np.array_equal(idx.concrete_default(), values)
+    default = idx.concrete_default
+    assert isinstance(default, np.ndarray)
+    assert np.array_equal(default, values)
 
 
 def test_timeseries_index_value_attribute():
-    """Test that concrete_default() holds the numpy array."""
+    """Test that concrete_default holds the numpy array."""
     values = np.array([10.0, 20.0, 30.0])
     idx = TimeseriesIndex("cap", values)
-    assert isinstance(idx.concrete_default(), np.ndarray)
-    assert np.array_equal(idx.concrete_default(), values)
+    default = idx.concrete_default
+    assert isinstance(default, np.ndarray)
+    assert np.array_equal(default, values)
 
 
 def test_timeseries_index_evaluation():
@@ -158,14 +160,14 @@ def test_index_scalar_creates_placeholder():
     """Index(scalar) creates a graph.placeholder node (D1a: value lives in model layer)."""
     idx = Index("cost", 8.0)
     assert isinstance(idx.node, graph.placeholder)
-    assert idx.concrete_default() == 8.0
+    assert idx.concrete_default == 8.0
 
 
 def test_const_index_scalar_creates_constant():
     """ConstIndex always creates a graph.constant node regardless of D1a."""
     idx = ConstIndex("cost", 8.0)
     assert isinstance(idx.node, graph.constant)
-    assert idx.concrete_default() == 8.0
+    assert idx.concrete_default == 8.0
 
 
 def test_timeseries_index_array_creates_timeseries_placeholder():
@@ -173,8 +175,9 @@ def test_timeseries_index_array_creates_timeseries_placeholder():
     arr = np.array([1.0, 2.0, 3.0])
     idx = TimeseriesIndex("ts", arr)
     assert isinstance(idx.node, graph.timeseries_placeholder)
-    assert isinstance(idx.concrete_default(), np.ndarray)
-    assert np.array_equal(idx.concrete_default(), arr)
+    default = idx.concrete_default
+    assert isinstance(default, np.ndarray)
+    assert np.array_equal(default, arr)
 
 
 def test_const_timeseries_index_creates_timeseries_constant():
@@ -429,9 +432,9 @@ def test_distribution_index_params_property_returns_copy():
 
 
 def test_const_index_value():
-    """ConstIndex.concrete_default() returns the constant value."""
+    """ConstIndex.concrete_default returns the constant value."""
     idx = ConstIndex("c", 42.0)
-    assert idx.concrete_default() == 42.0
+    assert idx.concrete_default == 42.0
 
 
 def test_const_index_str():
@@ -450,8 +453,9 @@ def test_const_timeseries_index_construction():
     arr = np.array([1.0, 2.0, 3.0])
     ts = ConstTimeseriesIndex("demand", arr)
     assert ts.name == "demand"
-    assert isinstance(ts.concrete_default(), np.ndarray)
-    assert np.array_equal(ts.concrete_default(), arr)
+    default = ts.concrete_default
+    assert isinstance(default, np.ndarray)
+    assert np.array_equal(default, arr)
     assert isinstance(ts.node, graph.timeseries_constant)
 
 

--- a/tests/dt_model/symbols/test_index.py
+++ b/tests/dt_model/symbols/test_index.py
@@ -18,16 +18,16 @@ def test_timeseries_index_construction():
     idx = TimeseriesIndex("cap", values)
     assert idx.name == "cap"
     assert isinstance(idx.node, graph.timeseries_placeholder)
-    assert isinstance(idx.value, np.ndarray)
-    assert np.array_equal(idx.value, values)
+    assert isinstance(idx.concrete_default(), np.ndarray)
+    assert np.array_equal(idx.concrete_default(), values)
 
 
 def test_timeseries_index_value_attribute():
-    """Test that the value attribute holds the numpy array."""
+    """Test that concrete_default() holds the numpy array."""
     values = np.array([10.0, 20.0, 30.0])
     idx = TimeseriesIndex("cap", values)
-    assert isinstance(idx.value, np.ndarray)
-    assert np.array_equal(idx.value, values)
+    assert isinstance(idx.concrete_default(), np.ndarray)
+    assert np.array_equal(idx.concrete_default(), values)
 
 
 def test_timeseries_index_evaluation():
@@ -66,7 +66,7 @@ def test_timeseries_index_no_values():
     """Test construction of a TimeseriesIndex with no values (placeholder mode)."""
     idx = TimeseriesIndex("inflow")
     assert isinstance(idx.node, graph.timeseries_placeholder)
-    assert idx.value is None
+    assert idx.is_abstract
 
 
 def test_timeseries_index_placeholder_raises_without_state():
@@ -100,11 +100,12 @@ def test_timeseries_index_str_placeholder():
 
 
 def test_timeseries_index_formula_construction():
-    """TimeseriesIndex accepts a graph.Node and stores it as the node."""
+    """TimeseriesIndex accepts a graph.Node and reuses it directly as its node."""
     ts = TimeseriesIndex("inflow")
-    result = TimeseriesIndex("outflow", ts.node * ts.node)
+    formula = ts.node * ts.node
+    result = TimeseriesIndex("outflow", formula)
     assert isinstance(result.node, graph.multiply)
-    assert isinstance(result.value, graph.Node)
+    assert result.node is formula
 
 
 def test_timeseries_index_formula_str():
@@ -157,14 +158,14 @@ def test_index_scalar_creates_placeholder():
     """Index(scalar) creates a graph.placeholder node (D1a: value lives in model layer)."""
     idx = Index("cost", 8.0)
     assert isinstance(idx.node, graph.placeholder)
-    assert idx.value == 8.0
+    assert idx.concrete_default() == 8.0
 
 
 def test_const_index_scalar_creates_constant():
     """ConstIndex always creates a graph.constant node regardless of D1a."""
     idx = ConstIndex("cost", 8.0)
     assert isinstance(idx.node, graph.constant)
-    assert idx.value == 8.0
+    assert idx.concrete_default() == 8.0
 
 
 def test_timeseries_index_array_creates_timeseries_placeholder():
@@ -172,8 +173,8 @@ def test_timeseries_index_array_creates_timeseries_placeholder():
     arr = np.array([1.0, 2.0, 3.0])
     idx = TimeseriesIndex("ts", arr)
     assert isinstance(idx.node, graph.timeseries_placeholder)
-    assert isinstance(idx.value, np.ndarray)
-    assert np.array_equal(idx.value, arr)
+    assert isinstance(idx.concrete_default(), np.ndarray)
+    assert np.array_equal(idx.concrete_default(), arr)
 
 
 def test_const_timeseries_index_creates_timeseries_constant():
@@ -428,9 +429,9 @@ def test_distribution_index_params_property_returns_copy():
 
 
 def test_const_index_value():
-    """ConstIndex.value returns the constant value."""
+    """ConstIndex.concrete_default() returns the constant value."""
     idx = ConstIndex("c", 42.0)
-    assert idx.value == 42.0
+    assert idx.concrete_default() == 42.0
 
 
 def test_const_index_str():
@@ -449,8 +450,8 @@ def test_const_timeseries_index_construction():
     arr = np.array([1.0, 2.0, 3.0])
     ts = ConstTimeseriesIndex("demand", arr)
     assert ts.name == "demand"
-    assert isinstance(ts.value, np.ndarray)
-    assert np.array_equal(ts.value, arr)
+    assert isinstance(ts.concrete_default(), np.ndarray)
+    assert np.array_equal(ts.concrete_default(), arr)
     assert isinstance(ts.node, graph.timeseries_constant)
 
 


### PR DESCRIPTION
## Summary

- Replace the public `.value` on `Index`/`TimeseriesIndex`/`DistributionIndex`
  with purpose-specific accessors: `is_abstract`, `concrete_default`
  (property), `DistributionIndex.frozen_distribution`.
- **Breaking:** `Index.value` / `TimeseriesIndex.value` /
  `DistributionIndex.value` removed outright (no prior deprecation cycle) —
  see CHANGELOG `[Unreleased] ### Removed`.

## Test plan

- [x] `uv run pytest` — 1010 passed, 99% coverage
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest tests/test_doc_sync.py` — 7/7 (doc↔script alignment)
- [x] All `examples/doc/*.py` scripts run clean
- [x] `examples/overtourism_molveno/overtourism_molveno.py` (full domain
      example) runs end-to-end
- [x] `CHANGELOG.md` `[Unreleased]` updated, breaking change marked