### PR TITLE
refactor(model)!: promote AbstractIndexNotInInputsError to a hard error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ModelContractWarning` (a hard error is not a stricter kind of soft
   warning); catch `ModelContractError` or the shared `ModelContractViolation`
   base instead.
+- **Breaking:** `AbstractIndexNotInInputsWarning` is renamed to
+  `AbstractIndexNotInInputsError` and is now raised directly by
+  `Model.__init__` instead of emitted via `warnings.warn` — an abstract
+  index absent from the declared `Inputs` is a hard error and can no longer
+  be silenced with `warnings.filterwarnings`.  It is no longer a subclass of
+  `ModelContractWarning`; catch `ModelContractError` or the shared
+  `ModelContractViolation` base instead.  
+- `ModelContractWarning` currently has no concrete members but remains
+  available for future soft violations.
 
 ### Removed
 

--- a/civic_digital_twins/dt_model/__init__.py
+++ b/civic_digital_twins/dt_model/__init__.py
@@ -5,7 +5,7 @@ from .axes import DOMAIN, ENSEMBLE, PARAMETER, TIME_AXIS, Axis, AxisRole
 from .engine.frontend.graph import HasNode
 from .engine.numpybackend.executor import Functor, NumpyBackend
 from .model import (
-    AbstractIndexNotInInputsWarning,
+    AbstractIndexNotInInputsError,
     CategoricalIndex,
     ConditionalCategoricalIndex,
     ConditionalDistributionIndex,
@@ -59,7 +59,7 @@ from .simulation import (
 )
 
 __all__ = [
-    "AbstractIndexNotInInputsWarning",
+    "AbstractIndexNotInInputsError",
     "Functor",
     "HasNode",
     "Axis",

--- a/civic_digital_twins/dt_model/model/__init__.py
+++ b/civic_digital_twins/dt_model/model/__init__.py
@@ -17,7 +17,7 @@ from .index import (
     TimeseriesIndex,
 )
 from .model import (
-    AbstractIndexNotInInputsWarning,
+    AbstractIndexNotInInputsError,
     InputsContractError,
     Model,
     ModelContractError,
@@ -27,7 +27,7 @@ from .model import (
 from .model_variant import ModelVariant
 
 __all__ = [
-    "AbstractIndexNotInInputsWarning",
+    "AbstractIndexNotInInputsError",
     "Axis",
     "define",
     "expose",

--- a/civic_digital_twins/dt_model/model/model.py
+++ b/civic_digital_twins/dt_model/model/model.py
@@ -83,19 +83,14 @@ class InputsContractError(ModelContractError):
     """
 
 
-class AbstractIndexNotInInputsWarning(ModelContractWarning):
-    """Emitted when an abstract index is not declared in a :class:`Model`'s ``Inputs``.
+class AbstractIndexNotInInputsError(ModelContractError):
+    """Raised when an abstract index is not declared in a :class:`Model`'s ``Inputs``.
 
     Abstract indexes receive their values from outside the model (via the
     ensemble or a parent model's scenario assignments).  They are therefore
-    inputs by definition and should be declared in the ``Inputs`` dataclass
+    inputs by definition and must be declared in the ``Inputs`` dataclass
     so that the data-flow contract is explicit and cross-variant consistency
     checks work correctly.
-
-    This is a soft warning initially (not an error) for backwards
-    compatibility with models that create abstract indexes internally and
-    surface them via ``expose`` or flat ``indexes`` lists.  It is tracked
-    for promotion to an error in a future release.
 
     The canonical fix is to declare the abstract index as a field of
     ``Inputs`` and wire it through ``super().__init__(inputs=Inputs(...))``.
@@ -628,16 +623,16 @@ class Model:
                     "value is fixed and should never be overridden."
                 )
 
-            for idx in self.abstract_indexes():
-                if idx not in self.inputs:
-                    idx_name = getattr(idx, "name", repr(idx))
-                    warnings.warn(
-                        f"{concrete_cls.__name__}: abstract index {idx_name!r} is not "
-                        f"declared in Inputs. Abstract indexes receive their values from "
-                        f"outside the model and should be declared in Inputs.",
-                        AbstractIndexNotInInputsWarning,
-                        stacklevel=3,
-                    )
+            _missing_abstract = [
+                getattr(idx, "name", repr(idx)) for idx in self.abstract_indexes() if idx not in self.inputs
+            ]
+            if _missing_abstract:
+                _names = ", ".join(repr(n) for n in _missing_abstract)
+                raise AbstractIndexNotInInputsError(
+                    f"{concrete_cls.__name__}: abstract index(es) {_names} not declared "
+                    f"in Inputs. Abstract indexes receive their values from outside the "
+                    f"model and must be declared in Inputs."
+                )
 
     def abstract_indexes(self) -> list[GenericIndex]:
         """Return indexes that require external values before evaluation.

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -482,15 +482,11 @@ except ModelContractViolation:
 ```
 
 **`ModelContractWarning(ModelContractViolation, UserWarning)`** — base class
-for all *soft* Model I/O contract warnings.  Use
-
-```python
-import warnings
-warnings.filterwarnings("error", category=ModelContractWarning)
-```
-
-to promote the remaining soft-warning family into hard errors, which is
-recommended in test suites.
+for *soft* Model I/O contract warnings, filterable via
+`warnings.filterwarnings`.  It currently has no concrete members — both
+`InputsContractError` and `AbstractIndexNotInInputsError` (below) are hard
+errors — but remains the extension point for any future contract violation
+that should stay soft rather than fatal.
 
 **`ModelContractError(ModelContractViolation)`** — base class for all *hard*
 Model I/O contract errors.  `ModelContractWarning` and `ModelContractError`
@@ -516,15 +512,11 @@ because `x` is a `GenericIndex` constructor parameter but is not
 declared in `Inputs`:
 
 ```python
-from dataclasses import dataclass
+from civic_digital_twins.dt_model import DistributionIndex, Index, Model, outputs
 
-from scipy import stats
+class BadModel(Model, legacy=True):
 
-from civic_digital_twins.dt_model import DistributionIndex, Index, Model
-
-class BadModel(Model):
-
-    @dataclass
+    @outputs
     class Outputs:
         z: Index
 
@@ -537,13 +529,15 @@ class BadModel(Model):
 Declare an `Inputs` dataclass and pass an instance to avoid the error:
 
 ```python
-class GoodModel(Model):
+from civic_digital_twins.dt_model import DistributionIndex, Index, Model, inputs, outputs
 
-    @dataclass
+class GoodModel(Model, legacy=True):
+
+    @inputs
     class Inputs:
         x: DistributionIndex
 
-    @dataclass
+    @outputs
     class Outputs:
         z: Index
 

--- a/docs/design/dd-cdt-model.md
+++ b/docs/design/dd-cdt-model.md
@@ -504,12 +504,12 @@ rather than routing it through `warnings.warn`, so it cannot be silenced
 with `warnings.filterwarnings`.  The message names the offending
 parameter precisely so it can be located and added to `Inputs`.
 
-**`AbstractIndexNotInInputsWarning(ModelContractWarning)`** — emitted when
-an abstract index (one whose value is `None` or a `Distribution`) is not
+**`AbstractIndexNotInInputsError(ModelContractError)`** — raised when an
+abstract index (one whose value is `None` or a `Distribution`) is not
 reachable via `self.inputs`.  Abstract indexes receive their values from
-outside the model and are therefore inputs by definition.  Currently a soft
-warning for backwards compatibility; planned for promotion to an error in a
-future release.
+outside the model and are therefore inputs by definition.  Like
+`InputsContractError`, this is a hard error: `Model` raises it directly and
+it cannot be silenced with `warnings.filterwarnings`.
 
 Example — the following model raises `InputsContractError`
 because `x` is a `GenericIndex` constructor parameter but is not

--- a/docs/design/dd-cdt-modularity.md
+++ b/docs/design/dd-cdt-modularity.md
@@ -1571,8 +1571,8 @@ class ModelContractError(ModelContractViolation):
 class InputsContractError(ModelContractError):
     """Raised when a constructor parameter holds a GenericIndex not declared in Inputs."""
 
-class AbstractIndexNotInInputsWarning(ModelContractWarning):
-    """Emitted when an abstract index is not reachable via the model's Inputs."""
+class AbstractIndexNotInInputsError(ModelContractError):
+    """Raised when an abstract index is not reachable via the model's Inputs."""
 ```
 
 `ModelContractWarning` and `ModelContractError` are siblings, not parent/child: a hard error is not a
@@ -1581,20 +1581,10 @@ family lineage.  `ModelContractViolation` exists purely so that a single `except
 it inherits from `Exception` (rather than being a bare marker) precisely so it is itself a valid
 `except`/`pytest.raises` target, but it is never raised or emitted directly.
 
-`InputsContractError` is raised directly (a hard error, unaffected by `warnings.filterwarnings`);
-`AbstractIndexNotInInputsWarning` remains a soft warning that can be escalated with a single filter
-on its own base class:
-
-```python
-import warnings
-
-from civic_digital_twins.dt_model import ModelContractWarning
-
-with warnings.catch_warnings():
-    # InputsContractError is already a hard error; this escalates the
-    # remaining soft warnings still in the family.
-    warnings.filterwarnings("error", category=ModelContractWarning)
-```
+Both `InputsContractError` and `AbstractIndexNotInInputsError` are raised directly (hard errors,
+unaffected by `warnings.filterwarnings`).  `ModelContractWarning` currently has no concrete members —
+it remains the extension point for any future *soft* contract violation that should stay filterable
+rather than fatal.
 
 To catch *any* contract violation regardless of severity, catch `ModelContractViolation` instead:
 

--- a/docs/design/dd-cdt-modularity.md
+++ b/docs/design/dd-cdt-modularity.md
@@ -546,23 +546,12 @@ raises `InputsContractError`.
 
 This is a **hard error**, and deliberately *not* a subclass of `ModelContractWarning`: `Model` raises
 it directly rather than routing it through `warnings.warn`, so it cannot be silenced with
-`warnings.filterwarnings`.  Fix the offending `__init__` instead.  Other, still-soft members of the
-contract-warning family can be escalated during development:
+`warnings.filterwarnings`.  Fix the offending `__init__` instead.  `AbstractIndexNotInInputsError`
+(the other member of the contract-violation family, raised when an abstract index is not declared in
+`Inputs`) is likewise a hard error, not a soft warning to escalate.
 
-```python
-import warnings
-
-from civic_digital_twins.dt_model import ModelContractWarning
-
-with warnings.catch_warnings():
-    # InputsContractError is already a hard error; this escalates the
-    # remaining soft warnings still in the family.
-    warnings.filterwarnings("error", category=ModelContractWarning)
-```
-
-`InputsContractError` and `ModelContractWarning`'s subclasses are siblings under `ModelContractViolation`,
-so a single `except ModelContractViolation` catches any contract violation regardless of severity —
-hard error or (once escalated) soft warning alike.
+`InputsContractError` and `AbstractIndexNotInInputsError` are siblings under `ModelContractViolation`,
+so a single `except ModelContractViolation` catches either regardless of which one fires.
 
 ---
 

--- a/tests/dt_model/model/test_model.py
+++ b/tests/dt_model/model/test_model.py
@@ -11,7 +11,7 @@ from scipy import stats
 from civic_digital_twins.dt_model import expose, inputs, outputs
 from civic_digital_twins.dt_model.model.index import Distribution, Index, TimeseriesIndex
 from civic_digital_twins.dt_model.model.model import (
-    AbstractIndexNotInInputsWarning,
+    AbstractIndexNotInInputsError,
     InputsContractError,
     IOProxy,
     Model,
@@ -119,12 +119,12 @@ def test_abstract_indexes_includes_timeseries_placeholder():
 
 
 # ---------------------------------------------------------------------------
-# AbstractIndexNotInInputsWarning — convention check
+# AbstractIndexNotInInputsError — convention check (hard error)
 # ---------------------------------------------------------------------------
 
 
-def test_abstract_index_not_in_inputs_warning_fires_for_unresolved_output():
-    """Warn when an Output holds a genuine unresolved abstract Index absent from Inputs."""
+def test_abstract_index_not_in_inputs_error_raised_for_unresolved_output():
+    """Raise when an Output holds a genuine unresolved abstract Index absent from Inputs."""
 
     class _Bad(Model, legacy=True):
         @outputs
@@ -135,12 +135,33 @@ def test_abstract_index_not_in_inputs_warning_fires_for_unresolved_output():
             placeholder = Index("dangling", None)
             super().__init__("Bad", outputs=_Bad.Outputs(placeholder=placeholder))
 
-    with pytest.warns(AbstractIndexNotInInputsWarning, match="'dangling'"):
+    with pytest.raises(AbstractIndexNotInInputsError, match="'dangling'"):
         _Bad()
 
 
-def test_abstract_index_not_in_inputs_no_warning_when_declared():
-    """No warning when the abstract Output index is also declared in Inputs."""
+def test_abstract_index_not_in_inputs_error_names_every_missing_index():
+    """Raise once, naming every undeclared abstract Output index."""
+
+    class _Bad(Model, legacy=True):
+        @outputs
+        class Outputs:
+            first: Index
+            second: Index
+
+        def __init__(self) -> None:
+            first = Index("first_dangling", None)
+            second = Index("second_dangling", None)
+            super().__init__("Bad", outputs=_Bad.Outputs(first=first, second=second))
+
+    with pytest.raises(AbstractIndexNotInInputsError) as excinfo:
+        _Bad()
+    message = str(excinfo.value)
+    assert "'first_dangling'" in message
+    assert "'second_dangling'" in message
+
+
+def test_abstract_index_not_in_inputs_no_error_when_declared():
+    """No error when the abstract Output index is also declared in Inputs."""
 
     class _Good(Model, legacy=True):
         @inputs
@@ -159,11 +180,7 @@ def test_abstract_index_not_in_inputs_no_warning_when_declared():
                 outputs=_Good.Outputs(placeholder=placeholder),
             )
 
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", AbstractIndexNotInInputsWarning)
-        _Good()  # must not raise
+    _Good()  # must not raise
 
 
 # ---------------------------------------------------------------------------
@@ -294,10 +311,16 @@ def test_inputs_contract_error_is_subclass_of_model_contract_error_not_warning()
     assert not issubclass(InputsContractError, ModelContractWarning)
 
 
-def test_inputs_contract_error_and_abstract_index_warning_share_violation_base():
-    """Both severities are ModelContractViolation, enabling a single unified except clause."""
+def test_inputs_contract_error_and_abstract_index_error_share_violation_base():
+    """Both are ModelContractViolation, enabling a single unified except clause."""
     assert issubclass(InputsContractError, ModelContractViolation)
-    assert issubclass(AbstractIndexNotInInputsWarning, ModelContractViolation)
+    assert issubclass(AbstractIndexNotInInputsError, ModelContractViolation)
+
+
+def test_abstract_index_not_in_inputs_error_is_subclass_of_model_contract_error_not_warning():
+    """AbstractIndexNotInInputsError is a ModelContractError, not a ModelContractWarning."""
+    assert issubclass(AbstractIndexNotInInputsError, ModelContractError)
+    assert not issubclass(AbstractIndexNotInInputsError, ModelContractWarning)
 
 
 def test_model_contract_error_base_catches_inputs_contract_error():
@@ -342,8 +365,8 @@ def test_model_contract_violation_catches_inputs_contract_error():
         _Bad(received)
 
 
-def test_model_contract_violation_catches_abstract_index_warning_once_escalated():
-    """ModelContractViolation also catches the soft AbstractIndexNotInInputsWarning once escalated."""
+def test_model_contract_violation_catches_abstract_index_not_in_inputs_error():
+    """Catching ModelContractViolation also catches the hard-error AbstractIndexNotInInputsError."""
 
     class _Bad(Model, legacy=True):
         @outputs
@@ -354,12 +377,8 @@ def test_model_contract_violation_catches_abstract_index_warning_once_escalated(
             placeholder = Index("dangling", None)
             super().__init__("Bad", outputs=_Bad.Outputs(placeholder=placeholder))
 
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", AbstractIndexNotInInputsWarning)
-        with pytest.raises(ModelContractViolation):
-            _Bad()
+    with pytest.raises(ModelContractViolation):
+        _Bad()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Renames `AbstractIndexNotInInputsWarning` → `AbstractIndexNotInInputsError`
  and promotes it to a hard error, mirroring `InputsContractError` (#212):
  `Model.__init__` now raises it directly instead of routing it through
  `warnings.warn`, collecting every undeclared abstract index into a single
  raise instead of warning once per index.
- **Breaking:** No longer a subclass of `ModelContractWarning` — catch
  `ModelContractError` or the shared `ModelContractViolation` base instead.
  `ModelContractWarning` currently has no concrete members but remains the
  extension point for future soft violations.
- Updates design docs (`dd-cdt-model.md`, `dd-cdt-modularity.md`) and
  `CHANGELOG.md` accordingly, including two stale leftovers found on review:
  a `filterwarnings(ModelContractWarning)` escalation example that no longer
  applies now that both contract errors are hard, and an `InputsContractError`
  illustration still using bare `@dataclass`/no `legacy=True` — both removed
  by #209 earlier this milestone.

## Test plan

- [x] `uv run pytest` — 1017 passed, 100% coverage
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest tests/test_doc_sync.py` — 7/7 (doc↔script alignment)
- [x] `CHANGELOG.md` `[Unreleased]` updated, breaking change marked