### PR TITLE
fix(simulation): ModelEvaluator index-value lookup silently returned None

### DIFF
--- a/civic_digital_twins/dt_model/simulation/runner.py
+++ b/civic_digital_twins/dt_model/simulation/runner.py
@@ -44,7 +44,7 @@ import numpy as np
 
 from ..axes import Axis
 from ..engine.numpybackend.executor import Functor, NumpyBackend, State
-from ..model.index import GenericIndex
+from ..model.index import DistributionIndex, GenericIndex, Index, TimeseriesIndex
 from ..model.model import Model
 from ..model.model_variant import ModelVariant
 from .axis_layout import AxisLayout
@@ -827,6 +827,22 @@ def _format_value(val: Any) -> str:
     return str(val)
 
 
+def _own_index_value(idx: GenericIndex) -> Any:
+    """Return *idx*'s own default value, mirroring the pre-#211 ``.value`` semantics.
+
+    Used by :meth:`ModelEvaluator.get_index_diffs` and
+    :meth:`ModelEvaluator.get_model_values` as the no-override baseline: the
+    frozen distribution for a :class:`~model.index.DistributionIndex`, else
+    the concrete scalar/array default (``None`` when abstract or
+    formula-backed).
+    """
+    if isinstance(idx, DistributionIndex):
+        return idx.frozen_distribution
+    if isinstance(idx, (Index, TimeseriesIndex)):
+        return idx.concrete_default
+    return None
+
+
 # ---------------------------------------------------------------------------
 # ModelEvaluator
 # ---------------------------------------------------------------------------
@@ -1197,7 +1213,7 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
             empty dict when no overrides are active.
         """
         return {
-            idx.name: f"was {_format_value(getattr(idx, 'value', None))} \u2192 now {_format_value(override_val)}"
+            idx.name: f"was {_format_value(_own_index_value(idx))} \u2192 now {_format_value(override_val)}"
             for idx, override_val in scenario.overrides.items()
         }
 
@@ -1205,8 +1221,9 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
         """Return the effective value of every model index under *scenario*.
 
         For indexes that have an active override the override value is
-        returned; for all others the model's own ``idx.value`` is used
-        (which may be ``None`` for abstract indexes with no override).
+        returned; for all others the index's own default value is used via
+        :func:`_own_index_value` (which may be ``None`` for abstract indexes
+        with no override).
 
         Parameters
         ----------
@@ -1219,9 +1236,7 @@ class ModelEvaluator(ABC, Generic[ModelT, OutputT]):
             ``{index_name: effective_value}`` for every index in the model.
         """
         active = scenario.overrides
-        return {
-            idx.name: (active[idx] if idx in active else getattr(idx, "value", None)) for idx in self._model.indexes
-        }
+        return {idx.name: (active[idx] if idx in active else _own_index_value(idx)) for idx in self._model.indexes}
 
     # ------------------------------------------------------------------
     # Resume template method

--- a/tests/dt_model/simulation/test_runner.py
+++ b/tests/dt_model/simulation/test_runner.py
@@ -67,7 +67,7 @@ class _SimpleModel(Model):
         return _SimpleModel.Outputs(y=y)
 
 
-def _make_simple_model() -> tuple[Index, _SimpleModel]:
+def _make_simple_model() -> tuple[DistributionIndex, _SimpleModel]:
     """Return a (x_index, model) pair ready for evaluation."""
     x = DistributionIndex("x", stats.norm, {"loc": 5.0, "scale": 1.0})
     return x, _SimpleModel(inputs=_SimpleModel.Inputs(x=x))
@@ -656,6 +656,15 @@ class TestGetIndexDiffs:
         assert "now" in diffs[cost.name]
         assert "99.0" in diffs[cost.name]
 
+    def test_diff_string_for_distribution_override(self) -> None:
+        """Override of a DistributionIndex shows the original frozen distribution, not '(none)'."""
+        x, model = _make_simple_model()
+        new_dist = stats.norm(loc=1.0, scale=1.0)
+        scenario = Scenario(model, overrides={x: new_dist})  # type: ignore[arg-type]
+        evaluator = _MinimalEvaluator(model)
+        diffs = evaluator.get_index_diffs(scenario)
+        assert diffs[x.name] == f"was {_format_value(x.frozen_distribution)} → now {_format_value(new_dist)}"
+
     def test_diff_keys_match_overridden_indexes(self) -> None:
         """Diff dict has exactly one key per overridden index."""
         cost, model = _make_scalar_model()
@@ -679,9 +688,9 @@ class TestGetModelValues:
         evaluator = _MinimalEvaluator(model)
         values = evaluator.get_model_values(Scenario(model))
         # x is abstract (DistributionIndex) → value is the frozen distribution
-        # y is concrete (Index computed from x) → value is a graph node, idx.value is None
-        assert x.name in values
-        assert "y" in values
+        assert values[x.name] is x.frozen_distribution
+        # y is concrete (Index computed from x) → formula-backed, idx.concrete_default is None
+        assert values["y"] is None
 
     def test_returns_override_for_overridden_index(self) -> None:
         """Override value is returned instead of the model default."""


### PR DESCRIPTION
## Summary
- `get_index_diffs()` / `get_model_values()` used `getattr(idx, "value", None)`, which has silently returned `None` for every index since `.value` was privatized in #211 — an internal loose end from that same unreleased change.
- Restore intended semantics via `_own_index_value()`: `frozen_distribution` for `DistributionIndex`, `concrete_default` otherwise.
- Strengthen the two existing tests to assert actual values (not just key presence), and add a `DistributionIndex`-override case — both fail against the pre-fix code.
- No `CHANGELOG.md` change: the `.value` removal entry is still under `[Unreleased]`, so this closes a gap within that same unreleased change.

## Test plan
- [x] `uv run pytest` (full suite) — 1030 passed
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] Confirmed both new/strengthened tests fail against the pre-fix code