### PR TITLE
ci(dev): skip +dev marker check via Release-PR commit trailer

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -13,7 +13,10 @@ on:
 jobs:
   # ── Version sanity ───────────────────────────────────────────────────────────
   # The dev branch must always carry a +dev version marker so that the
-  # development build is never confused with a published release.
+  # development build is never confused with a published release. The one
+  # expected exception is the release-prep commit (see README.md Step 2),
+  # which strips +dev right before the dev -> main PR; it's tagged with a
+  # `Release-PR: true` trailer so this check knows to skip it.
   version-check:
     name: Version has +dev marker
     runs-on: ubuntu-latest
@@ -23,6 +26,11 @@ jobs:
 
       - name: Assert version contains +dev
         run: |
+          if git log -1 --format=%B | grep -q 'Release-PR: true'; then
+            echo "Release-PR trailer found on HEAD commit; skipping +dev check."
+            exit 0
+          fi
+
           version=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           echo "Version: $version"
           if ! echo "$version" | grep -q '+dev'; then

--- a/README.md
+++ b/README.md
@@ -311,24 +311,41 @@ Perform the following steps on the `dev` branch before opening the
    `<!-- SPDX-License-Identifier: Apache-2.0 -->` (Markdown) to any file
    that is missing the header.
 
-8. Commit the release preparation:
+8. Commit the release preparation. The `Release-PR: true` trailer tells
+   `CI (dev)` to skip the `+dev` marker check for this specific commit — see
+   [`ci-dev.yml`](.github/workflows/ci-dev.yml):
    ```bash
    git add pyproject.toml uv.lock CHANGELOG.md docs/
-   git commit -m "chore: prepare v<version> release"
+   git commit -m "$(cat <<'EOF'
+   chore: prepare v<version> release
+
+   Release-PR: true
+   EOF
+   )"
    git push origin dev
    ```
 
 Open the PR from `dev` to `main`. The `CI (release)` workflow runs the full
 verification suite automatically (all Python versions, doc examples, domain
 examples, SPDX headers, dependency audit, build smoke test). Merge once it
-is green.
+is green, using **"Create a merge commit"** (the only method `main`'s
+ruleset allows) — this keeps `dev`'s commit history intact and attached to
+`main`, so the next release's `dev → main` diff only shows genuinely new
+commits.
 
 ### Step 3 — Tagging and publishing
 
-After the `dev → main` PR is merged:
-
+After the `dev → main` PR is merged, GitHub may have auto-deleted `dev`
+(if `delete_branch_on_merge` is enabled). Restore it from the merge
+commit before continuing — either click **"Restore branch"** on the merged
+PR page, or recreate it locally:
 ```bash
 git checkout main && git pull
+git push origin main:refs/heads/dev
+```
+
+Then tag and push the release:
+```bash
 git tag v<version> && git push origin main v<version>
 ```
 
@@ -379,7 +396,11 @@ git push origin dev
 > Rulesets) to require `CI (dev)` to pass before merging into `dev`, and all
 > `CI (release)` jobs to pass before merging into `main`. Direct pushes to
 > `main` should be blocked; maintainers should be allowed to bypass `dev`
-> protection for post-release bump commits.
+> protection for post-release bump commits. `main`'s ruleset must allow only
+> the `merge` method (no squash/rebase) and must not require linear history —
+> squashing or rebasing the `dev → main` PR mints new commit SHAs unrelated
+> to `dev`'s own commits, which detaches `dev` from `main`'s history and
+> makes every subsequent `dev → main` diff re-show already-released commits.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- `ci-dev.yml`'s "Version has +dev marker" check now skips when `HEAD`'s
  commit message contains a `Release-PR: true` trailer, instead of relying
  on the +dev suffix always being present. The release-prep commit
  (README Step 2) intentionally strips +dev right before the `dev → main`
  PR, so this check needs a way to recognize that one expected exception.
- Reads the trailer via `git log -1 --format=%B` in the shell step rather
  than `github.event.head_commit.message`, since the latter only exists on
  `push` events and this workflow also triggers on `pull_request` — the
  old approach tripped the GitHub Actions language server's context-access
  validation.
- Documents the fallout from this cycle's dev → main merge: `main`'s
  ruleset now requires "Create a merge commit" (no squash/rebase) to keep
  `dev` attached to `main`'s history, and `dev` needs restoring after each
  release since `delete_branch_on_merge` removes it on PR merge.

## Test plan
- [x] `CI (dev)` green on this PR (exercises the `pull_request` trigger path)
- [x] Verified manually against the actual v0.11.0 release-prep commit