### PR TITLE
fix: port issue #222/#223/#224 hotfixes to v0.11.1

### DIFF
--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -329,6 +329,10 @@ class PlaceholderValueNotProvided(Exception):
     """Raised when a required placeholder value is not provided in the state."""
 
 
+class InvalidFunctionResult(Exception):
+    """Raised when a user-defined function returns something other than a concrete value."""
+
+
 @runtime_checkable
 class Functor(Protocol):
     """A user-defined callable integrated into the DAG."""
@@ -635,7 +639,20 @@ def _eval_function(state: State, node: graph.Node) -> np.ndarray:
         function = state.functions.get(node.name)
     if function is None:
         raise FunctionNotFound(f"executor: cannot find functor for: {node.name}")
-    return function(*args, **kwargs)
+    result = function(*args, **kwargs)
+    if isinstance(result, graph.Node):
+        raise InvalidFunctionResult(
+            f"executor: function '{node.name}' returned a graph.Node ({result!r}) instead of "
+            "a concrete value. This usually means a GenericIndex/Index (or its .node) leaked "
+            "into the function's closure or data and was used in arithmetic instead of being "
+            "unwrapped to a concrete value beforehand."
+        )
+    if not isinstance(result, (np.ndarray, np.generic, int, float, bool)):
+        raise InvalidFunctionResult(
+            f"executor: function '{node.name}' returned {type(result).__name__}, expected a "
+            "numpy array/scalar, int, float, or bool."
+        )
+    return result
 
 
 def _eval_variant_selector_noop(_state: State, _node: graph.Node) -> np.ndarray:

--- a/civic_digital_twins/dt_model/model/index.py
+++ b/civic_digital_twins/dt_model/model/index.py
@@ -444,14 +444,33 @@ class TimeseriesIndex(GenericIndex):
       Scenario or ``parameters=`` before evaluation.
     * **Formula** — ``TimeseriesIndex(name, formula_node)``
       Node is the formula node directly; value is computed by the engine.
+      Another :class:`TimeseriesIndex` is also accepted here and coerced to
+      its underlying ``.node`` (reusing the formula). A sibling type
+      carrying a different shape — :class:`Index` — is deliberately *not*
+      accepted; mixing shapes this way is almost always a mistake, not a
+      formula reuse.
     """
 
     def __init__(
         self,
         name: str,
-        value: np.ndarray | graph.Node | None = None,
+        value: "np.ndarray | graph.Node | TimeseriesIndex | None" = None,
     ) -> None:
         self._name = name
+
+        # Coerce another TimeseriesIndex to its underlying node so a formula
+        # that reuses it is treated as formula-backed, mirroring Index's
+        # unwrap of a sibling Index. Scoped to TimeseriesIndex (not the
+        # broader GenericIndex) so that passing a differently-shaped sibling
+        # like Index is a static/runtime error rather than a silent shape
+        # mismatch.
+        if isinstance(value, TimeseriesIndex):
+            value = value.node
+        elif isinstance(value, GenericIndex):
+            raise TypeError(
+                f"TimeseriesIndex {name!r} cannot be initialised from a {type(value).__name__}. "
+                f"Pass its .node explicitly if the shape mismatch is intentional."
+            )
 
         # Formula node: reuse it directly as this index's node.
         if isinstance(value, graph.Node):

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -240,7 +240,10 @@ class Evaluation:
         if nodes_of_interest is None:
             nodes_of_interest = list(self.model.indexes)
 
-        actual_nodes = [idx.node for idx in nodes_of_interest]
+        # Dedupe by node identity: distinct Index wrappers can legitimately
+        # share one underlying node, and downstream processing assumes one
+        # entry per distinct node.
+        actual_nodes = list(dict.fromkeys(idx.node for idx in nodes_of_interest))
         linearized_nodes = linearize.forest(*actual_nodes)
         has_timeseries = any(
             isinstance(node, (graph.timeseries_constant, graph.timeseries_placeholder)) for node in linearized_nodes
@@ -483,7 +486,10 @@ class Evaluation:
         backend: type[executor.NumpyBackend],
     ) -> EvaluationResult:
         """Execute an :class:`~simulation.plan.EvaluationPlan`."""
-        actual_nodes = [idx.node for idx in plan.nodes_of_interest]
+        # Dedupe by node identity: distinct Index wrappers can legitimately
+        # share one underlying node, and downstream processing assumes one
+        # entry per distinct node.
+        actual_nodes = list(dict.fromkeys(idx.node for idx in plan.nodes_of_interest))
         _raw_scenario_subs = self._scenario.base_substitutions()
         # Filter out entries where base_substitutions() wrapped a graph.Node as a numpy
         # object array — this happens for formula-based Index instances whose `.value`

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -546,6 +546,67 @@ def test_user_defined_function():
         executor.evaluate_nodes(state2, *linearize.forest(g))
 
 
+def test_user_defined_function_rejects_graph_node_result():
+    """A function returning a graph.Node must raise instead of silently going symbolic.
+
+    Regression test for https://github.com/fbk-most/civic-digital-twins/issues/222:
+    a closure that accidentally captures Index/GenericIndex objects instead of
+    plain floats causes arithmetic inside the user function to build graph nodes
+    (via GenericIndex/Node dunder methods) rather than computing a value. Without
+    this check, the resulting Node is silently stored as the node's "value" and
+    every downstream numpy op keeps building graph instead of raising.
+    """
+    from civic_digital_twins.dt_model.model.index import Index
+
+    # Mistake: list_w should be plain floats (e.g. [0.5, 0.5]), not Index objects.
+    zone_props = [Index("w0", 0.5), Index("w1", 0.5)]
+
+    def ts_w_sum_list(*args, list_w):
+        return sum(w * a for w, a in zip(list_w, args))
+
+    functor = executor.NumpyBackend.adapt(
+        lambda *args: ts_w_sum_list(*args, list_w=zone_props)  # type: ignore[arg-type]
+    )
+
+    x0 = graph.placeholder("x0")
+    x1 = graph.placeholder("x1")
+    call = graph.function_call("f", x0, x1)
+
+    state = executor.State(
+        values={x0: np.asarray(10.0), x1: np.asarray(20.0)},
+        functions={"f": functor},
+    )
+    with pytest.raises(executor.InvalidFunctionResult):
+        executor.evaluate_nodes(state, *linearize.forest(call))
+
+
+def test_user_defined_function_rejects_non_numeric_result():
+    """A function returning a non-numeric value (e.g. a list) must raise."""
+    a = graph.placeholder("a")
+    call = graph.function_call("f", a)
+    functor = executor.NumpyBackend.adapt(lambda a: [a, a])  # type: ignore[arg-type]  # not numeric
+
+    state = executor.State(values={a: np.asarray(1.0)}, functions={"f": functor})
+    with pytest.raises(executor.InvalidFunctionResult):
+        executor.evaluate_nodes(state, *linearize.forest(call))
+
+
+def test_user_defined_function_accepts_numpy_scalar_result():
+    """A function returning a bare numpy scalar (not np.ndarray) must still work.
+
+    np.sum() without keepdims returns np.float64, which is not an np.ndarray
+    instance; the InvalidFunctionResult check must not reject this common,
+    legitimate case.
+    """
+    a = graph.placeholder("a")
+    call = graph.function_call("f", a)
+    functor = executor.NumpyBackend.adapt(lambda a: np.sum(a))
+
+    state = executor.State(values={a: np.asarray([1.0, 2.0, 3.0])}, functions={"f": functor})
+    executor.evaluate_nodes(state, *linearize.forest(call))
+    assert state.get_node_value(call) == np.asarray(6.0)
+
+
 def test_state_set_node_value():
     """Ensure we can mutate the state and set node values."""
     state = executor.State(values={})

--- a/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
+++ b/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
@@ -686,3 +686,36 @@ def test_evaluation_raises_when_parameter_axes_not_in_parameters():
     ens = CrossProductEnsemble(scenario)  # pv excluded from ensemble
     with pytest.raises(ValueError, match="parameter_axes"):
         Evaluation(scenario).evaluate(ensemble=ens)  # pv not in parameters=
+
+
+# ---------------------------------------------------------------------------
+# A node shared by two Index/TimeseriesIndex wrappers must not be
+# double-processed by shape normalisation.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_node_across_two_index_wrappers_does_not_corrupt_shape():
+    """Two different index objects sharing one node must not break shape normalisation.
+
+    Regression test for https://github.com/fbk-most/civic-digital-twins/issues/224.
+    A TimeseriesIndex wrapping another index's `.node` (to give it its own identity —
+    a pattern the model layer explicitly supports, see issue #223) makes the same
+    underlying graph node reachable from `model.indexes` twice, once per wrapper.
+    `_execute_plan`'s shape-normalisation loop used to iterate this un-deduplicated
+    list and reshape the node twice, tripping its own ndim assertion on the second
+    pass whenever an ENSEMBLE/PARAMETER axis is present (has_timeseries=True).
+    """
+    ts_starting = TimeseriesIndex("base starting", np.array([1.0, 2.0, 3.0]))
+    # Reuse ts_starting's node so `modified_starting` has its own Index identity
+    # while sharing the same underlying graph node — exactly the pattern used in
+    # AreaVerde's CordonModifiedFlowsModel.
+    modified_starting = TimeseriesIndex("modified starting", ts_starting.node)
+    noise = DistributionIndex("noise", stats.norm, {"loc": 0.0, "scale": 1.0})
+
+    model = _make_model(ts_starting, modified_starting, noise)
+    scenario = Scenario(model)
+    ens = DistributionEnsemble(scenario, size=5, rng=np.random.default_rng(42))
+
+    ev = Evaluation(scenario).evaluate(ensemble=ens)
+    assert ev[modified_starting].shape == (1, 3)
+    np.testing.assert_array_equal(ev[modified_starting][0], np.array([1.0, 2.0, 3.0]))

--- a/tests/dt_model/symbols/test_index.py
+++ b/tests/dt_model/symbols/test_index.py
@@ -496,6 +496,42 @@ def test_index_rejects_timeseries_index():
         Index("x", ts)  # type: ignore[arg-type]
 
 
+def test_index_unwraps_nested_index():
+    """Index(name, other_index) shares other_index's node instead of orphaning a new one."""
+    base = Index("base", None)
+    copy = Index("copy", base)
+    assert copy.node is base.node
+
+
+def test_timeseries_index_unwraps_nested_timeseries_index():
+    """TimeseriesIndex(name, other_ts_index) shares other's node instead of orphaning a new one.
+
+    Regression test for https://github.com/fbk-most/civic-digital-twins/issues/223: before the
+    fix, TimeseriesIndex.__init__ had no unwrap logic for a nested GenericIndex, so passing
+    another TimeseriesIndex (instead of its .node) fell through to np.asarray(other_index),
+    which silently wrapped the whole object in a 0-d dtype=object array and minted a brand-new,
+    disconnected timeseries_placeholder node.
+    """
+    ts_base = TimeseriesIndex("ts_base")
+    ts_copy = TimeseriesIndex("ts_copy", ts_base)
+    assert ts_copy.node is ts_base.node
+    assert ts_copy.concrete_default is None
+
+
+def test_timeseries_index_unwraps_nested_timeseries_index_with_default():
+    """The unwrap also covers a base index that carries a concrete default array."""
+    ts_base = TimeseriesIndex("ts_base", np.array([1.0, 2.0, 3.0]))
+    ts_copy = TimeseriesIndex("ts_copy", ts_base)
+    assert ts_copy.node is ts_base.node
+
+
+def test_timeseries_index_rejects_mismatched_generic_index():
+    """TimeseriesIndex(name, a_scalar_index) raises TypeError instead of silently misbehaving."""
+    idx = Index("x", 1.0)
+    with pytest.raises(TypeError, match="from a Index"):
+        TimeseriesIndex("bad", idx)  # type: ignore[arg-type]
+
+
 def test_index_repr_formula_mode():
     """Index repr shows '<formula>' when the value is a graph node."""
     n = graph.constant(42.0)


### PR DESCRIPTION
## Summary
Ports the three engine/model-layer fixes already released as v0.10.1
(`backport/v0.10.1`) to the current `v0.11.0` line:
  - **Executor** (#222): a `NumpyBackend`-adapted function returning a
    `graph.Node` (or any other non-numeric value) instead of a concrete
    number now raises `executor.InvalidFunctionResult` immediately,
    instead of silently storing the `Node` as the evaluated value and
    letting every downstream computation go symbolic without warning.
  - **`TimeseriesIndex`** (#223): initializing from another
    `TimeseriesIndex` now correctly shares the underlying graph node
    instead of silently minting a disconnected, orphaned placeholder;
    initializing from a differently-shaped sibling (`Index`) now raises
    `TypeError`. `Index` already had this behavior on `main`, so only
    `TimeseriesIndex` needed the fix here.
  - **`Evaluation`** (#224): `_execute_plan`'s shape-normalisation pass no
    longer double-processes a graph node legitimately shared by two
    different `Index`/`TimeseriesIndex` wrappers, which previously could
    raise a spurious `AssertionError` ("unexpected ndim=2").

## Closed issues
- Closes: #222
- Closes: #223
- Closes: #224