### PR TITLE
fix: reject invalid function results, unwrap nested indexes, dedupe shared nodes

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,4 +1,9 @@
-# CI for releases: runs on every push to `main` and on pull requests targeting `main`.
+# CI for releases: runs on every push to `main` and on pull requests targeting
+# `main`, plus the same for `hotfix/**`/`backport/**` maintenance branches (see
+# the "Hotfix and backport releases" section of the README) — and manually
+# against any ref via workflow_dispatch, as a bootstrap/fallback verification
+# path for the very first PR into a new maintenance branch (before that
+# branch's own copy of this trigger exists to fire automatically).
 # Scope: full release gate — all Python versions, doc examples, domain examples,
 # SPDX headers, dependency audit, build smoke test, and coverage upload.
 #
@@ -14,9 +19,10 @@ name: CI (release)
 
 on:
   push:
-    branches: [main]
+    branches: [main, "hotfix/**", "backport/**"]
   pull_request:
-    branches: [main]
+    branches: [main, "hotfix/**", "backport/**"]
+  workflow_dispatch: {}
 
 jobs:
   # ── Version sanity ───────────────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-08-20
+
+### Fixed
+
+- **Executor**: a `NumpyBackend`-adapted function returning a `graph.Node`
+  (or any other non-numeric value) instead of a concrete number now raises
+  `executor.InvalidFunctionResult` immediately, instead of silently storing
+  the `Node` as the node's evaluated value and letting every downstream
+  computation go symbolic without warning — e.g. when a closure accidentally
+  captures `Index` objects instead of plain floats (#222).
+- **`TimeseriesIndex`**: initializing from another `TimeseriesIndex` now
+  correctly shares the underlying graph node instead of silently minting a
+  disconnected, orphaned placeholder node; initializing from a
+  differently-shaped sibling (`Index`) now raises `TypeError` instead of
+  silently misbehaving (#223). `Index` already had this behavior.
+- **`Evaluation`**: `_execute_plan`'s shape-normalisation pass no longer
+  double-processes a graph node that is legitimately shared by two
+  different `Index`/`TimeseriesIndex` wrappers, which previously could
+  raise a spurious `AssertionError` ("unexpected ndim=2") (#224).
+
 ## [0.11.0] - 2026-07-24
 
 ### Added
@@ -993,7 +1013,8 @@ All new axis reduction operators have corresponding convenience methods on `Gene
 
 ## [0.5.0] - 2025-07-14
 
-[Unreleased]: https://github.com/fbk-most/civic-digital-twins/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/fbk-most/civic-digital-twins/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/fbk-most/civic-digital-twins/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/fbk-most/civic-digital-twins/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/fbk-most/civic-digital-twins/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/fbk-most/civic-digital-twins/compare/v0.8.1...v0.9.0

--- a/README.md
+++ b/README.md
@@ -370,6 +370,71 @@ git commit -m "chore: start v<next-version> development"
 git push origin dev
 ```
 
+### Hotfix and backport releases
+
+Two situations don't fit the normal `dev → main` flow above:
+
+- **Hotfix** — a bug needs fixing in the version `main` currently sits at,
+  while `dev` has independently moved on to unfinished next-version work
+  that isn't ready to ship. Branch directly off `main`'s current tip.
+- **Backport** — a bug needs fixing in an *older*, already-superseded
+  release line (`main` has moved past it by one or more versions). Branch
+  off the old release tag instead.
+
+Both use a dedicated `hotfix/vX.Y.Z` or `backport/vX.Y.Z` branch as a
+short-lived staging branch: individual pieces of work are PR'd and merged
+into it (never committed to directly), then it is either merged onward
+(hotfix) or tagged and released directly (backport).
+
+#### Hotfix procedure
+
+1. `git checkout -b hotfix/v<version> origin/main`, push it:
+   `git push -u origin hotfix/v<version>`.
+2. For each piece of work (bug fixes, release prep), branch off
+   `hotfix/v<version>`, PR into it, merge. `CI (release)` runs
+   automatically on these PRs (see below).
+3. Once `hotfix/v<version>` contains everything for the release, open a PR
+   from it into `main` — this is the actual release PR (version bump,
+   changelog, etc. is typically already in place from step 2) and triggers
+   `CI (release)` normally, exactly like a `dev → main` PR.
+4. Tag and publish from `main`'s new tip, exactly as in Step 3 above.
+5. Forward-port the same fix into `dev` as its own small PR, so the next
+   regular release doesn't reintroduce it. Don't touch `dev`'s in-progress
+   work otherwise.
+
+#### Backport procedure
+
+1. `git checkout -b backport/v<version> v<old-version>`, push it.
+2. For each piece of work, branch off `backport/v<version>`, PR into it,
+   merge — same as the hotfix flow.
+3. Tag and publish **directly from `backport/v<version>`'s tip**. This
+   branch never merges into `main` or `dev` — their code has diverged too
+   far for that to be meaningful. On the Releases page, review the draft
+   and explicitly set **"Set as the latest release"** to **No** before
+   publishing, so the repository's "latest" designation stays on the
+   current release.
+4. Separately, port the same fix forward into whichever line is actually
+   current (typically as a hotfix per above, or folded into normal `dev`
+   work).
+
+#### CI on maintenance branches
+
+`CI (release)` (`.github/workflows/ci-release.yml`) triggers on
+`push`/`pull_request` against `main`, `hotfix/**`, and `backport/**`, plus
+`workflow_dispatch` for manual runs. A brand-new `hotfix/*`/`backport/*`
+branch created straight from a historical tag may carry an older snapshot
+of the CI workflow that lacks this pattern — add it (and a
+`workflow_dispatch: {}` fallback) as part of setting up the branch.
+
+The pattern trigger only fires once a branch's *own* committed copy of the
+workflow already includes it, so the very first PR into a brand-new branch
+(before that trigger exists there) won't auto-fire. Verify it manually
+instead, dispatching against the PR's source branch directly (this works
+even if the target branch doesn't have the trigger yet):
+```bash
+gh workflow run <workflow-file> --ref <branch-name>
+```
+
 ### One-time setup
 
 > **PyPI Trusted Publisher:** must be configured before the first release.

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -329,6 +329,10 @@ class PlaceholderValueNotProvided(Exception):
     """Raised when a required placeholder value is not provided in the state."""
 
 
+class InvalidFunctionResult(Exception):
+    """Raised when a user-defined function returns something other than a concrete value."""
+
+
 @runtime_checkable
 class Functor(Protocol):
     """A user-defined callable integrated into the DAG."""
@@ -635,7 +639,20 @@ def _eval_function(state: State, node: graph.Node) -> np.ndarray:
         function = state.functions.get(node.name)
     if function is None:
         raise FunctionNotFound(f"executor: cannot find functor for: {node.name}")
-    return function(*args, **kwargs)
+    result = function(*args, **kwargs)
+    if isinstance(result, graph.Node):
+        raise InvalidFunctionResult(
+            f"executor: function '{node.name}' returned a graph.Node ({result!r}) instead of "
+            "a concrete value. This usually means a GenericIndex/Index (or its .node) leaked "
+            "into the function's closure or data and was used in arithmetic instead of being "
+            "unwrapped to a concrete value beforehand."
+        )
+    if not isinstance(result, (np.ndarray, np.generic, int, float, bool)):
+        raise InvalidFunctionResult(
+            f"executor: function '{node.name}' returned {type(result).__name__}, expected a "
+            "numpy array/scalar, int, float, or bool."
+        )
+    return result
 
 
 def _eval_variant_selector_noop(_state: State, _node: graph.Node) -> np.ndarray:

--- a/civic_digital_twins/dt_model/model/index.py
+++ b/civic_digital_twins/dt_model/model/index.py
@@ -444,14 +444,33 @@ class TimeseriesIndex(GenericIndex):
       Scenario or ``parameters=`` before evaluation.
     * **Formula** — ``TimeseriesIndex(name, formula_node)``
       Node is the formula node directly; value is computed by the engine.
+      Another :class:`TimeseriesIndex` is also accepted here and coerced to
+      its underlying ``.node`` (reusing the formula). A sibling type
+      carrying a different shape — :class:`Index` — is deliberately *not*
+      accepted; mixing shapes this way is almost always a mistake, not a
+      formula reuse.
     """
 
     def __init__(
         self,
         name: str,
-        value: np.ndarray | graph.Node | None = None,
+        value: "np.ndarray | graph.Node | TimeseriesIndex | None" = None,
     ) -> None:
         self._name = name
+
+        # Coerce another TimeseriesIndex to its underlying node so a formula
+        # that reuses it is treated as formula-backed, mirroring Index's
+        # unwrap of a sibling Index. Scoped to TimeseriesIndex (not the
+        # broader GenericIndex) so that passing a differently-shaped sibling
+        # like Index is a static/runtime error rather than a silent shape
+        # mismatch.
+        if isinstance(value, TimeseriesIndex):
+            value = value.node
+        elif isinstance(value, GenericIndex):
+            raise TypeError(
+                f"TimeseriesIndex {name!r} cannot be initialised from a {type(value).__name__}. "
+                f"Pass its .node explicitly if the shape mismatch is intentional."
+            )
 
         # Formula node: reuse it directly as this index's node.
         if isinstance(value, graph.Node):

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -240,7 +240,10 @@ class Evaluation:
         if nodes_of_interest is None:
             nodes_of_interest = list(self.model.indexes)
 
-        actual_nodes = [idx.node for idx in nodes_of_interest]
+        # Dedupe by node identity: distinct Index wrappers can legitimately
+        # share one underlying node, and downstream processing assumes one
+        # entry per distinct node.
+        actual_nodes = list(dict.fromkeys(idx.node for idx in nodes_of_interest))
         linearized_nodes = linearize.forest(*actual_nodes)
         has_timeseries = any(
             isinstance(node, (graph.timeseries_constant, graph.timeseries_placeholder)) for node in linearized_nodes
@@ -483,7 +486,10 @@ class Evaluation:
         backend: type[executor.NumpyBackend],
     ) -> EvaluationResult:
         """Execute an :class:`~simulation.plan.EvaluationPlan`."""
-        actual_nodes = [idx.node for idx in plan.nodes_of_interest]
+        # Dedupe by node identity: distinct Index wrappers can legitimately
+        # share one underlying node, and downstream processing assumes one
+        # entry per distinct node.
+        actual_nodes = list(dict.fromkeys(idx.node for idx in plan.nodes_of_interest))
         _raw_scenario_subs = self._scenario.base_substitutions()
         # Filter out entries where base_substitutions() wrapped a graph.Node as a numpy
         # object array — this happens for formula-based Index instances whose `.value`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "hatchling.build"
 name = "civic-digital-twins"
 
 # Current version
-version = "0.11.0"
+version = "0.11.1"
 
 # Short description of the project
 description = "Civic-Digital-Twins Modeling Framework"

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -546,6 +546,67 @@ def test_user_defined_function():
         executor.evaluate_nodes(state2, *linearize.forest(g))
 
 
+def test_user_defined_function_rejects_graph_node_result():
+    """A function returning a graph.Node must raise instead of silently going symbolic.
+
+    Regression test for https://github.com/fbk-most/civic-digital-twins/issues/222:
+    a closure that accidentally captures Index/GenericIndex objects instead of
+    plain floats causes arithmetic inside the user function to build graph nodes
+    (via GenericIndex/Node dunder methods) rather than computing a value. Without
+    this check, the resulting Node is silently stored as the node's "value" and
+    every downstream numpy op keeps building graph instead of raising.
+    """
+    from civic_digital_twins.dt_model.model.index import Index
+
+    # Mistake: list_w should be plain floats (e.g. [0.5, 0.5]), not Index objects.
+    zone_props = [Index("w0", 0.5), Index("w1", 0.5)]
+
+    def ts_w_sum_list(*args, list_w):
+        return sum(w * a for w, a in zip(list_w, args))
+
+    functor = executor.NumpyBackend.adapt(
+        lambda *args: ts_w_sum_list(*args, list_w=zone_props)  # type: ignore[arg-type]
+    )
+
+    x0 = graph.placeholder("x0")
+    x1 = graph.placeholder("x1")
+    call = graph.function_call("f", x0, x1)
+
+    state = executor.State(
+        values={x0: np.asarray(10.0), x1: np.asarray(20.0)},
+        functions={"f": functor},
+    )
+    with pytest.raises(executor.InvalidFunctionResult):
+        executor.evaluate_nodes(state, *linearize.forest(call))
+
+
+def test_user_defined_function_rejects_non_numeric_result():
+    """A function returning a non-numeric value (e.g. a list) must raise."""
+    a = graph.placeholder("a")
+    call = graph.function_call("f", a)
+    functor = executor.NumpyBackend.adapt(lambda a: [a, a])  # type: ignore[arg-type]  # not numeric
+
+    state = executor.State(values={a: np.asarray(1.0)}, functions={"f": functor})
+    with pytest.raises(executor.InvalidFunctionResult):
+        executor.evaluate_nodes(state, *linearize.forest(call))
+
+
+def test_user_defined_function_accepts_numpy_scalar_result():
+    """A function returning a bare numpy scalar (not np.ndarray) must still work.
+
+    np.sum() without keepdims returns np.float64, which is not an np.ndarray
+    instance; the InvalidFunctionResult check must not reject this common,
+    legitimate case.
+    """
+    a = graph.placeholder("a")
+    call = graph.function_call("f", a)
+    functor = executor.NumpyBackend.adapt(lambda a: np.sum(a))
+
+    state = executor.State(values={a: np.asarray([1.0, 2.0, 3.0])}, functions={"f": functor})
+    executor.evaluate_nodes(state, *linearize.forest(call))
+    assert state.get_node_value(call) == np.asarray(6.0)
+
+
 def test_state_set_node_value():
     """Ensure we can mutate the state and set node values."""
     state = executor.State(values={})

--- a/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
+++ b/tests/dt_model/simulation/test_scenario_ensemble_interaction.py
@@ -686,3 +686,36 @@ def test_evaluation_raises_when_parameter_axes_not_in_parameters():
     ens = CrossProductEnsemble(scenario)  # pv excluded from ensemble
     with pytest.raises(ValueError, match="parameter_axes"):
         Evaluation(scenario).evaluate(ensemble=ens)  # pv not in parameters=
+
+
+# ---------------------------------------------------------------------------
+# A node shared by two Index/TimeseriesIndex wrappers must not be
+# double-processed by shape normalisation.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_node_across_two_index_wrappers_does_not_corrupt_shape():
+    """Two different index objects sharing one node must not break shape normalisation.
+
+    Regression test for https://github.com/fbk-most/civic-digital-twins/issues/224.
+    A TimeseriesIndex wrapping another index's `.node` (to give it its own identity —
+    a pattern the model layer explicitly supports, see issue #223) makes the same
+    underlying graph node reachable from `model.indexes` twice, once per wrapper.
+    `_execute_plan`'s shape-normalisation loop used to iterate this un-deduplicated
+    list and reshape the node twice, tripping its own ndim assertion on the second
+    pass whenever an ENSEMBLE/PARAMETER axis is present (has_timeseries=True).
+    """
+    ts_starting = TimeseriesIndex("base starting", np.array([1.0, 2.0, 3.0]))
+    # Reuse ts_starting's node so `modified_starting` has its own Index identity
+    # while sharing the same underlying graph node — exactly the pattern used in
+    # AreaVerde's CordonModifiedFlowsModel.
+    modified_starting = TimeseriesIndex("modified starting", ts_starting.node)
+    noise = DistributionIndex("noise", stats.norm, {"loc": 0.0, "scale": 1.0})
+
+    model = _make_model(ts_starting, modified_starting, noise)
+    scenario = Scenario(model)
+    ens = DistributionEnsemble(scenario, size=5, rng=np.random.default_rng(42))
+
+    ev = Evaluation(scenario).evaluate(ensemble=ens)
+    assert ev[modified_starting].shape == (1, 3)
+    np.testing.assert_array_equal(ev[modified_starting][0], np.array([1.0, 2.0, 3.0]))

--- a/tests/dt_model/symbols/test_index.py
+++ b/tests/dt_model/symbols/test_index.py
@@ -496,6 +496,42 @@ def test_index_rejects_timeseries_index():
         Index("x", ts)  # type: ignore[arg-type]
 
 
+def test_index_unwraps_nested_index():
+    """Index(name, other_index) shares other_index's node instead of orphaning a new one."""
+    base = Index("base", None)
+    copy = Index("copy", base)
+    assert copy.node is base.node
+
+
+def test_timeseries_index_unwraps_nested_timeseries_index():
+    """TimeseriesIndex(name, other_ts_index) shares other's node instead of orphaning a new one.
+
+    Regression test for https://github.com/fbk-most/civic-digital-twins/issues/223: before the
+    fix, TimeseriesIndex.__init__ had no unwrap logic for a nested GenericIndex, so passing
+    another TimeseriesIndex (instead of its .node) fell through to np.asarray(other_index),
+    which silently wrapped the whole object in a 0-d dtype=object array and minted a brand-new,
+    disconnected timeseries_placeholder node.
+    """
+    ts_base = TimeseriesIndex("ts_base")
+    ts_copy = TimeseriesIndex("ts_copy", ts_base)
+    assert ts_copy.node is ts_base.node
+    assert ts_copy.concrete_default is None
+
+
+def test_timeseries_index_unwraps_nested_timeseries_index_with_default():
+    """The unwrap also covers a base index that carries a concrete default array."""
+    ts_base = TimeseriesIndex("ts_base", np.array([1.0, 2.0, 3.0]))
+    ts_copy = TimeseriesIndex("ts_copy", ts_base)
+    assert ts_copy.node is ts_base.node
+
+
+def test_timeseries_index_rejects_mismatched_generic_index():
+    """TimeseriesIndex(name, a_scalar_index) raises TypeError instead of silently misbehaving."""
+    idx = Index("x", 1.0)
+    with pytest.raises(TypeError, match="from a Index"):
+        TimeseriesIndex("bad", idx)  # type: ignore[arg-type]
+
+
 def test_index_repr_formula_mode():
     """Index repr shows '<formula>' when the value is a graph node."""
     n = graph.constant(42.0)

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "civic-digital-twins"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

**Bug fixes** — ports the three engine/model-layer fixes already released
as v0.10.1 (`backport/v0.10.1`), found while porting AreaVerde onto
civic-digital-twins:
- **Executor** (#222): a `NumpyBackend`-adapted function returning a
  `graph.Node` (or any other non-numeric value) instead of a concrete
  number now raises `executor.InvalidFunctionResult` immediately, instead
  of silently going symbolic.
- **`TimeseriesIndex`** (#223): initializing from another `TimeseriesIndex`
  now correctly shares the underlying graph node instead of silently
  minting a disconnected, orphaned placeholder; a mismatched sibling
  (`Index`) now raises `TypeError`. `Index` already had this behavior.
- **`Evaluation`** (#224): `_execute_plan`'s shape-normalisation pass no
  longer double-processes a graph node shared by two different
  `Index`/`TimeseriesIndex` wrappers.

**Process** — documents the hotfix/backport release procedures in the
README (branch naming, PR-into-staging-branch flow, when to use which),
and extends `CI (release)` to trigger on `hotfix/**`/`backport/**`
branches (plus a `workflow_dispatch` fallback for the bootstrap case
before that trigger exists on a brand-new branch).

## Closed issues
- Closes #222
- Closes #223 
- Closes #224
